### PR TITLE
Partial Grounding in SequentialSimulator and in SequentialPlanValidator 

### DIFF
--- a/unified_planning/engines/compilers/__init__.py
+++ b/unified_planning/engines/compilers/__init__.py
@@ -19,7 +19,7 @@ from unified_planning.engines.compilers.conditional_effects_remover import (
 from unified_planning.engines.compilers.disjunctive_conditions_remover import (
     DisjunctiveConditionsRemover,
 )
-from unified_planning.engines.compilers.grounder import Grounder
+from unified_planning.engines.compilers.grounder import Grounder, GroundingSupport
 from unified_planning.engines.compilers.quantifiers_remover import QuantifiersRemover
 from unified_planning.engines.compilers.negative_conditions_remover import (
     NegativeConditionsRemover,

--- a/unified_planning/engines/compilers/__init__.py
+++ b/unified_planning/engines/compilers/__init__.py
@@ -19,7 +19,7 @@ from unified_planning.engines.compilers.conditional_effects_remover import (
 from unified_planning.engines.compilers.disjunctive_conditions_remover import (
     DisjunctiveConditionsRemover,
 )
-from unified_planning.engines.compilers.grounder import Grounder, GroundingSupport
+from unified_planning.engines.compilers.grounder import Grounder, GrounderHelper
 from unified_planning.engines.compilers.quantifiers_remover import QuantifiersRemover
 from unified_planning.engines.compilers.negative_conditions_remover import (
     NegativeConditionsRemover,

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -32,6 +32,152 @@ from itertools import product
 from functools import partial
 
 
+class GroundingSupport:
+    """
+    This class gives the capability of grounding a :class:`~unified_planning.model.Problem` by taking
+    it at construction time.
+
+    It offers the capability both of grounding a whole problem, like the :class:`~unified_planning.engines.compilers.Grounder`
+    in the :func:`~unified_planning.engines.compilers.Grounder.compile` method (with the :func:`~unified_planning.engines.compilers.GroundingSupport.ground_problem`
+    method) or offers the capability of grounding a single Action of the Problem given the grounding parameters
+    (with the :func:`~unified_planning.engines.compilers.GroundingSupport.ground_action` method).
+
+    This class also caches the grounded actions so it avoids duplication.
+    """
+
+    def __init__(
+        self,
+        problem: Problem,
+        grounding_actions_map: Optional[Dict[Action, List[Tuple[FNode, ...]]]] = None,
+    ):
+        assert isinstance(problem, Problem)
+        self._problem = problem
+        self._grounding_actions_map = grounding_actions_map
+        # grounded_actions is a map from an Action of the original problem and it's parameters
+        # to the grounded instance of the Action with the given parameters.
+        self._grounded_actions: Dict[
+            Tuple[Action, Tuple[FNode, ...]], Optional[Action]
+        ] = {}
+        env = problem.env
+        self._substituter = Substituter(env)
+        self._simplifier = Simplifier(env, problem)
+        self._grounding_result: Optional[CompilerResult] = None
+
+    @property
+    def name(self):
+        return "grounder"
+
+    def ground_action(
+        self, action: Action, parameters: Tuple[FNode, ...] = tuple()
+    ) -> Optional[Action]:
+        """
+        Grounds the given `action` with the given `parameters`.
+        An `Action` is grounded when it has no :func:`parameters <unified_planning.model.Action.parameters>`.
+
+        The returned `Action` is cached, so if the same method is called twice with the same function parameters,
+        the same object is returned, and the same object will be returned in the total problem grounding, so
+        if the resulting `Action` or :class:`~unified_planning.model.Problem` are modified, all the copies
+        returned by this class will be modified.
+
+        :param action: The `Action` that must be grounded with the given `parameters`.
+        :param parameters: The tuple of expressions used to ground the given `action`.
+        :return: The `action` grounded with the given `parameters` or `None` if the grounded
+            action does not have `effects` or the `action conditions` can be easily evaluated as a
+            contradiction.
+        """
+        assert len(action.parameters) == len(
+            parameters
+        ), "The number of given parameters for the grounding is different from the action's parameters"
+        key = (action, tuple(parameters))
+        if key in self._grounded_actions:  # The action is already created
+            return self._grounded_actions[key]
+        else:
+            subs: Dict[Expression, Expression] = dict(
+                zip(action.parameters, list(parameters))
+            )
+            new_action = create_action_with_given_subs(
+                self._problem, action, self._simplifier, self._substituter, subs
+            )
+            self._grounded_actions[key] = new_action
+            return new_action
+
+    def ground_problem(self) -> CompilerResult:
+        """
+        Grounds the :class:`~unified_planning.model.Problem` given at construction time and stores the result
+        inside this class, so if this method is called twice, the same `CompilerResult` is returned.
+
+        :return: The `CompilerResult` created; the same of a :func:`~unified_planning.engines.compilers.Grounder.compile` call
+            where the `Problem` is the one giv4en at construction time.
+        """
+        if (
+            self._grounding_result is None
+        ):  # if the problem was never grounded before, ground it
+            trace_back_map: Dict[Action, Tuple[Action, List[FNode]]] = {}
+
+            new_problem = self._problem.clone()
+            new_problem.name = f"{self.name}_{self._problem.name}"
+            new_problem.clear_actions()
+            for old_action in self._problem.actions:
+                # contains the type of every parameter of the action
+                type_list: List[Type] = [param.type for param in old_action.parameters]
+                # if the action does not have parameters, it does not need to be grounded.
+                if len(type_list) == 0:
+                    if (
+                        self._grounding_actions_map is None
+                        or self._grounding_actions_map.get(old_action, None) is not None
+                    ):
+                        new_action = old_action.clone()
+                        new_problem.add_action(new_action)
+                        trace_back_map[new_action] = (old_action, [])
+                    continue
+                grounded_params_list: Optional[Iterator[Tuple[FNode, ...]]] = None
+                if self._grounding_actions_map is None:
+                    # a list containing the list of object in the self._problem of the given type.
+                    # So, if the self._problem has 2 Locations l1 and l2, and 2 Robots r1 and r2, and
+                    # the action move_to takes as parameters a Robot and a Location,
+                    # the variable state at this point will be the following:
+                    # type_list = [Robot, Location]
+                    # objects_list = [[r1, r2], [l1, l2]]
+                    # the product of *objects_list will be:
+                    # [(r1, l1), (r1, l2), (r2, l1), (r2,l2)]
+                    ground_size = 1
+                    domain_sizes = []
+                    for t in type_list:
+                        ds = domain_size(new_problem, t)
+                        domain_sizes.append(ds)
+                        ground_size *= ds
+                    items_list: List[List[FNode]] = []
+                    for size, type in zip(domain_sizes, type_list):
+                        items_list.append(
+                            [domain_item(new_problem, type, j) for j in range(size)]
+                        )
+                    grounded_params_list = product(*items_list)
+                else:
+                    # The grounding_actions_map is not None, therefore it must be used to ground
+                    grounded_params_list = iter(self._grounding_actions_map[old_action])
+                assert grounded_params_list is not None
+                for grounded_params in grounded_params_list:
+                    new_action = self.ground_action(old_action, grounded_params)
+                    # when the action is None it means it is not feasible,
+                    # it's conditions are in contradiction within one another.
+                    if new_action is not None:
+                        trace_back_map[new_action] = (
+                            old_action,
+                            self._problem.env.expression_manager.auto_promote(
+                                grounded_params
+                            ),
+                        )
+                        new_problem.add_action(new_action)
+
+            self._grounding_result = CompilerResult(
+                new_problem,
+                partial(lift_action_instance, map=trace_back_map),
+                self.name,
+            )
+
+        return self._grounding_result
+
+
 class Grounder(engines.engine.Engine, CompilerMixin):
     """
     Grounder class: the `Grounder` takes a :class:`~unified_planning.model.Problem` where the :class:`Actions <unified_planning.model.Action>`
@@ -118,71 +264,8 @@ class Grounder(engines.engine.Engine, CompilerMixin):
             only `GROUNDING` is supported by this compiler
         :return: The resulting `CompilerResult` data structure.
         """
-        assert isinstance(problem, Problem)
-
-        env = problem.env
-        substituter = Substituter(env)
-        simplifier = Simplifier(env, problem)
-        trace_back_map: Dict[Action, Tuple[Action, List[FNode]]] = {}
-
-        new_problem = problem.clone()
-        new_problem.name = f"{self.name}_{problem.name}"
-        new_problem.clear_actions()
-        for old_action in problem.actions:
-            # contains the type of every parameter of the action
-            type_list: List[Type] = [param.type for param in old_action.parameters]
-            # if the action does not have parameters, it does not need to be grounded.
-            if len(type_list) == 0:
-                if (
-                    self._grounding_actions_map is None
-                    or self._grounding_actions_map.get(old_action, None) is not None
-                ):
-                    new_action = old_action.clone()
-                    new_problem.add_action(new_action)
-                    trace_back_map[new_action] = (old_action, [])
-                continue
-            grounded_params_list: Optional[Iterator[Tuple[FNode, ...]]] = None
-            if self._grounding_actions_map is None:
-                # a list containing the list of object in the problem of the given type.
-                # So, if the problem has 2 Locations l1 and l2, and 2 Robots r1 and r2, and
-                # the action move_to takes as parameters a Robot and a Location,
-                # the variable state at this point will be the following:
-                # type_list = [Robot, Location]
-                # objects_list = [[r1, r2], [l1, l2]]
-                # the product of *objects_list will be:
-                # [(r1, l1), (r1, l2), (r2, l1), (r2,l2)]
-                ground_size = 1
-                domain_sizes = []
-                for t in type_list:
-                    ds = domain_size(new_problem, t)
-                    domain_sizes.append(ds)
-                    ground_size *= ds
-                items_list: List[List[FNode]] = []
-                for size, type in zip(domain_sizes, type_list):
-                    items_list.append(
-                        [domain_item(new_problem, type, j) for j in range(size)]
-                    )
-                grounded_params_list = product(*items_list)
-            else:
-                # The grounding_actions_map is not None, therefore it must be used to ground
-                grounded_params_list = iter(self._grounding_actions_map[old_action])
-            assert grounded_params_list is not None
-            for grounded_params in grounded_params_list:
-                subs: Dict[Expression, Expression] = dict(
-                    zip(old_action.parameters, list(grounded_params))
-                )
-                new_action = create_action_with_given_subs(
-                    problem, old_action, simplifier, substituter, subs
-                )
-                # when the action is None it means it is not feasible,
-                # it's conditions are in contraddiction within one another.
-                if new_action is not None:
-                    trace_back_map[new_action] = (
-                        old_action,
-                        env.expression_manager.auto_promote(subs.values()),
-                    )
-                    new_problem.add_action(new_action)
-
-        return CompilerResult(
-            new_problem, partial(lift_action_instance, map=trace_back_map), self.name
-        )
+        assert isinstance(
+            problem, Problem
+        ), "The given problem is not a class supported by the Grounder"
+        gs = GroundingSupport(problem, self._grounding_actions_map)
+        return gs.ground_problem()

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 #
 
+
 import unified_planning as up
-from unified_planning.engines.compilers import Grounder, GroundingSupport
+from unified_planning.engines.compilers import Grounder, GrounderHelper
 from unified_planning.engines.engine import Engine
 from unified_planning.engines.mixins.simulator import Event, SimulatorMixin
 from unified_planning.exceptions import UPUsageError, UPConflictingEffectsException
@@ -60,7 +61,7 @@ class SequentialSimulator(Engine, SimulatorMixin):
         pk = problem.kind
         assert Grounder.supports(pk)
         assert isinstance(self._problem, up.model.Problem)
-        self._grounder = GroundingSupport(problem)
+        self._grounder = GrounderHelper(problem)
         self._events: Dict[
             Tuple["up.model.Action", Tuple["up.model.FNode", ...]], List[Event]
         ] = {}
@@ -188,42 +189,19 @@ class SequentialSimulator(Engine, SimulatorMixin):
         # that is applicable, yield it.
         # Otherwise just return all the applicable events
         if not self._all_events_grounded:
-
-            # total grounding
+            # perform total grounding
             self._all_events_grounded = True
-            grounding_result = self._grounder.ground_problem()
-            grounded_problem: "up.model.Problem" = cast(
-                up.model.Problem, grounding_result.problem
-            )
-            lift_map = grounding_result.map_back_action_instance
-            assert lift_map is not None
-
             # for every grounded action, translate it in an Event
-            for grounded_action in grounded_problem.actions:
-                if isinstance(grounded_action, up.model.InstantaneousAction):
-                    lifted_ai = lift_map(ActionInstance(grounded_action))
-                    assert lifted_ai is not None
-
-                    # check if the event is already cached; if not: create it and cache it
-                    key = (lifted_ai.action, lifted_ai.actual_parameters)
-                    event_list = self._events.get(key, None)
-                    if event_list is None:
-                        event_list = [
-                            InstantaneousEvent(
-                                grounded_action.preconditions,
-                                grounded_action.effects,
-                                grounded_action.simulated_effect,
-                            )
-                        ]
-                        self._events[key] = event_list
-                    # sanity check
-                    assert len(event_list) < 2
-                    # if the event is applicable, yield it
-                    for event in event_list:
-                        if self.is_applicable(event, state):
-                            yield event
-                else:
-                    raise NotImplementedError
+            for (
+                original_action,
+                params,
+                grounded_action,
+            ) in self._grounder.get_grounded_actions():
+                for event in self._get_or_create_events(
+                    original_action, params, grounded_action
+                ):
+                    if self.is_applicable(event, state):
+                        yield event
         else:  # the problem has been fully grounded before, just check for event applicability
             for events in self._events.values():
                 for event in events:
@@ -252,26 +230,8 @@ class SequentialSimulator(Engine, SimulatorMixin):
         params_exp = tuple(
             self._problem.env.expression_manager.auto_promote(parameters)
         )
-        # if event already cached, return it
-        key = (action, tuple(params_exp))
-        if key in self._events:
-            return self._events[key]
-        # otherwise create it and return it
-        grounded_action = self._grounder.ground_action(action, tuple(params_exp))
-        if grounded_action is not None:
-            if isinstance(grounded_action, up.model.InstantaneousAction):
-                event_list: List[Event] = [
-                    InstantaneousEvent(
-                        grounded_action.preconditions,
-                        grounded_action.effects,
-                        grounded_action.simulated_effect,
-                    )
-                ]
-            else:
-                raise NotImplementedError
-        else:
-            event_list = []
-        self._events[key] = event_list
+        grounded_action = self._grounder.ground_action(action, params_exp)
+        event_list = self._get_or_create_events(action, params_exp, grounded_action)
         return event_list
 
     def _get_unsatisfied_goals(
@@ -324,3 +284,46 @@ class SequentialSimulator(Engine, SimulatorMixin):
     @staticmethod
     def supports(problem_kind):
         return problem_kind <= SequentialSimulator.supported_kind()
+
+    def _get_or_create_events(
+        self,
+        original_action: "up.model.Action",
+        params: Tuple["up.model.FNode", ...],
+        grounded_action: Optional["up.model.Action"],
+    ) -> List[Event]:
+        """
+        Support function that takes the `original Action`, the `parameters` used to ground the `grounded Action` and
+        the `grounded Action` itself, and adds the corresponding `List of Events` to this `Simulator`. If the
+        corresponding `Events` were already created, the same value is returned and no new `Events` are created.
+
+        :param original_action: The `Action` of the :class:`~unified_planning.model.Problem` grounded with the given `params`.
+        :param params: The expressions used to ground the `original_action`.
+        :param grounded_action: The grounded action, result of the `original_action` grounded with the given `parameters`.
+        :return: The retrieved or created `List of Events` corresponding to the `grounded_action`.
+        """
+        if isinstance(original_action, up.model.InstantaneousAction):
+            # check if the event is already cached; if not: create it and cache it
+            key = (original_action, params)
+            event_list = self._events.get(key, None)
+            if event_list is None:
+                if (
+                    grounded_action is None
+                ):  # The grounded action is meaningless, no event associated
+                    event_list = []
+                else:
+                    assert isinstance(grounded_action, up.model.InstantaneousAction)
+                    event_list = [
+                        InstantaneousEvent(
+                            grounded_action.preconditions,
+                            grounded_action.effects,
+                            grounded_action.simulated_effect,
+                        )
+                    ]
+                self._events[key] = event_list
+            # sanity check
+            assert len(event_list) < 2
+            return event_list
+        else:
+            raise NotImplementedError(
+                "The SequentialSimulator currently supports only InstantaneousActions."
+            )

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -14,7 +14,7 @@
 #
 
 import unified_planning as up
-from unified_planning.engines.compilers import Grounder
+from unified_planning.engines.compilers import Grounder, GroundingSupport
 from unified_planning.engines.engine import Engine
 from unified_planning.engines.mixins.simulator import Event, SimulatorMixin
 from unified_planning.exceptions import UPUsageError, UPConflictingEffectsException
@@ -60,36 +60,12 @@ class SequentialSimulator(Engine, SimulatorMixin):
         pk = problem.kind
         assert Grounder.supports(pk)
         assert isinstance(self._problem, up.model.Problem)
-        grounder = Grounder()
-        self._grounding_result = grounder.compile(
-            self._problem, up.engines.CompilationKind.GROUNDING
-        )
-
-        grounded_problem: "up.model.Problem" = cast(
-            up.model.Problem, self._grounding_result.problem
-        )
-        lift_map = self._grounding_result.map_back_action_instance
-        assert lift_map is not None
+        self._grounder = GroundingSupport(problem)
         self._events: Dict[
             Tuple["up.model.Action", Tuple["up.model.FNode", ...]], List[Event]
         ] = {}
-        for grounded_action in grounded_problem.actions:
-            if isinstance(grounded_action, up.model.InstantaneousAction):
-                lifted_ai = lift_map(ActionInstance(grounded_action))
-                assert lifted_ai is not None
-                event_list = self._events.setdefault(
-                    (lifted_ai.action, lifted_ai.actual_parameters), []
-                )
-                event_list.append(
-                    InstantaneousEvent(
-                        grounded_action.preconditions,
-                        grounded_action.effects,
-                        grounded_action.simulated_effect,
-                    )
-                )
-            else:
-                raise NotImplementedError
         self._se = StateEvaluator(self._problem)
+        self._all_events_grounded: bool = False
 
     def _get_unsatisfied_conditions(
         self, event: "Event", state: "up.model.ROState", early_termination: bool = False
@@ -207,10 +183,52 @@ class SequentialSimulator(Engine, SimulatorMixin):
         :param state: The state where the formulas are evaluated.
         :return: an Iterator of applicable Events.
         """
-        for events in self._events.values():
-            for event in events:
-                if self.is_applicable(event, state):
-                    yield event
+        # if the problem was never fully grounded before,
+        # ground it and save all the new events. For every event
+        # that is applicable, yield it.
+        # Otherwise just return all the applicable events
+        if not self._all_events_grounded:
+
+            # total grounding
+            self._all_events_grounded = True
+            grounding_result = self._grounder.ground_problem()
+            grounded_problem: "up.model.Problem" = cast(
+                up.model.Problem, grounding_result.problem
+            )
+            lift_map = grounding_result.map_back_action_instance
+            assert lift_map is not None
+
+            # for every grounded action, translate it in an Event
+            for grounded_action in grounded_problem.actions:
+                if isinstance(grounded_action, up.model.InstantaneousAction):
+                    lifted_ai = lift_map(ActionInstance(grounded_action))
+                    assert lifted_ai is not None
+
+                    # check if the event is already cached; if not: create it and cache it
+                    key = (lifted_ai.action, lifted_ai.actual_parameters)
+                    event_list = self._events.get(key, None)
+                    if event_list is None:
+                        event_list = [
+                            InstantaneousEvent(
+                                grounded_action.preconditions,
+                                grounded_action.effects,
+                                grounded_action.simulated_effect,
+                            )
+                        ]
+                        self._events[key] = event_list
+                    # sanity check
+                    assert len(event_list) < 2
+                    # if the event is applicable, yield it
+                    for event in event_list:
+                        if self.is_applicable(event, state):
+                            yield event
+                else:
+                    raise NotImplementedError
+        else:  # the problem has been fully grounded before, just check for event applicability
+            for events in self._events.values():
+                for event in events:
+                    if self.is_applicable(event, state):
+                        yield event
 
     def _get_events(
         self,
@@ -226,6 +244,7 @@ class SequentialSimulator(Engine, SimulatorMixin):
         :param parameters: The parameters needed to ground the action
         :return: the List of Events derived from this action with these parameters.
         """
+        # sanity checks
         if action not in cast(up.model.Problem, self._problem).actions:
             raise UPUsageError(
                 "The action given as parameter does not belong to the problem given to the SequentialSimulator."
@@ -233,7 +252,27 @@ class SequentialSimulator(Engine, SimulatorMixin):
         params_exp = tuple(
             self._problem.env.expression_manager.auto_promote(parameters)
         )
-        return self._events.get((action, tuple(params_exp)), [])
+        # if event already cached, return it
+        key = (action, tuple(params_exp))
+        if key in self._events:
+            return self._events[key]
+        # otherwise create it and return it
+        grounded_action = self._grounder.ground_action(action, tuple(params_exp))
+        if grounded_action is not None:
+            if isinstance(grounded_action, up.model.InstantaneousAction):
+                event_list: List[Event] = [
+                    InstantaneousEvent(
+                        grounded_action.preconditions,
+                        grounded_action.effects,
+                        grounded_action.simulated_effect,
+                    )
+                ]
+            else:
+                raise NotImplementedError
+        else:
+            event_list = []
+        self._events[key] = event_list
+        return event_list
 
     def _get_unsatisfied_goals(
         self, state: "up.model.ROState", early_termination: bool = False

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -262,6 +262,8 @@ class TestGrounder(TestCase):
         gro = Grounder()
         ground_result = gro.compile(problem, CompilationKind.GROUNDING)
         grounded_problem = ground_result.problem
+        print(problem)
+        print(grounded_problem)
         self.assertEqual(len(grounded_problem.actions), 2)
         for a in grounded_problem.actions:
             self.assertEqual(len(a.parameters), 0)

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -262,8 +262,6 @@ class TestGrounder(TestCase):
         gro = Grounder()
         ground_result = gro.compile(problem, CompilationKind.GROUNDING)
         grounded_problem = ground_result.problem
-        print(problem)
-        print(grounded_problem)
         self.assertEqual(len(grounded_problem.actions), 2)
         for a in grounded_problem.actions:
             self.assertEqual(len(a.parameters), 0)


### PR DESCRIPTION
The `GroundingSupport` class allows the grounding of only an `Action` and not necessarily an entire `Problem`.

This class is used in the `Grounder` compiler and in the `SequentialSimulator`.