### PR TITLE
Fix/proto writer imports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Test all packages imports
         run: python3 scripts/test_imports.py
 
-
   run-tests-ubuntu:
     runs-on: ubuntu-latest
     needs: [basic-check]
@@ -90,8 +89,8 @@ jobs:
       - name: Setup java for ENHSP
         uses: actions/setup-java@v2
         with:
-            distribution: 'microsoft'
-            java-version: '17'
+          distribution: "microsoft"
+          java-version: "17"
 
       - name: Download and install ENHSP
         run: |
@@ -106,12 +105,12 @@ jobs:
         run: bash run_tests.sh
 
       - name: "Upload coverage to Codecov"
+        if: ${{ github.repository == 'aiplan4eu/unified-planning' }}
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
-
 
   run-tests-windows:
     runs-on: windows-latest
@@ -155,8 +154,8 @@ jobs:
       - name: Setup java for ENHSP
         uses: actions/setup-java@v2
         with:
-            distribution: 'microsoft'
-            java-version: '17'
+          distribution: "microsoft"
+          java-version: "17"
 
       - name: Download and install ENHSP
         run: |
@@ -166,7 +165,6 @@ jobs:
 
       - name: Run tests
         run: bash run_tests.sh
-
 
   run-tests-macos:
     runs-on: macos-latest
@@ -190,8 +188,7 @@ jobs:
       - name: Install tarski
         run: |
           python3 -m pip install tarski[arithmetic]
-#          brew install gringo -- Commented because not working on github actions
-
+      #          brew install gringo -- Commented because not working on github actions
       - name: Checkout up-tamer
         uses: actions/checkout@v2
         with:
@@ -215,8 +212,8 @@ jobs:
       - name: Setup java for ENHSP
         uses: actions/setup-java@v2
         with:
-            distribution: 'microsoft'
-            java-version: '17'
+          distribution: "microsoft"
+          java-version: "17"
 
       - name: Download and install ENHSP
         run: |
@@ -226,7 +223,6 @@ jobs:
 
       - name: Run tests
         run: bash run_tests.sh
-
 
   check-protobuf:
     runs-on: ubuntu-20.04
@@ -252,10 +248,15 @@ jobs:
           echo "Checking that the committed protobuf bindings are exactly the one generated from the declaration"
           git diff --exit-code
 
-
   run-colab-notebooks:
     runs-on: ubuntu-latest
-    needs: [basic-check, run-tests-ubuntu, run-tests-windows, run-tests-macos, check-protobuf] # We only test colabs if the base tests were succesful
+    needs: [
+        basic-check,
+        run-tests-ubuntu,
+        run-tests-windows,
+        run-tests-macos,
+        check-protobuf,
+      ] # We only test colabs if the base tests were succesful
 
     steps:
       - name: Checkout
@@ -303,29 +304,35 @@ jobs:
       - name: Run colabs
         run: bash scripts/test_colab.sh
 
-
   deploy-pypi:
     runs-on: ubuntu-latest
-    needs: [basic-check, run-tests-ubuntu, run-tests-windows, run-tests-macos, check-protobuf, run-colab-notebooks] # We only deploy if the tests were successful
+    needs: [
+        basic-check,
+        run-tests-ubuntu,
+        run-tests-windows,
+        run-tests-macos,
+        check-protobuf,
+        run-colab-notebooks,
+      ] # We only deploy if the tests were successful
     if: github.ref == 'refs/heads/master' # We only deploy on master commits
 
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@master
-      with:
-        fetch-depth: 0
+      - name: Checkout repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
 
-    - name: Make distrib
-      run: |
-        python3 -m pip install wheel
-        bash scripts/make_distrib.sh
+      - name: Make distrib
+        run: |
+          python3 -m pip install wheel
+          bash scripts/make_distrib.sh
 
-    - name: Upload to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/unified_planning/grpc/proto_writer.py
+++ b/unified_planning/grpc/proto_writer.py
@@ -19,8 +19,10 @@ from typing import List, Union
 
 import unified_planning.grpc.generated.unified_planning_pb2 as proto
 from unified_planning import model
+import unified_planning.engines
 import unified_planning.model.htn
 import unified_planning.model.walkers as walkers
+import unified_planning.plans
 from unified_planning.model.types import domain_size, domain_item
 from unified_planning.exceptions import UPException
 from unified_planning.grpc.converter import Converter, handles
@@ -523,7 +525,7 @@ class ProtobufWriter(Converter):
     @handles(model.Problem, model.htn.HierarchicalProblem)
     def _convert_problem(self, problem: model.Problem) -> proto.Problem:
         goals = [proto.Goal(goal=self.convert(g)) for g in problem.goals]
-        for (t, gs) in problem.timed_goals:
+        for t, gs in problem.timed_goals:
             goals += [
                 proto.Goal(goal=self.convert(g), timing=self.convert(t)) for g in gs
             ]
@@ -724,7 +726,6 @@ class ProtobufWriter(Converter):
             status
             == unified_planning.engines.PlanGenerationResultStatus.UNSUPPORTED_PROBLEM
         ):
-
             return proto.PlanGenerationResult.Status.Value("UNSUPPORTED_PROBLEM")
         elif status == unified_planning.engines.PlanGenerationResultStatus.INTERMEDIATE:
             return proto.PlanGenerationResult.Status.Value("INTERMEDIATE")


### PR DESCRIPTION
I'm trying to convert the problems and plans from the examples into their binary versions.

Importing the `ProtobufWriter` raises the following `AttributeError`:

``` bash
Traceback (most recent call last):
  File "/home/rgodet/thesis/planners/aries/planning/ext/up/problem_builder.py", line 10, in <module>
    from unified_planning.grpc.proto_writer import ProtobufWriter
  File "/home/rgodet/thesis/planners/aries/planning/ext/up/unified_planning/unified_planning/grpc/proto_writer.py", line 274, in <module>
    class ProtobufWriter(Converter):
  File "/home/rgodet/thesis/planners/aries/planning/ext/up/unified_planning/unified_planning/grpc/proto_writer.py", line 632, in ProtobufWriter
    @handles(unified_planning.plans.ActionInstance)
AttributeError: module 'unified_planning' has no attribute 'plans'
```

Adding `import unified_planning.plans` to the top of the file fixes the error.

The same error occurs with `unified_planning.engines`.

I also added the condition `if: ${{ github.repository == 'aiplan4eu/unified-planning' }}` on the CI for Codecov in order to disable it on my repo.
