### PR TITLE
Fix proto conversion of TimeTriggeredPlan

### DIFF
--- a/unified_planning/grpc/proto_reader.py
+++ b/unified_planning/grpc/proto_reader.py
@@ -662,7 +662,9 @@ class ProtobufReader(Converter):
     def _convert_action_instance(
         self, msg: proto.ActionInstance, problem: Problem
     ) -> Tuple[
-        str, ActionInstance, Optional[Tuple[model.Timing, model.timing.Duration]]
+        str,
+        ActionInstance,
+        Optional[Tuple[fractions.Fraction, Optional[fractions.Fraction]]],
     ]:
         # action instance parameters are atoms but in UP they are FNodes
         # converting to up.model.FNode
@@ -678,7 +680,11 @@ class ProtobufReader(Converter):
             start_time = self.convert(msg.start_time)
             end_time = self.convert(msg.end_time)
             duration = end_time - start_time
-            return id, action_instance, (start_time, duration)
+            return (
+                id,
+                action_instance,
+                (start_time, None if duration == 0 else duration),
+            )
         else:
             return id, action_instance, None
 

--- a/unified_planning/grpc/proto_writer.py
+++ b/unified_planning/grpc/proto_writer.py
@@ -716,7 +716,8 @@ class ProtobufWriter(Converter):
         for a in plan.timed_actions:
             id = ids.get(a[1]) if ids else None
             start_time = self.convert(a[0])
-            end_time = self.convert(a[0] + a[2])
+            duration = 0 if a[2] is None else a[2]
+            end_time = self.convert(a[0] + duration)
             instance = self._convert_action_instance(
                 a[1], start_time=start_time, end_time=end_time, id=id
             )


### PR DESCRIPTION
This PR fixes the `ProtoReader` and `ProtoWriter` with `TimeTriggeredPlans` that have some `InstantaneousActions` with duration equals to `None`