### PR TITLE
Add a CI step that checks whether the protobuf definition is valid.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
 
   deploy-pypi:
     runs-on: ubuntu-latest
-    needs: [run-tests-ubuntu, run-tests-windows, run-tests-macos] # We only deploy if the tests were successful
+    needs: [run-tests-ubuntu, run-tests-windows, run-tests-macos, check-protobuf] # We only deploy if the tests were successful
     if: github.ref == 'refs/heads/master' # We only deploy on master commits
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,19 @@ jobs:
 
       - name: Run tests
         run: bash run_tests.sh
+  
+  check-protobuf:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Protobuf compiler
+        run: sudo apt install -y protobuf-compiler && protoc --version
+
+      - name: Check Protobuf validity
+        run: cd unified_planning/grpc && protoc --python_out=. unified_planning.proto
 
 
   deploy-pypi:

--- a/unified_planning/grpc/unified_planning.proto
+++ b/unified_planning/grpc/unified_planning.proto
@@ -286,37 +286,38 @@ message Assignment {
 }
 
 
-message MetricBody {
-    oneof {
-      Expression expression = 1;
-
-      // map from action's name to cost
-      map<string, Expression> action_costs = 2;
-    }
-}
-
 message Metric {
     enum MetricKind {
-      // Minimize the action costs expressed in the metric body
-      MINIMIZE_ACTION_COSTS = 1;
+      // Minimize the action costs expressed in the `action_costs` field
+      MINIMIZE_ACTION_COSTS = 0;
 
       // Minimize the length of the resulting sequential plan
-      MINIMIZE_SEQUENTIAL_PLAN_LENGTH = 2;
+      MINIMIZE_SEQUENTIAL_PLAN_LENGTH = 1;
 
       // Minimize the makespan in case of temporal planning
       // features: durative_actions
-      MINIMIZE_MAKESPAN = 3;
+      MINIMIZE_MAKESPAN = 2;
 
-      // Minimize the value of the expression defined in the metric body
-      MINIMIZE_EXPRESSION_ON_FINAL_STATE = 4;
+      // Minimize the value of the expression defined in the `expression`` field
+      MINIMIZE_EXPRESSION_ON_FINAL_STATE = 3;
 
-      // Maximize the value of the expression defined in the metric body
-      MAXIMIZE_EXPRESSION_ON_FINAL_STATE = 5;
+      // Maximize the value of the expression defined in the `expression`` field
+      MAXIMIZE_EXPRESSION_ON_FINAL_STATE = 4;
     }
     MetricKind kind = 1;
+    
 
-    // Optional body
-    MetricBody = 2;
+    // Expression to minimize/maximize in the final state.
+    // Empty, if the `kind` is not {MIN/MAX}IMIZE_EXPRESSION_ON_FINAL_STATE
+    Expression expression = 2;
+
+    // If `kind == MINIMZE_ACTION_COSTS``, then each action is associated to a cost expression.
+    // 
+    // TODO: Document what is allowed in the expression. 
+    // In particular, for this metric to be useful in many practical problems, the cost expression
+    // should allow referring to the action parameters (and possibly the current state at the action start/end).
+    // This is very awkward to do in this setting where the expression is detached from its scope.
+    map<string, Expression> action_costs = 3;
 }
 
 message Problem {
@@ -486,7 +487,7 @@ service UnifiedPlanning {
     // The planner replies with a stream of N `Answer` messages where:
     //  - the first (N-1) message are of type `IntermediateReport`
     //  - the last message is of type `FinalReport`
-    rpc planOneShot(PlanRequest) returns(stream Answer);
+    rpc planOneShot(PlanRequest) returns(stream PlanGenerationResult);
 
 
     // ===== About bidirectional interaction =====


### PR DESCRIPTION
It also fixes several problems in the protobuf definition that were introduced when metrics were added.

@alvalentini For metrics, I inlined the `MetricBody` in the main message, mostly due to the fact the `map` structures cannot appear in `oneof` structures.
While I was at it, I added a TODO related to the documentation of action costs, in particular to state whether it is allowed to refer to action parameters in such detached cost expressions.