### PR TITLE
fix(expression): use isintance to check the value type

### DIFF
--- a/unified_planning/model/expression.py
+++ b/unified_planning/model/expression.py
@@ -512,7 +512,7 @@ class ExpressionManager(object):
         :param value: The boolean value that must be promoted to `FNode`.
         :return: The `FNode` containing the given `value` as his payload.
         """
-        if type(value) != bool:
+        if not isinstance(value, bool):
             raise UPTypeError("Expecting bool, got %s" % type(value))
 
         if value:
@@ -527,7 +527,7 @@ class ExpressionManager(object):
         :param value: The integer that must be promoted to `FNode`.
         :return: The `FNode` containing the given `integer` as his payload.
         """
-        if type(value) != int:
+        if not isinstance(value, int):
             raise UPTypeError("Expecting int, got %s" % type(value))
         return self.create_node(
             node_type=OperatorKind.INT_CONSTANT, args=tuple(), payload=value
@@ -540,7 +540,7 @@ class ExpressionManager(object):
         :param value: The `Fraction` that must be promoted to `FNode`.
         :return: The `FNode` containing the given `value` as his payload.
         """
-        if type(value) != Fraction:
+        if not isinstance(value, Fraction):
             raise UPTypeError("Expecting Fraction, got %s" % type(value))
         return self.create_node(
             node_type=OperatorKind.REAL_CONSTANT, args=tuple(), payload=value


### PR DESCRIPTION
The value can be an `int` without having the type `int`, *e.g.* `IntEnum` which is a subclass of `int`.