### PR TITLE
fix(examples): duration of move in the htn-go-temporal problem

### DIFF
--- a/unified_planning/test/examples/hierarchical.py
+++ b/unified_planning/test/examples/hierarchical.py
@@ -154,7 +154,7 @@ def get_example_problems():
     durative_move.add_condition(StartTiming(), Equals(loc, l_from))
     durative_move.add_condition(overall, connected(l_from, l_to))
     durative_move.add_effect(EndTiming(), loc, l_to)
-    durative_move.set_fixed_duration(10)
+    durative_move.set_fixed_duration(1)
     htn_temporal.add_action(durative_move)
     go = htn_temporal.add_task("go", target=Location)
 


### PR DESCRIPTION
The duration was set to 10 in the problem and 1 in the plan.
Therefore, the plan was not valid.