### PR TITLE
[pddl] Performance improvement in PDDL parser.

### DIFF
--- a/unified_planning/io/pddl_reader.py
+++ b/unified_planning/io/pddl_reader.py
@@ -25,14 +25,14 @@ from collections import OrderedDict
 from fractions import Fraction
 from typing import Dict, Union, Callable, List, cast
 
-
 import pyparsing
 
 assert (
     pyparsing.__version__ >= "3.0.0"
 ), f"unified_planning needs a pyparsing version >= 3. Current version detected: {pyparsing.__version__}, please update it."
 from pyparsing import Word, alphanums, alphas, ZeroOrMore, OneOrMore, Keyword
-from pyparsing import Suppress, nested_expr, Group, rest_of_line, Optional
+from pyparsing import Suppress, Group, rest_of_line, Optional, Forward
+from pyparsing import CharsNotIn, Empty
 from pyparsing.results import ParseResults
 from pyparsing import one_of
 
@@ -64,6 +64,16 @@ class CaseInsensitiveToken:
 
 Object = CaseInsensitiveToken("object")
 TypesMap = Dict[CaseInsensitiveToken, unified_planning.model.Type]
+
+
+def nested_expr():
+    '''A hand-rolled alternative to pyparsing.nested_expr() that substantially improves its performance in our case'''
+    cnt = Empty() + CharsNotIn("() \n\t\r")
+    nested = Forward()
+    nested <<= Group(
+        Suppress("(") + ZeroOrMore(cnt | nested) + Suppress(")")
+    )
+    return nested
 
 
 class PDDLGrammar:

--- a/unified_planning/io/pddl_reader.py
+++ b/unified_planning/io/pddl_reader.py
@@ -66,21 +66,14 @@ Object = CaseInsensitiveToken("object")
 TypesMap = Dict[CaseInsensitiveToken, unified_planning.model.Type]
 
 
-def nested_expr(max_nesting: typing.Optional[int] = None):
-    """A hand-rolled alternative to pyparsing.nested_expr() that substantially improves its performance in our case.
-
-    `max_nesting` specializes the function to parse at most the given number of nestings (useful to parse :init in particular)
+def nested_expr():
+    """
+    A hand-rolled alternative to pyparsing.nested_expr() that substantially improves its performance in our case.
     """
     cnt = Empty() + CharsNotIn("() \n\t\r")
-    if max_nesting:
-        res = Group(Suppress("(") + ZeroOrMore(cnt) + Suppress(")"))
-        for _ in range(max_nesting):
-            res = Group(Suppress("(") + ZeroOrMore(cnt | res) + Suppress(")"))
-        return res
-    else:
-        nested = Forward()
-        nested <<= Group(Suppress("(") + ZeroOrMore(cnt | nested) + Suppress(")"))
-        return nested
+    nested = Forward()
+    nested <<= Group(Suppress("(") + ZeroOrMore(cnt | nested) + Suppress(")"))
+    return nested
 
 
 class PDDLGrammar:
@@ -275,7 +268,7 @@ class PDDLGrammar:
             + Optional(htn_def.setResultsName("htn"))
             + Suppress("(")
             + ":init"
-            + ZeroOrMore(nested_expr(2)).setResultsName("init")
+            + ZeroOrMore(nested_expr()).setResultsName("init")
             + Suppress(")")
             + Optional(
                 Suppress("(")


### PR DESCRIPTION
This is a straightforward adaptation of the alternative implementation of `pyparsing.nestedExpr` proposed by @mikand in #254.

On my machines, it reduces the time to parse all 27 hddl instances of  `test/hddl` from 42s to 5 seconds, making it an excellent mitigation. I would not say it fixes the issue, but it certainly makes it less urgent to handle.


