### PR TITLE
feat(engines): Add the aries-val engine for plan validation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "fast-downward": ["up-fast-downward==0.1.2"],
         "lpg": ["up-lpg==0.0.4.9"],
         "fmap": ["up-fmap==0.0.2"],
-        "aries": ["up-aries>=0.0.4"],
+        "aries": ["up-aries>=0.0.7"],
         "engines": [
             "tarski[arithmetic]",
             "up-pyperplan==0.3.0.2.dev1",
@@ -40,7 +40,7 @@ setup(
             "up-fast-downward==0.1.2",
             "up-lpg==0.0.4.9",
             "up-fmap==0.0.2",
-            "up-aries>=0.0.4",
+            "up-aries>=0.0.7",
         ],
     },
     license="APACHE",

--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -50,6 +50,7 @@ DEFAULT_ENGINES = {
     "lpg-anytime": ("up_lpg.lpg_planner", "LPGAnytimeEngine"),
     "fmap": ("up_fmap.fmap_planner", "FMAPsolver"),
     "aries": ("up_aries", "Aries"),
+    "aries-val": ("up_aries", "AriesVal"),
     "sequential_plan_validator": (
         "unified_planning.engines.plan_validator",
         "SequentialPlanValidator",
@@ -129,6 +130,7 @@ DEFAULT_ENGINES_PREFERENCE_LIST = [
     "lpg-anytime",
     "fmap",
     "aries",
+    "aries-val",
 ]
 
 DEFAULT_META_ENGINES_PREFERENCE_LIST = ["oversubscription"]


### PR DESCRIPTION
This PR adds a new plan validator to the UP, that notably supports hierarchical plans.

The PR also bumps new minimum required version for up-aries to 0.0.7 that introduces the validator
and reenables support for anytime planning.
