### PR TITLE
Disabled CI tests with gringo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Install tarski
         run: |
           python3 -m pip install tarski[arithmetic]
-          brew install gringo
+#          brew install gringo -- Commented because not working on github actions
 
       - name: Checkout up-tamer
         uses: actions/checkout@v2


### PR DESCRIPTION
Tests are failing on GitHub Actions, likely caused by an update of MacOS 