### PR TITLE
Added two planning engines: "symk" and "symk-opt"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "lpg": ["up-lpg==0.0.6.3"],
         "fmap": ["up-fmap==0.0.6"],
         "aries": ["up-aries>=0.0.8"],
+        "symk": ["up-symk>=0.0.3"],
         "engines": [
             "tarski[arithmetic]",
             "up-pyperplan==0.3.0.4.dev1",
@@ -41,6 +42,7 @@ setup(
             "up-lpg==0.0.6.3",
             "up-fmap==0.0.6",
             "up-aries>=0.0.8",
+            "up-symk>=0.0.3"
         ],
     },
     license="APACHE",

--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -44,6 +44,8 @@ from pathlib import PurePath
 DEFAULT_ENGINES = {
     "fast-downward": ("up_fast_downward", "FastDownwardPDDLPlanner"),
     "fast-downward-opt": ("up_fast_downward", "FastDownwardOptimalPDDLPlanner"),
+    "symk": ("up_symk", "SymKPDDLPlanner"),
+    "symk-opt": ("up_symk", "SymKOptimalPDDLPlanner"),
     "pyperplan": ("up_pyperplan.engine", "EngineImpl"),
     "pyperplan-opt": ("up_pyperplan.engine", "OptEngineImpl"),
     "enhsp": ("up_enhsp.enhsp_planner", "ENHSPSatEngine"),
@@ -118,6 +120,8 @@ DEFAULT_META_ENGINES = {
 DEFAULT_ENGINES_PREFERENCE_LIST = [
     "fast-downward",
     "fast-downward-opt",
+    "symk",
+    "symk-opt",
     "pyperplan",
     "pyperplan-opt",
     "enhsp",


### PR DESCRIPTION
As part of the 1st sprint of the "Symbolic Search for Diverse Plans and Maximum Utility" project, we added two search engines to the UP that can be installed using the [up-symk](https://github.com/aiplan4eu/up-symk/tree/master) repo. Both engines can generate a single or multiple/all plans using the OneshotPlanner and AnytimePlanner interfaces. The two differ in that "symk-opt" has an optimality guarantee for both settings, generating a single or multiple/all optimal plans.

You can find a usage example [here](https://github.com/aiplan4eu/up-symk/blob/master/notebooks/symk_usage.ipynb).

Let me know if you want any changes.

Best
David