### PR TITLE
Implementing the add-after-delete semantic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: push
 
 env:
-  up_tamer_commit: "dd148293813d2d9664854788cdbff627cf901e82"
+  up_tamer_commit: "362628b459f0d01d7c401da73158e29764e1137c"
   up_pyperplan_commit: "587a92b6a8198e8259ca9172312927f3e409867e"
   up_fast_downward_commit: "52b08699a8f76bf24884a5fd5100e013b4fca224"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: push
 
 env:
-  up_tamer_commit: "323a3a9f6a650b20d31cf1014725b3ecb9349065"
+  up_tamer_commit: "dd148293813d2d9664854788cdbff627cf901e82"
   up_pyperplan_commit: "587a92b6a8198e8259ca9172312927f3e409867e"
   up_fast_downward_commit: "52b08699a8f76bf24884a5fd5100e013b4fca224"
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "grpc": ["grpcio", "grpcio-tools", "grpc-stubs"],
         "tarski": ["tarski[arithmetic]"],
         "pyperplan": ["up-pyperplan==0.3.0.2.dev1"],
-        "tamer": ["up-tamer==0.3.1.7.dev1"],
+        "tamer": ["up-tamer==0.3.1.9.dev1"],
         "enhsp": ["up-enhsp==0.0.11"],
         "fast-downward": ["up-fast-downward==0.1.2"],
         "lpg": ["up-lpg==0.0.4.9"],
