### PR TITLE
[dist] Include all PDDL, HDDL and ANML files in the python package distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include unified_planning/test/pddl/ *.pddl *.hddl
+recursive-include unified_planning/test/ *.pddl *.hddl *.anml


### PR DESCRIPTION
Previously only a subset of the PDDL/HDDL files where included in the python package.

This PR allows in inclusion of all planning domains in the `test/` directory (PDDL/HDDL/ANML).

Benefits: these domains can be used for testing e.g. compatibility of a planner. (I discovered they were absent from the distribution when I tried to exploit them for planning-test-cases).

Cons: they will take some space in the disctribution (e.g. the HDDL/ANML problems that were previously ignored would take ~800kB, which is ~50% of the size of the `test/` directory).
