### PR TITLE
feat(model): Allow treating action arguments as attributes.

### DIFF
--- a/unified_planning/model/action.py
+++ b/unified_planning/model/action.py
@@ -110,8 +110,8 @@ class Action:
         >>> move.parameter("target")
         Location target
 
-        If a parameter's name does not conflict with an existing attribute of an action, it can also be accessed as
-        if it was an attribute of the action. For instance:
+        If a parameter's name (1) does not conflict with an existing attribute of `Action` and (2) does not start with '_'
+        it can also be accessed as if it was an attribute of the action. For instance:
 
         >>> move.source
         Location source
@@ -124,6 +124,11 @@ class Action:
         return self._parameters[name]
 
     def __getattr__(self, parameter_name: str) -> "up.model.parameter.Parameter":
+        if parameter_name.startswith("_"):
+            # guard access as pickling relies on attribute error to be thrown even when
+            # no attributes of the object have been set.
+            # In this case accessing `self._name` or `self._parameters`, would re-invoke __getattr__
+            raise AttributeError(f"Action has no attribute '{parameter_name}'")
         if parameter_name not in self._parameters:
             raise AttributeError(
                 f"Action '{self.name}' has no attribute or parameter '{parameter_name}'"

--- a/unified_planning/model/action.py
+++ b/unified_planning/model/action.py
@@ -124,7 +124,11 @@ class Action:
         return self._parameters[name]
 
     def __getattr__(self, parameter_name: str) -> "up.model.parameter.Parameter":
-        return self.parameter(parameter_name)
+        if parameter_name not in self._parameters:
+            raise AttributeError(
+                f"Action '{self.name}' has no attribute or parameter '{parameter_name}'"
+            )
+        return self._parameters[parameter_name]
 
     def is_conditional(self) -> bool:
         """Returns `True` if the `Action` has `conditional effects`, `False` otherwise."""


### PR DESCRIPTION
This allows using subscript syntax to access parameters.

In a nutshell, it avoids the need for all the `action.parameter("...")` calls to enable the following syntax:

```py
move = InstantaneousAction("move", truck=Truck, src=Loc, tgt=Loc)
move.add_precondition(Equals(city(move.src), city(move.tgt)))
move.add_precondition(Equals(at(move.truck), move.src))
move.add_effect(at(move.truck), move.tgt)
```

While I am in general in favor of quite explicit code. The access to parameters has been quite pain point in my experience.
In particular, reextracting the parameters and storing them into intermediate variables was a common source of typos either when giving the name of the parameter to extract or when selecting the intermediate python variable (python scoping rules meaning that you have many such variables in scope).