### PR TITLE
Undefined value support

### DIFF
--- a/unified_planning/model/expression.py
+++ b/unified_planning/model/expression.py
@@ -66,6 +66,9 @@ class ExpressionManager(object):
         self.false_expression = self.create_node(
             node_type=OperatorKind.BOOL_CONSTANT, args=tuple(), payload=False
         )
+        self._undefined_expression = self.create_node(
+            node_type=OperatorKind.UNDEFINED, args=tuple(), payload=None
+        )
         return
 
     def _polymorph_args_to_tuple(
@@ -521,6 +524,10 @@ class ExpressionManager(object):
             return self.true_expression
         else:
             return self.false_expression
+
+    def UNDEFINED(self) -> "up.model.fnode.FNode":
+        """Return the constant value `Undefined`."""
+        return self._undefined_expression
 
     def Int(self, value: int) -> "up.model.fnode.FNode":
         """

--- a/unified_planning/model/fnode.py
+++ b/unified_planning/model/fnode.py
@@ -67,6 +67,8 @@ class FNode(object):
     def __repr__(self) -> str:
         if self.is_bool_constant():
             return "true" if self.is_true() else "false"
+        elif self.is_undefined():
+            return "undefined"
         elif self.is_int_constant():
             return str(self.constant_value())
         elif self.is_real_constant():
@@ -260,6 +262,10 @@ class FNode(object):
     def is_bool_constant(self) -> bool:
         """Test whether the expression is a `boolean` constant."""
         return self.node_type == OperatorKind.BOOL_CONSTANT
+
+    def is_undefined(self) -> bool:
+        """Test whether the expression is `undefined`."""
+        return self.node_type == OperatorKind.UNDEFINED
 
     def is_int_constant(self) -> bool:
         """Test whether the expression is an `integer` constant."""

--- a/unified_planning/model/operators.py
+++ b/unified_planning/model/operators.py
@@ -34,6 +34,7 @@ class OperatorKind(Enum):
     VARIABLE_EXP = auto()
     OBJECT_EXP = auto()
     TIMING_EXP = auto()
+    UNDEFINED = auto()
     BOOL_CONSTANT = auto()
     INT_CONSTANT = auto()
     REAL_CONSTANT = auto()

--- a/unified_planning/model/types.py
+++ b/unified_planning/model/types.py
@@ -40,7 +40,11 @@ class Type:
         return False
 
     def is_time_type(self) -> bool:
-        """Returns `True` iff is `time `True`."""
+        """Returns `True` iff is `time Type`."""
+        return False
+
+    def is_undefined_type(self) -> bool:
+        """Returns `True` iff is `undefined Type`."""
         return False
 
     def is_compatible(self, t_right: "Type") -> bool:
@@ -63,6 +67,17 @@ class _BoolType(Type):
 
     def is_bool_type(self) -> bool:
         """Returns true iff is boolean type."""
+        return True
+
+
+class _UndefinedType(Type):
+    """Represents the undefined type."""
+
+    def __repr__(self) -> str:
+        return "undefined"
+
+    def is_undefined_type(self) -> bool:
+        """Returns `True` iff is `undefined Type`."""
         return True
 
 
@@ -206,6 +221,7 @@ class _RealType(Type):
 
 BOOL = _BoolType()
 TIME = _TimeType()
+UNDEFINED = _UndefinedType()
 
 
 class TypeManager:
@@ -213,6 +229,7 @@ class TypeManager:
 
     def __init__(self):
         self._bool = BOOL
+        self._undefined = UNDEFINED
         self._ints: Dict[Tuple[Optional[int], Optional[int]], Type] = {}
         self._reals: Dict[Tuple[Optional[Fraction], Optional[Fraction]], Type] = {}
         self._user_types: Dict[Tuple[str, Optional[Type]], Type] = {}
@@ -226,6 +243,8 @@ class TypeManager:
         """
         if type.is_bool_type():
             return type == self._bool
+        elif type.is_undefined_type():
+            return type == self._undefined
         elif type.is_int_type():
             assert isinstance(type, _IntType)
             return self._ints.get((type.lower_bound, type.upper_bound), None) == type
@@ -243,6 +262,10 @@ class TypeManager:
     def BoolType(self) -> Type:
         """Returns this `Environment's` boolean `Type`."""
         return self._bool
+
+    def UndefinedType(self) -> Type:
+        """Returns this `Environment's` undefined `Type`."""
+        return self._undefined
 
     def IntType(
         self, lower_bound: Optional[int] = None, upper_bound: Optional[int] = None

--- a/unified_planning/model/walkers/dnf.py
+++ b/unified_planning/model/walkers/dnf.py
@@ -16,7 +16,7 @@
 
 import unified_planning.environment
 import unified_planning.model.walkers as walkers
-from unified_planning.exceptions import UPUnreachableCodeError
+from unified_planning.exceptions import UPUnreachableCodeError, UPUsageError
 from unified_planning.model.fnode import FNode
 from unified_planning.model.operators import OperatorKind
 from typing import List, Tuple
@@ -145,6 +145,8 @@ class Dnf(walkers.dag.DagWalker):
         For example, the form: !(a => (b && c)) becomes:
         a && (!b || !c), in NNF form, and then:
         (a && !b) || (a && !c), therefore a DNF expression."""
+        if expression.type.is_undefined_type():
+            raise UPUsageError("UNDEFINED value is not accepted by the Dnf walker")
         nnf_exp = self._nnf.get_nnf_expression(expression)
         tuples = self.walk(nnf_exp)
         return self.manager.Or(self.manager.And(and_args) for and_args in tuples)

--- a/unified_planning/model/walkers/expression_quantifiers_remover.py
+++ b/unified_planning/model/walkers/expression_quantifiers_remover.py
@@ -55,6 +55,8 @@ class ExpressionQuantifiersRemover(IdentityDagWalker):
         Note: The returned expression is not always equivalent to the given expression, but only considering
         the `objects` in the given `problem`.
         """
+        if expression.type.is_undefined_type():
+            return self._env.expression_manager.UNDEFINED()
         self._objects_set = objects_set
         return self.walk(expression)
 

--- a/unified_planning/model/walkers/identitydag.py
+++ b/unified_planning/model/walkers/identitydag.py
@@ -89,6 +89,9 @@ class IdentityDagWalker(walkers.dag.DagWalker):
     ) -> FNode:
         return self.manager.Bool(expression.bool_constant_value())
 
+    def walk_undefined(self, expression: FNode, args: List[FNode], **kwargs) -> FNode:
+        return self.manager.UNDEFINED()
+
     def walk_int_constant(
         self, expression: FNode, args: List[FNode], **kwargs
     ) -> FNode:

--- a/unified_planning/model/walkers/linear_checker.py
+++ b/unified_planning/model/walkers/linear_checker.py
@@ -16,7 +16,8 @@
 
 import unified_planning as up
 import unified_planning.model.walkers as walkers
-from unified_planning.environment import Environment, get_environment
+from unified_planning.environment import get_environment
+from unified_planning.exceptions import UPUsageError
 from unified_planning.model.walkers.dag import DagWalker
 from unified_planning.model.operators import OperatorKind
 from unified_planning.model.types import _IntType, _RealType
@@ -63,6 +64,10 @@ class LinearChecker(DagWalker):
         the `set` of the `fluent_expressions` appearing with a positive sign in the expression
         and the `set` of the `fluent_expressions` appearing with a negative sign in the expression .
         """
+        if expression.type.is_undefined_type():
+            raise UPUsageError(
+                "It makes no sense to check the linearity of an expression containing Undefined"
+            )
         return self.walk(self._simplifier.simplify(expression))
 
     @walkers.handles(

--- a/unified_planning/model/walkers/names_extractor.py
+++ b/unified_planning/model/walkers/names_extractor.py
@@ -76,6 +76,7 @@ class NamesExtractor(walkers.dag.DagWalker):
         op.OperatorKind.IFF,
         op.OperatorKind.TIMING_EXP,
         op.OperatorKind.BOOL_CONSTANT,
+        op.OperatorKind.UNDEFINED,
         op.OperatorKind.INT_CONSTANT,
         op.OperatorKind.REAL_CONSTANT,
         op.OperatorKind.PLUS,

--- a/unified_planning/model/walkers/simplifier.py
+++ b/unified_planning/model/walkers/simplifier.py
@@ -60,6 +60,8 @@ class Simplifier(walkers.dag.DagWalker):
         :param expression: The target expression that must be simplified with constant propagation.
         :return: The simplified expression.
         """
+        if expression.type.is_undefined_type():
+            return self.manager.UNDEFINED()
         return self.walk(expression)
 
     def walk_and(self, expression: FNode, args: List[FNode]) -> FNode:

--- a/unified_planning/model/walkers/usertype_fluents_walker.py
+++ b/unified_planning/model/walkers/usertype_fluents_walker.py
@@ -67,6 +67,8 @@ class UsertypeFluentsWalker(walkers.dag.DagWalker):
             expression, the top level fluent and all the FluentExp that must be True for the 2 expressions to be
             equivalent.
         """
+        if expression.type.is_undefined_type():
+            return (self.manager.UNDEFINED(), None, Set(), None, Set())
         exp, last_var, free_vars, last_fluent, added_fluents = self.walk(expression)
         if last_var is not None:
             assert last_fluent is not None
@@ -85,6 +87,8 @@ class UsertypeFluentsWalker(walkers.dag.DagWalker):
         :param expression: The FNode that must be returned without UsertypeFluents.
         :return: The equivalent expression without Usertype Fluents.
         """
+        if expression.type.is_undefined_type():
+            return (self.manager.UNDEFINED(), None, set(), None, set())
         new_exp, last_var, free_vars, last_fluent, added_fluents = self.walk(expression)
         assert (
             last_var is None and last_fluent is None

--- a/unified_planning/shortcuts.py
+++ b/unified_planning/shortcuts.py
@@ -271,6 +271,11 @@ def FALSE() -> FNode:
     return get_environment().expression_manager.FALSE()
 
 
+def UNDEFINED() -> FNode:
+    """Return the undefined constant."""
+    return get_environment().expression_manager.UNDEFINED()
+
+
 def Bool(value: bool) -> FNode:
     """
     Return a boolean constant.

--- a/unified_planning/test/test_sequential_simulator.py
+++ b/unified_planning/test/test_sequential_simulator.py
@@ -144,12 +144,12 @@ class TestSimulator(TestCase):
 
         self.assertTrue(simulator.is_goal(state))
 
-    def test_with_sequential_simualtor_instance(self):
+    def test_with_sequential_simulator_instance(self):
         problem = self.problems["hierarchical_blocks_world"].problem
         simulator = SequentialSimulator(problem)
         self.simulate_on_hierarchical_blocks_world(simulator, problem)
 
-    def test_with_smulator_from_factory(self):
+    def test_with_simulator_from_factory(self):
         problem = self.problems["hierarchical_blocks_world"].problem
         with Simulator(problem) as simulator:
             self.simulate_on_hierarchical_blocks_world(simulator, problem)

--- a/unified_planning/test/test_undefined_check.py
+++ b/unified_planning/test/test_undefined_check.py
@@ -1,0 +1,38 @@
+# Copyright 2021 AIPlan4EU project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unified_planning
+from unified_planning.exceptions import UPTypeError
+from unified_planning.shortcuts import *
+from unified_planning.test import TestCase
+
+
+class UndefinedCheck(TestCase):
+    def test_undefined(self):
+        u = UNDEFINED()
+        f = Fluent("f")
+        self.assertTrue(u.type.is_undefined_type())
+
+        exp_1 = And(u, f)
+        self.assertTrue(exp_1.type.is_undefined_type())
+
+        exp_2 = Plus(exp_1, 5)
+        self.assertTrue(exp_2.type.is_undefined_type())
+
+        with self.assertRaises(UPTypeError):
+            Plus(f, 5)
+
+        exp_3 = And(u, Plus(f, 5))
+        exp_4 = And(Plus(f, 5), u)


### PR DESCRIPTION
This PR introduces the possibility of assigning a fluent in the initial state of the problem the value UNDEFINED; this means that the value must be set to something defined before it can be evaluated to something meaningful.