### PR TITLE
Add enhsp and fast-downward as default solvers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,12 @@ setup(name='unified_planning',
           'tarski': ['tarski[arithmetic]'],
           'pyperplan': ['up-pyperplan==0.1.0.24.dev1'],
           'tamer': ['up-tamer==0.1.0.23.dev1'],
+          'enhsp': ['up-enhsp==0.0.2'],
           'solvers': [
               'tarski[arithmetic]',
               'up-pyperplan==0.1.0.24.dev1',
-              'up-tamer==0.1.0.23.dev1'
+              'up-tamer==0.1.0.23.dev1',
+              'up-enhsp==0.0.2'
           ]
       },
       license='APACHE',

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,13 @@ setup(name='unified_planning',
           'pyperplan': ['up-pyperplan==0.1.0.24.dev1'],
           'tamer': ['up-tamer==0.1.0.23.dev1'],
           'enhsp': ['up-enhsp==0.0.2'],
+          'fast-downward': ['up-fast-downward==0.0.2'],
           'solvers': [
               'tarski[arithmetic]',
               'up-pyperplan==0.1.0.24.dev1',
               'up-tamer==0.1.0.23.dev1',
-              'up-enhsp==0.0.2'
+              'up-enhsp==0.0.2',
+              'up-fast-downward==0.0.2'
           ]
       },
       license='APACHE',

--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -26,10 +26,12 @@ from typing import IO, Dict, Tuple, Optional, List, Union, Type
 
 
 DEFAULT_ENGINES = {
+    'fast-downward' : ('up_fast_downward', 'FastDownwardPDDLPlanner'),
+    'fast-downward-opt' : ('up_fast_downward', 'FastDownwardOptimalPDDLPlanner'),
     'pyperplan' : ('up_pyperplan.engine', 'EngineImpl'),
-    'tamer' : ('up_tamer.engine', 'EngineImpl'),
     'enhsp' : ('up_enhsp.enhsp_planner', 'ENHSPSatEngine'),
-    'enhspOpt' : ('up_enhsp.enhsp_planner', 'ENHSPOptEngine'),
+    'enhsp-opt' : ('up_enhsp.enhsp_planner', 'ENHSPOptEngine'),
+    'tamer' : ('up_tamer.engine', 'EngineImpl'),
     'sequential_plan_validator' : ('unified_planning.engines.plan_validator', 'SequentialPlanValidator'),
     'up_conditional_effects_remover' : ('unified_planning.engines.compilers.conditional_effects_remover', 'ConditionalEffectsRemover'),
     'up_disjunctive_conditions_remover' : ('unified_planning.engines.compilers.disjunctive_conditions_remover', 'DisjunctiveConditionsRemover'),

--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -28,6 +28,8 @@ from typing import IO, Dict, Tuple, Optional, List, Union, Type
 DEFAULT_ENGINES = {
     'pyperplan' : ('up_pyperplan.engine', 'EngineImpl'),
     'tamer' : ('up_tamer.engine', 'EngineImpl'),
+    'enhsp' : ('up_enhsp.enhsp_planner', 'ENHSPSatEngine'),
+    'enhspOpt' : ('up_enhsp.enhsp_planner', 'ENHSPOptEngine'),
     'sequential_plan_validator' : ('unified_planning.engines.plan_validator', 'SequentialPlanValidator'),
     'up_conditional_effects_remover' : ('unified_planning.engines.compilers.conditional_effects_remover', 'ConditionalEffectsRemover'),
     'up_disjunctive_conditions_remover' : ('unified_planning.engines.compilers.disjunctive_conditions_remover', 'DisjunctiveConditionsRemover'),


### PR DESCRIPTION
I have added enhsp into the configuration file, aligned with the very last up-enshp version