@@ -35,7 +35,7 @@ setup(
         "engines": [
             "tarski[arithmetic]",
             "up-pyperplan==0.3.0.2.dev1",
-            "up-tamer==0.3.1.7.dev1",
+            "up-tamer==0.3.1.9.dev1",
             "up-enhsp==0.0.11",
             "up-fast-downward==0.1.2",
             "up-lpg==0.0.4.9",

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -34,7 +34,6 @@ from unified_planning.engines.results import (
 )
 from unified_planning.engines.sequential_simulator import (
     SequentialSimulator,
-    InstantaneousEvent,
 )
 from unified_planning.plans import SequentialPlan, PlanKind
 from unified_planning.exceptions import UPConflictingEffectsException
@@ -143,7 +142,7 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                 logs = [LogMessage(LogLevel.INFO, msg)]
                 return ValidationResult(ValidationResultStatus.INVALID, self.name, logs)
         unsatisfied_goals = simulator.get_unsatisfied_goals(current_state)
-        if len(unsatisfied_goals) == 0:
+        if not unsatisfied_goals:
             return ValidationResult(ValidationResultStatus.VALID, self.name, [])
         else:
             msg = f"Goals {unsatisfied_goals} are not satisfied by the plan."

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -222,12 +222,14 @@ class SequentialSimulator(Engine, SimulatorMixin):
                 # If f was already modified and it was modified by an increase/decrease or with an assign
                 # with a different value
                 if old_value is not None and (
-                    f not in assigned_fluent or old_value != v
+                    f not in assigned_fluent
+                    or old_value.constant_value() != v.constant_value()
                 ):
                     if not f.type.is_bool_type():
                         raise UPConflictingEffectsException(
                             f"The fluent {f} is modified with different values in the same event."
                         )
+                    # solve with add-after-delete logic
                     elif not old_value.bool_constant_value():
                         updated_values[f] = v
                 else:

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -219,10 +219,14 @@ class SequentialSimulator(Engine, SimulatorMixin):
                 event.simulated_effect.function(self._problem, state, {}),
             ):
                 old_value = updated_values.get(f, None)
-                if old_value is not None:
+                # If f was already modified and it was modified by an increase/decrease or with an assign
+                # with a different value
+                if old_value is not None and (
+                    f not in assigned_fluent or old_value != v
+                ):
                     if not f.type.is_bool_type():
                         raise UPConflictingEffectsException(
-                            f"The fluent {f} is modified twice in the same event."
+                            f"The fluent {f} is modified with different values in the same event."
                         )
                     elif not old_value.bool_constant_value():
                         updated_values[f] = v

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -357,7 +357,7 @@ class SequentialSimulator(Engine, SimulatorMixin):
         :param parameters: The parameters needed to ground the action
         :return: the List of Events derived from this action with these parameters.
         """
-        # sanity checks
+        # sanity check
         if action not in self._actions:
             raise UPUsageError(
                 "The action given as parameter does not belong to the problem given to the SequentialSimulator."

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -300,13 +300,21 @@ class SequentialSimulator(Engine, SimulatorMixin):
                     )
                 # If the fluent is in updated_values, we take his modified value, (which was modified by another increase or decrease)
                 # otherwise we take it's evaluation in the state as it's value.
-                f_eval = updated_values.get(
-                    fluent, self._se.evaluate(fluent, state)
-                )
+                f_eval = updated_values.get(fluent, self._se.evaluate(fluent, state))
                 if effect.is_increase():
-                    return fluent, em.auto_promote(f_eval.constant_value() + new_value.constant_value())[0]
+                    return (
+                        fluent,
+                        em.auto_promote(
+                            f_eval.constant_value() + new_value.constant_value()
+                        )[0],
+                    )
                 elif effect.is_decrease():
-                    return fluent, em.auto_promote(f_eval.constant_value() - new_value.constant_value())[0]
+                    return (
+                        fluent,
+                        em.auto_promote(
+                            f_eval.constant_value() - new_value.constant_value()
+                        )[0],
+                    )
                 else:
                     raise NotImplementedError
         else:

--- a/unified_planning/model/action.py
+++ b/unified_planning/model/action.py
@@ -444,6 +444,7 @@ class InstantaneousAction(Action):
         up.model.effect.check_conflicting_simulated_effects(
             simulated_effect,
             None,
+            self._fluents_assigned,
             self._fluents_inc_dec,
             "action",
         )

--- a/unified_planning/model/action.py
+++ b/unified_planning/model/action.py
@@ -28,7 +28,7 @@ from unified_planning.exceptions import (
     UPConflictingEffectsException,
 )
 from fractions import Fraction
-from typing import List, Set, Union, Optional
+from typing import Dict, List, Set, Union, Optional
 from collections import OrderedDict
 
 from unified_planning.model.mixins.timed_conds_effs import TimedCondsEffs

--- a/unified_planning/model/action.py
+++ b/unified_planning/model/action.py
@@ -471,7 +471,9 @@ class InstantaneousAction(Action):
             `simulated effect`.
         """
         for f in simulated_effect.fluents:
-            if not f.type.is_bool_type() and f in self._fluents_inc_dec:
+            if not f.type.is_bool_type() and (
+                f in self._fluents_inc_dec or f in self._fluents_assigned
+            ):
                 raise UPConflictingEffectsException(
                     f"The simulated effect {simulated_effect} is in conflict with the effects already in the action."
                 )

--- a/unified_planning/model/action.py
+++ b/unified_planning/model/action.py
@@ -402,7 +402,7 @@ class InstantaneousAction(Action):
         assert (
             effect.environment == self._environment
         ), "effect does not have the same environment of the action"
-        if not effect.is_conditional():
+        if not effect.is_conditional() and not effect.value.type.is_bool_type():
             if effect.is_assignment():
                 if (
                     effect.fluent in self._fluents_assigned
@@ -422,6 +422,7 @@ class InstantaneousAction(Action):
                 raise NotImplementedError
         if (
             self._simulated_effect is not None
+            and not effect.fluent.type.is_bool_type()
             and effect.fluent in self._simulated_effect.fluents
         ):
             raise UPConflictingEffectsException(
@@ -442,7 +443,9 @@ class InstantaneousAction(Action):
             `simulated effect`.
         """
         for f in simulated_effect.fluents:
-            if f in self._fluents_assigned or f in self._fluents_inc_dec:
+            if not f.type.is_bool_type() and (
+                f in self._fluents_assigned or f in self._fluents_inc_dec
+            ):
                 raise UPConflictingEffectsException(
                     f"The simulated effect {simulated_effect} is in conflict with the effects already in the action."
                 )

--- a/unified_planning/model/effect.py
+++ b/unified_planning/model/effect.py
@@ -268,6 +268,16 @@ def check_conflicting_effects(
                 else:
                     msg = f"The effect {effect} at timing {timing} is in conflict with the increase/decrease effects already in the {name}."
                 raise UPConflictingEffectsException(msg)
+            # if the same fluent is involved in a simulated effect
+            elif (
+                simulated_effect is not None
+                and effect.fluent in simulated_effect.fluents
+            ):
+                if timing is None:
+                    msg = f"The effect {effect} is in conflict with the simulated effects already in the {name}."
+                else:
+                    msg = f"The effect {effect} at timing {timing} is in conflict with the simulated effects already in the {name}."
+                raise UPConflictingEffectsException(msg)
             # the same fluent is involved in another assign
             elif assigned_value is not None:
                 # if the 2 values are different, raise exception
@@ -280,12 +290,6 @@ def check_conflicting_effects(
                         msg = f"The effect {effect} is in conflict with the effects already in the {name}."
                     else:
                         msg = f"The effect {effect} at timing {timing} is in conflict with the effects already in the {name}."
-                    raise UPConflictingEffectsException(msg)
-                elif effect.fluent in simulated_effect.fluents:
-                    if timing is None:
-                        msg = f"The effect {effect} is in conflict with the simulated effects already in the {name}."
-                    else:
-                        msg = f"The effect {effect} at timing {timing} is in conflict with the simulated effects already in the {name}."
                     raise UPConflictingEffectsException(msg)
             else:
                 fluents_assigned[effect.fluent] = effect.value
@@ -301,9 +305,11 @@ def check_conflicting_effects(
                 simulated_effect is not None
                 and effect.fluent in simulated_effect.fluents
             ):
-                raise UPConflictingEffectsException(
-                    f"The effect {effect} is in conflict with the simulated effects already in the {name}."
-                )
+                if timing is None:
+                    msg = f"The effect {effect} is in conflict with the simulated effects already in the {name}."
+                else:
+                    msg = f"The effect {effect} at timing {timing} is in conflict with the simulated effects already in the {name}."
+                raise UPConflictingEffectsException(msg)
         else:
             raise NotImplementedError
 

--- a/unified_planning/model/effect.py
+++ b/unified_planning/model/effect.py
@@ -281,6 +281,12 @@ def check_conflicting_effects(
                     else:
                         msg = f"The effect {effect} at timing {timing} is in conflict with the effects already in the {name}."
                     raise UPConflictingEffectsException(msg)
+                elif effect.fluent in simulated_effect.fluents:
+                    if timing is None:
+                        msg = f"The effect {effect} is in conflict with the simulated effects already in the {name}."
+                    else:
+                        msg = f"The effect {effect} at timing {timing} is in conflict with the simulated effects already in the {name}."
+                    raise UPConflictingEffectsException(msg)
             else:
                 fluents_assigned[effect.fluent] = effect.value
         elif effect.is_increase() or effect.is_decrease():
@@ -305,6 +311,7 @@ def check_conflicting_effects(
 def check_conflicting_simulated_effects(
     simulated_effect: SimulatedEffect,
     timing: Optional["up.model.timing.Timing"],
+    fluents_assigned: Dict["up.model.fnode.FNode", "up.model.fnode.FNode"],
     fluents_inc_dec: Set["up.model.fnode.FNode"],
     name: str,
 ):
@@ -315,13 +322,15 @@ def check_conflicting_simulated_effects(
     :param simulated_effect: The target simulated_effect to add.
     :param timing: Optionally, the timing at which the simulated_effect is performed; None if the timing
         is not meaningful, like in InstantaneousActions.
+    :param fluents_assigned: The mapping from a fluent to it's value of the effects happening in the
+        same instant of the given simulated_effect.
     :param fluents_inc_dec: The set of fluents being increased or decremented in the same instant
         of the given simulated_effect.
     :param name: string used for better error indexing.
     :raises: UPConflictingException if the given simulated_effect is in conflict with the data structure around it.
     """
     for f in simulated_effect.fluents:
-        if f in fluents_inc_dec:
+        if f in fluents_inc_dec or f in fluents_assigned:
             if timing is None:
                 msg = f"The simulated effect {simulated_effect} is in conflict with the effects already in the {name}."
             else:

--- a/unified_planning/model/mixins/timed_conds_effs.py
+++ b/unified_planning/model/mixins/timed_conds_effs.py
@@ -2,7 +2,11 @@ from typing import Optional, Dict, List, Set, Tuple, Union
 
 import unified_planning as up
 from unified_planning.environment import Environment, get_environment
-from unified_planning.exceptions import UPConflictingEffectsException, UPTypeError
+from unified_planning.exceptions import (
+    UPConflictingEffectsException,
+    UPTypeError,
+    UPUsageError,
+)
 
 
 class TimedCondsEffs:
@@ -209,11 +213,16 @@ class TimedCondsEffs:
             value_exp,
             condition_exp,
         ) = self._environment.expression_manager.auto_promote(fluent, value, condition)
-        assert fluent_exp.is_fluent_exp()
+        if not fluent_exp.is_fluent_exp():
+            raise UPUsageError(
+                "fluent field of add_effect must be a Fluent or a FluentExp"
+            )
         if not self._environment.type_checker.get_type(condition_exp).is_bool_type():
             raise UPTypeError("Effect condition is not a Boolean condition!")
         if not fluent_exp.type.is_compatible(value_exp.type):
-            raise UPTypeError("DurativeAction effect has not compatible types!")
+            raise UPTypeError(
+                f"DurativeAction effect has an incompatible value type. Fluent type: {fluent_exp.type} // Value type: {value_exp.type}"
+            )
         self._add_effect_instance(
             timing, up.model.effect.Effect(fluent_exp, value_exp, condition_exp)
         )
@@ -239,11 +248,16 @@ class TimedCondsEffs:
             value_exp,
             condition_exp,
         ) = self._environment.expression_manager.auto_promote(fluent, value, condition)
-        assert fluent_exp.is_fluent_exp()
+        if not fluent_exp.is_fluent_exp():
+            raise UPUsageError(
+                "fluent field of add_increase_effect must be a Fluent or a FluentExp"
+            )
         if not condition_exp.type.is_bool_type():
             raise UPTypeError("Effect condition is not a Boolean condition!")
         if not fluent_exp.type.is_compatible(value_exp.type):
-            raise UPTypeError("DurativeAction effect has not compatible types!")
+            raise UPTypeError(
+                f"DurativeAction effect has an incompatible value type. Fluent type: {fluent_exp.type} // Value type: {value_exp.type}"
+            )
         if not fluent_exp.type.is_int_type() and not fluent_exp.type.is_real_type():
             raise UPTypeError("Increase effects can be created only on numeric types!")
         self._add_effect_instance(
@@ -277,11 +291,16 @@ class TimedCondsEffs:
             value_exp,
             condition_exp,
         ) = self._environment.expression_manager.auto_promote(fluent, value, condition)
-        assert fluent_exp.is_fluent_exp()
+        if not fluent_exp.is_fluent_exp():
+            raise UPUsageError(
+                "fluent field of add_decrease_effect must be a Fluent or a FluentExp"
+            )
         if not condition_exp.type.is_bool_type():
             raise UPTypeError("Effect condition is not a Boolean condition!")
         if not fluent_exp.type.is_compatible(value_exp.type):
-            raise UPTypeError("DurativeAction effect has not compatible types!")
+            raise UPTypeError(
+                f"DurativeAction effect has an incompatible value type. Fluent type: {fluent_exp.type} // Value type: {value_exp.type}"
+            )
         if not fluent_exp.type.is_int_type() and not fluent_exp.type.is_real_type():
             raise UPTypeError("Decrease effects can be created only on numeric types!")
         self._add_effect_instance(

--- a/unified_planning/model/mixins/timed_conds_effs.py
+++ b/unified_planning/model/mixins/timed_conds_effs.py
@@ -304,7 +304,7 @@ class TimedCondsEffs:
         fluents_assigned = self._fluents_assigned.setdefault(timing, set())
         fluents_inc_dec = self._fluents_inc_dec.setdefault(timing, set())
         simulated_effect = self._simulated_effects.get(timing, None)
-        if not effect.is_conditional():
+        if not effect.is_conditional() and not effect.fluent.type.is_bool_type():
             if effect.is_assignment():
                 if (
                     effect.fluent in fluents_assigned
@@ -322,7 +322,11 @@ class TimedCondsEffs:
                 fluents_inc_dec.add(effect.fluent)
             else:
                 raise NotImplementedError
-        if simulated_effect is not None and effect.fluent in simulated_effect.fluents:
+        if (
+            simulated_effect is not None
+            and not effect.fluent.type.is_bool_type()
+            and effect.fluent in simulated_effect.fluents
+        ):
             raise UPConflictingEffectsException(
                 f"The effect {effect} is in conflict with the simulated effects already in the action."
             )
@@ -347,9 +351,10 @@ class TimedCondsEffs:
         :param simulated effects: The `simulated effect` that must be applied at the given `timing`.
         """
         for f in simulated_effect.fluents:
-            if f in self._fluents_assigned.get(
-                timing, set()
-            ) or f in self._fluents_inc_dec.get(timing, set()):
+            if not f.type.is_bool_type() and (
+                f in self._fluents_assigned.get(timing, set())
+                or f in self._fluents_inc_dec.get(timing, set())
+            ):
                 raise UPConflictingEffectsException(
                     f"The simulated effect {simulated_effect} is in conflict with the effects already in the action."
                 )

--- a/unified_planning/model/mixins/timed_conds_effs.py
+++ b/unified_planning/model/mixins/timed_conds_effs.py
@@ -356,6 +356,7 @@ class TimedCondsEffs:
         up.model.effect.check_conflicting_simulated_effects(
             simulated_effect,
             timing,
+            self._fluents_assigned.setdefault(timing, {}),
             self._fluents_inc_dec.get(timing, set()),
             f"action or problem: {self.name}",  # type: ignore[attr-defined]
         )

--- a/unified_planning/model/mixins/timed_conds_effs.py
+++ b/unified_planning/model/mixins/timed_conds_effs.py
@@ -380,8 +380,9 @@ class TimedCondsEffs:
         :param simulated effects: The `simulated effect` that must be applied at the given `timing`.
         """
         for f in simulated_effect.fluents:
-            if not f.type.is_bool_type() and f in self._fluents_inc_dec.get(
-                timing, set()
+            if not f.type.is_bool_type() and (
+                f in self._fluents_inc_dec.get(timing, set())
+                or (timing, f) in self._fluents_assigned
             ):
                 raise UPConflictingEffectsException(
                     f"The simulated effect {simulated_effect} is in conflict with the effects already in the action."

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -187,7 +187,7 @@ class TestGrounder(TestCase):
         ground_result = gro.compile(problem, CompilationKind.GROUNDING)
         grounded_problem = ground_result.problem
         assert isinstance(grounded_problem, Problem)
-        self.assertEqual(len(grounded_problem.actions), 90)
+        self.assertEqual(len(grounded_problem.actions), 108)
         for a in grounded_problem.actions:
             self.assertEqual(len(a.parameters), 0)
 

--- a/unified_planning/test/test_model.py
+++ b/unified_planning/test/test_model.py
@@ -15,6 +15,11 @@
 
 import unified_planning
 from unified_planning.shortcuts import *
+from unified_planning.exceptions import (
+    UPUsageError,
+    UPTypeError,
+    UPConflictingEffectsException,
+)
 from unified_planning.test.examples import get_example_problems
 from unified_planning.test import TestCase, main
 
@@ -120,6 +125,109 @@ class TestModel(TestCase):
         )
         self.assertEqual(move.effects[0], e)
 
+        # variables used to test exceptions
+        Utl1 = UserType("UserTypeL1")
+        Utl2 = UserType("UserTypeL2")
+        is_at = Fluent("is_at", BoolType(), obj=Utl1)
+        int_fluent = Fluent("int", IntType())
+        test_exceptions = InstantaneousAction("test_exceptions")
+        l1 = ObjectExp(Object("l1", Utl1))
+        l2 = ObjectExp(Object("l2", Utl2))
+
+        # test add_effect exceptions
+        with self.assertRaises(UPUsageError) as usage_error:
+            test_exceptions.add_effect(l1, l2)
+        self.assertEqual(
+            str(usage_error.exception),
+            "fluent field of add_effect must be a Fluent or a FluentExp",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_effect(is_at(l1), l2, l1)
+        self.assertEqual(
+            str(type_error.exception), "Effect condition is not a Boolean condition!"
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_effect(is_at(l1), l2)
+        self.assertEqual(
+            str(type_error.exception),
+            f"InstantaneousAction effect has an incompatible value type. Fluent type: {is_at(l1).type} // Value type: {l2.type}",
+        )
+        test_exceptions.add_effect(int_fluent, 5)
+        test_exceptions.add_effect(int_fluent, 5)
+        with self.assertRaises(UPConflictingEffectsException) as conf_error:
+            test_exceptions.add_effect(int_fluent, 6)
+        effect = Effect(int_fluent(), Int(6), TRUE())
+        self.assertEqual(
+            str(conf_error.exception),
+            f"The effect {effect} is in conflict with the effects already in the action.",
+        )
+
+        # test add_increase_effect exceptions
+        with self.assertRaises(UPUsageError) as usage_error:
+            test_exceptions.add_increase_effect(l1, l2)
+        self.assertEqual(
+            str(usage_error.exception),
+            "fluent field of add_increase_effect must be a Fluent or a FluentExp",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_increase_effect(is_at(l1), l2, l1)
+        self.assertEqual(
+            str(type_error.exception), "Effect condition is not a Boolean condition!"
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_increase_effect(is_at(l1), l2)
+        self.assertEqual(
+            str(type_error.exception),
+            f"InstantaneousAction effect has an incompatible value type. Fluent type: {is_at(l1).type} // Value type: {l2.type}",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_increase_effect(is_at(l1), True)
+        self.assertEqual(
+            str(type_error.exception),
+            "Increase effects can be created only on numeric types!",
+        )
+        with self.assertRaises(UPConflictingEffectsException) as conf_error:
+            test_exceptions.add_increase_effect(int_fluent, 6)
+        effect = Effect(int_fluent(), Int(6), TRUE(), EffectKind.INCREASE)
+        self.assertEqual(
+            str(conf_error.exception),
+            f"The effect {effect} is in conflict with the effects already in the action.",
+        )
+        test_exceptions.clear_effects()
+        test_exceptions.add_increase_effect(int_fluent, 6)
+        sim_eff = SimulatedEffect([int_fluent()], lambda x, y, z: [Int(6)])
+        with self.assertRaises(UPConflictingEffectsException) as conf_error:
+            test_exceptions.set_simulated_effect(sim_eff)
+        self.assertEqual(
+            str(conf_error.exception),
+            f"The simulated effect {sim_eff} is in conflict with the effects already in the action.",
+        )
+
+        # test add_decrease_effect exceptions
+        with self.assertRaises(UPUsageError) as usage_error:
+            test_exceptions.add_decrease_effect(l1, l2)
+        self.assertEqual(
+            str(usage_error.exception),
+            "fluent field of add_decrease_effect must be a Fluent or a FluentExp",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_decrease_effect(is_at(l1), l2, l1)
+        self.assertEqual(
+            str(type_error.exception), "Effect condition is not a Boolean condition!"
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_decrease_effect(is_at(l1), l2)
+        self.assertEqual(
+            str(type_error.exception),
+            f"InstantaneousAction effect has an incompatible value type. Fluent type: {is_at(l1).type} // Value type: {l2.type}",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_decrease_effect(is_at(l1), True)
+        self.assertEqual(
+            str(type_error.exception),
+            "Decrease effects can be created only on numeric types!",
+        )
+
     def test_durative_action(self):
         Location = UserType("Location")
         x = Fluent("x")
@@ -148,6 +256,110 @@ class TestModel(TestCase):
         move.add_condition(StartTiming(), x)
         move.add_condition(ClosedTimeInterval(StartTiming(), EndTiming()), x)
         self.assertIn("duration = [1, 2)", str(move))
+
+        # variables used to test exceptions
+        Utl1 = UserType("UserTypeL1")
+        Utl2 = UserType("UserTypeL2")
+        is_at = Fluent("is_at", BoolType(), obj=Utl1)
+        int_fluent = Fluent("int", IntType())
+        test_exceptions = DurativeAction("test_exceptions")
+        l1 = ObjectExp(Object("l1", Utl1))
+        l2 = ObjectExp(Object("l2", Utl2))
+        t = StartTiming()
+
+        # test add_effect exceptions
+        with self.assertRaises(UPUsageError) as usage_error:
+            test_exceptions.add_effect(t, l1, l2)
+        self.assertEqual(
+            str(usage_error.exception),
+            "fluent field of add_effect must be a Fluent or a FluentExp",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_effect(t, is_at(l1), l2, l1)
+        self.assertEqual(
+            str(type_error.exception), "Effect condition is not a Boolean condition!"
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_effect(t, is_at(l1), l2)
+        self.assertEqual(
+            str(type_error.exception),
+            f"DurativeAction effect has an incompatible value type. Fluent type: {is_at(l1).type} // Value type: {l2.type}",
+        )
+        test_exceptions.add_effect(t, int_fluent, 5)
+        test_exceptions.add_effect(t, int_fluent, 5)
+        with self.assertRaises(UPConflictingEffectsException) as conf_error:
+            test_exceptions.add_effect(t, int_fluent, 6)
+        effect = Effect(int_fluent(), Int(6), TRUE())
+        self.assertEqual(
+            str(conf_error.exception),
+            f"The effect {effect} at timing {t} is in conflict with the effects already in the action.",
+        )
+
+        # test add_increase_effect exceptions
+        with self.assertRaises(UPUsageError) as usage_error:
+            test_exceptions.add_increase_effect(t, l1, l2)
+        self.assertEqual(
+            str(usage_error.exception),
+            "fluent field of add_increase_effect must be a Fluent or a FluentExp",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_increase_effect(t, is_at(l1), l2, l1)
+        self.assertEqual(
+            str(type_error.exception), "Effect condition is not a Boolean condition!"
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_increase_effect(t, is_at(l1), l2)
+        self.assertEqual(
+            str(type_error.exception),
+            f"DurativeAction effect has an incompatible value type. Fluent type: {is_at(l1).type} // Value type: {l2.type}",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_increase_effect(t, is_at(l1), True)
+        self.assertEqual(
+            str(type_error.exception),
+            "Increase effects can be created only on numeric types!",
+        )
+        with self.assertRaises(UPConflictingEffectsException) as conf_error:
+            test_exceptions.add_increase_effect(t, int_fluent, 6)
+        effect = Effect(int_fluent(), Int(6), TRUE(), EffectKind.INCREASE)
+        self.assertEqual(
+            str(conf_error.exception),
+            f"The effect {effect} at timing {t} is in conflict with the effects already in the action.",
+        )
+        test_exceptions.clear_effects()
+        test_exceptions.add_increase_effect(t, int_fluent, 6)
+        sim_eff = SimulatedEffect([int_fluent()], lambda x, y, z: [Int(6)])
+        with self.assertRaises(UPConflictingEffectsException) as conf_error:
+            test_exceptions.set_simulated_effect(t, sim_eff)
+        self.assertEqual(
+            str(conf_error.exception),
+            f"The simulated effect {sim_eff} is in conflict with the effects already in the action.",
+        )
+
+        # test add_decrease_effect exceptions
+        with self.assertRaises(UPUsageError) as usage_error:
+            test_exceptions.add_decrease_effect(t, l1, l2)
+        self.assertEqual(
+            str(usage_error.exception),
+            "fluent field of add_decrease_effect must be a Fluent or a FluentExp",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_decrease_effect(t, is_at(l1), l2, l1)
+        self.assertEqual(
+            str(type_error.exception), "Effect condition is not a Boolean condition!"
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_decrease_effect(t, is_at(l1), l2)
+        self.assertEqual(
+            str(type_error.exception),
+            f"DurativeAction effect has an incompatible value type. Fluent type: {is_at(l1).type} // Value type: {l2.type}",
+        )
+        with self.assertRaises(UPTypeError) as type_error:
+            test_exceptions.add_decrease_effect(t, is_at(l1), True)
+        self.assertEqual(
+            str(type_error.exception),
+            "Decrease effects can be created only on numeric types!",
+        )
 
     def test_problem(self):
         x = Fluent("x")

--- a/unified_planning/test/test_model.py
+++ b/unified_planning/test/test_model.py
@@ -292,7 +292,7 @@ class TestModel(TestCase):
         effect = Effect(int_fluent(), Int(6), TRUE())
         self.assertEqual(
             str(conf_error.exception),
-            f"The effect {effect} at timing {t} is in conflict with the effects already in the action.",
+            f"The effect {effect} at timing {t} is in conflict with the effects already in the action or problem: test_exceptions.",
         )
 
         # test add_increase_effect exceptions
@@ -324,7 +324,7 @@ class TestModel(TestCase):
         effect = Effect(int_fluent(), Int(6), TRUE(), EffectKind.INCREASE)
         self.assertEqual(
             str(conf_error.exception),
-            f"The effect {effect} at timing {t} is in conflict with the effects already in the action.",
+            f"The effect {effect} at timing {t} is in conflict with the effects already in the action or problem: test_exceptions.",
         )
         test_exceptions.clear_effects()
         test_exceptions.add_increase_effect(t, int_fluent, 6)
@@ -333,7 +333,7 @@ class TestModel(TestCase):
             test_exceptions.set_simulated_effect(t, sim_eff)
         self.assertEqual(
             str(conf_error.exception),
-            f"The simulated effect {sim_eff} is in conflict with the effects already in the action.",
+            f"The simulated effect {sim_eff} at timing {t} is in conflict with the effects already in the action or problem: test_exceptions.",
         )
 
         # test add_decrease_effect exceptions


### PR DESCRIPTION
PR linked to the discussion #191 

Before merging this PR, the engines that don't implement the **add-after-delete** semantic (i know about tamer and aries) should never return **UNSOLVABLE_PROVEN** but **UNSOLVABLE_INCOMPLETELY**. 

Maybe, a **conservative** check can be done to see if the **add-after-delete** semantic **never impacts the problem**. 
In this case, the engine **might** return **UNSOLVABLE_PROVEN**.