### PR TITLE
Enhancement PlanValidationResult with invalid plans

### DIFF
--- a/unified_planning/engines/__init__.py
+++ b/unified_planning/engines/__init__.py
@@ -32,6 +32,7 @@ from unified_planning.engines.results import (
     ValidationResult,
     ValidationResultStatus,
     CompilerResult,
+    FailedValidationReasons,
 )
 from unified_planning.engines.sequential_simulator import (
     UPSequentialSimulator,

--- a/unified_planning/engines/__init__.py
+++ b/unified_planning/engines/__init__.py
@@ -32,7 +32,7 @@ from unified_planning.engines.results import (
     ValidationResult,
     ValidationResultStatus,
     CompilerResult,
-    FailedValidationReasons,
+    FailedValidationReason,
 )
 from unified_planning.engines.sequential_simulator import (
     UPSequentialSimulator,
@@ -67,6 +67,7 @@ __all__ = [
     "PlanGenerationResultStatus",
     "ValidationResult",
     "ValidationResultStatus",
+    "FailedValidationReason",
     "CompilerResult",
     "PortfolioSelectorMixin",
     "OperationMode",

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -31,7 +31,7 @@ from unified_planning.engines.results import (
     ValidationResultStatus,
     LogMessage,
     LogLevel,
-    FailedValidationReasons,
+    FailedValidationReason,
 )
 from unified_planning.engines.sequential_simulator import (
     UPSequentialSimulator,
@@ -139,14 +139,14 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
             assert prev_state is not None
             try:
                 unsat_conds = simulator.get_unsatisfied_conditions(prev_state, ai)
+                if unsat_conds:
+                    msg = f"Preconditions {unsat_conds} of {str(i)}-th action instance {str(ai)} are not satisfied."
             except UPConflictingEffectsException as e:
                 msg = f"{str(i)}-th action instance {str(ai)} creates conflicting effects: {str(e)}"
             except UPUsageError as e:
                 msg = f"{str(i)}-th action instance {str(ai)} creates a UsageError: {str(e)}"
             except UPInvalidActionError as e:
                 msg = f"{str(i)}-th action instance {str(ai)} creates an Invalid Action: {str(e)}"
-            if unsat_conds:
-                msg = f"Preconditions {unsat_conds} of {str(i)}-th action instance {str(ai)} are not satisfied."
             next_state = simulator.apply_unsafe(prev_state, ai)
             if next_state is None:
                 msg = f"{str(i)}-th action instance {str(ai)} creates conflicting effects."
@@ -157,7 +157,7 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                     self.name,
                     logs,
                     None,
-                    FailedValidationReasons.INAPPLICABLE_ACTION,
+                    FailedValidationReason.INAPPLICABLE_ACTION,
                     ai,
                 )
             assert next_state is not None
@@ -190,5 +190,5 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                 self.name,
                 logs,
                 None,
-                FailedValidationReasons.UNSATISFIED_GOALS,
+                FailedValidationReason.UNSATISFIED_GOALS,
             )

--- a/unified_planning/engines/results.py
+++ b/unified_planning/engines/results.py
@@ -45,6 +45,13 @@ class ValidationResultStatus(Enum):
             return False
 
 
+class FailedValidationReasons(Enum):
+    """Enum representing the possible reasons the plan validation failed."""
+
+    INAPPLICABLE_ACTION = auto()
+    UNSATISFIED_GOALS = auto()
+
+
 class PlanGenerationResultStatus(Enum):
     """
     Enum representing the 9 possible values in the status field of a :class:`~unified_planning.engines.PlanGenerationResult`:
@@ -174,7 +181,14 @@ class ValidationResult(Result):
     metric_evaluations: Optional[Dict[PlanQualityMetric, Union[int, Fraction]]] = field(
         default=None
     )
-    last_executed_action: Optional[up.plans.ActionInstance] = field(default=None)
+    reason: Optional[FailedValidationReasons] = field(default=None)
+    inapplicable_action: Optional[up.plans.ActionInstance] = field(default=None)
+
+    def __post_init__(self):
+        assert (
+            self.inapplicable_action is None
+            or self.reason == FailedValidationReasons.INAPPLICABLE_ACTION
+        ), "The inapplicable_action can be set only if the reason of the failed plan is an inapplicable action."
 
     def is_definitive_result(self, *args) -> bool:
         return True

--- a/unified_planning/engines/results.py
+++ b/unified_planning/engines/results.py
@@ -45,7 +45,7 @@ class ValidationResultStatus(Enum):
             return False
 
 
-class FailedValidationReasons(Enum):
+class FailedValidationReason(Enum):
     """Enum representing the possible reasons the plan validation failed."""
 
     INAPPLICABLE_ACTION = auto()
@@ -181,13 +181,13 @@ class ValidationResult(Result):
     metric_evaluations: Optional[Dict[PlanQualityMetric, Union[int, Fraction]]] = field(
         default=None
     )
-    reason: Optional[FailedValidationReasons] = field(default=None)
+    reason: Optional[FailedValidationReason] = field(default=None)
     inapplicable_action: Optional[up.plans.ActionInstance] = field(default=None)
 
     def __post_init__(self):
         assert (
             self.inapplicable_action is None
-            or self.reason == FailedValidationReasons.INAPPLICABLE_ACTION
+            or self.reason == FailedValidationReason.INAPPLICABLE_ACTION
         ), "The inapplicable_action can be set only if the reason of the failed plan is an inapplicable action."
 
     def is_definitive_result(self, *args) -> bool:

--- a/unified_planning/engines/results.py
+++ b/unified_planning/engines/results.py
@@ -174,6 +174,7 @@ class ValidationResult(Result):
     metric_evaluations: Optional[Dict[PlanQualityMetric, Union[int, Fraction]]] = field(
         default=None
     )
+    last_executed_action: Optional[up.plans.ActionInstance] = field(default=None)
 
     def is_definitive_result(self, *args) -> bool:
         return True

--- a/unified_planning/test/test_validator.py
+++ b/unified_planning/test/test_validator.py
@@ -14,6 +14,8 @@
 
 import unified_planning as up
 from unified_planning.shortcuts import *
+from unified_planning.engines import SequentialPlanValidator, FailedValidationReasons
+from unified_planning.plans import SequentialPlan, ActionInstance
 from unified_planning.model.problem_kind import (
     classical_kind,
     general_numeric_kind,
@@ -85,6 +87,27 @@ class TestPlanValidator(TestCase):
             plan = up.plans.SequentialPlan([])
             res = validator.validate(problem, plan)
             self.assertEqual(res.status, up.engines.ValidationResultStatus.INVALID)
+
+    def test_invalid_report(self):
+        problem, plan = self.problems["travel"]
+        up_validator = SequentialPlanValidator()
+
+        # without the last action the goal fails.
+        failed_goal_plan = SequentialPlan([*plan.actions[:-1]])
+        res = up_validator.validate(problem, failed_goal_plan)
+        self.assertEqual(res.reason, FailedValidationReasons.UNSATISFIED_GOALS)
+
+        # add an invalid action to the plan
+        move = problem.action("move")
+        l1 = problem.object("l1")
+        l2 = problem.object("l2")
+        invalid_action = ActionInstance(move, (ObjectExp(l2), ObjectExp(l1)))
+        actions = [*plan.actions]
+        actions.append(invalid_action)
+        invalid_action_plan = SequentialPlan(actions)
+        res = up_validator.validate(problem, invalid_action_plan)
+        self.assertEqual(res.reason, FailedValidationReasons.INAPPLICABLE_ACTION)
+        self.assertEqual(res.inapplicable_action, invalid_action)
 
 
 if __name__ == "__main__":

--- a/unified_planning/test/test_validator.py
+++ b/unified_planning/test/test_validator.py
@@ -14,7 +14,7 @@
 
 import unified_planning as up
 from unified_planning.shortcuts import *
-from unified_planning.engines import SequentialPlanValidator, FailedValidationReasons
+from unified_planning.engines import SequentialPlanValidator, FailedValidationReason
 from unified_planning.plans import SequentialPlan, ActionInstance
 from unified_planning.model.problem_kind import (
     classical_kind,
@@ -95,7 +95,7 @@ class TestPlanValidator(TestCase):
         # without the last action the goal fails.
         failed_goal_plan = SequentialPlan([*plan.actions[:-1]])
         res = up_validator.validate(problem, failed_goal_plan)
-        self.assertEqual(res.reason, FailedValidationReasons.UNSATISFIED_GOALS)
+        self.assertEqual(res.reason, FailedValidationReason.UNSATISFIED_GOALS)
 
         # add an invalid action to the plan
         move = problem.action("move")
@@ -106,7 +106,7 @@ class TestPlanValidator(TestCase):
         actions.append(invalid_action)
         invalid_action_plan = SequentialPlan(actions)
         res = up_validator.validate(problem, invalid_action_plan)
-        self.assertEqual(res.reason, FailedValidationReasons.INAPPLICABLE_ACTION)
+        self.assertEqual(res.reason, FailedValidationReason.INAPPLICABLE_ACTION)
         self.assertEqual(res.inapplicable_action, invalid_action)
 
 


### PR DESCRIPTION
With this PR we add:
- an `Enum` representing the possible reasons of a failed plan (for now `INAPPLICABLE_ACTION` or `UNSATISFIED_GOAL`)
- an `Optional` field to the `PlanValidationResult` called `reason`, that is an instance of the `Enum` described above
- an `Optional` field to the `PlanValidationResult` called `inapplicable_action`, that might contain the failed action instance when the reason of the failed plan is `INAPPLICABLE_ACTION`