### PR TITLE
feat(validation): Assign correct boolean semantics to `PlanValidationResult`.

### DIFF
--- a/unified_planning/engines/results.py
+++ b/unified_planning/engines/results.py
@@ -37,6 +37,12 @@ class ValidationResultStatus(Enum):
         auto()
     )  # The plan is invalid for the problem, it does not satisfy all the hard constraints
 
+    def __bool__(self):
+        if self == ValidationResultStatus.VALID:
+            return True
+        else:
+            return False
+
 
 class PlanGenerationResultStatus(Enum):
     """
@@ -167,6 +173,12 @@ class ValidationResult(Result):
 
     def is_definitive_result(self, *args) -> bool:
         return True
+
+    def __bool__(self):
+        if self.status == ValidationResultStatus.VALID:
+            return True
+        else:
+            return False
 
 
 @dataclass


### PR DESCRIPTION
This allows using a validation result directly as a boolean.
Or more exactly when used as a boolean (e.g. in an if condition),
VALID would be interpreted as True and INVALID as False.

Previously, the code below was perfectly legal but would print ok
even if the plan was invalid.

```py
if validator.validate(pb, plan):
  print("ok")
else:
  print("ko")
```
