### PR TITLE
Scheduling stabilization

### DIFF
--- a/docs/code_snippets/temporal_and_scheduling.py
+++ b/docs/code_snippets/temporal_and_scheduling.py
@@ -47,32 +47,21 @@ for fuse_obj in fuse_objects:
 from unified_planning.model.scheduling import SchedulingProblem
 
 problem = SchedulingProblem("factory")
-
-Resource = UserType("Resource")
-r1 = problem.add_object("r1", Resource)
-r2 = problem.add_object("r2", Resource)
-problem.add_fluent("lvl", IntType(0, 1), default_initial_value=1, r=Resource)
-
-red = problem.add_fluent("red", BoolType(), r=Resource)
-problem.set_initial_value(red(r1), True)
-problem.set_initial_value(red(r2), True)
-
-workers = problem.add_resource("workers", 4)
-machine1 = problem.add_resource("machine1", 1)
-machine2 = problem.add_resource("machine2", 1)
+workers = problem.add_resource("workers", capacity=4)
+machine1 = problem.add_resource("machine1", capacity=1)
+machine2 = problem.add_resource("machine2", capacity=1)
 
 a1 = problem.add_activity("a1", duration=3)
-a1.uses(workers)
 a1.uses(machine1)
+a1.uses(workers, amount=2)
+a1.add_deadline(14)
 
 a2 = problem.add_activity("a2", duration=6)
-a2_r = a2.add_parameter("r", Resource)
-problem.add_constraint(red(a2_r))
 a2.uses(workers)
 a2.uses(machine2)
 
-problem.add_constraint(LT(a1.end, a2.start))
+problem.add_constraint(LT(a2.end, a1.start))
 
-# One worker is unavailable over [17, 25)
-problem.add_decrease_effect(17, workers, 1)
+# One worker is unavailable over [17, 25]
+problem.add_decrease_effect(16, workers, 1)
 problem.add_increase_effect(25, workers, 1)

--- a/docs/generate_api_doc.py
+++ b/docs/generate_api_doc.py
@@ -12,6 +12,7 @@ model.Problem
 model.InstantaneousAction
 model.DurativeAction
 model.Parameter
+model.metrics.PlanQualityMetric
 model.metrics.MinimizeActionCosts
 model.metrics.MinimizeSequentialPlanLength
 model.metrics.MinimizeMakespan
@@ -25,6 +26,13 @@ model.htn.Method
 model.multi_agent.MultiAgentProblem
 model.multi_agent.Agent
 model.multi_agent.MAEnvironment
+model.scheduling.SchedulingProblem
+model.scheduling.Activity
+model.timing.Timepoint
+model.timing.Timing
+model.timing.Interval
+model.timing.Duration
+model.timing.DurationInterval
 io.PDDLReader
 io.PDDLWriter
 io.ANMLWriter
@@ -44,6 +52,7 @@ plans.TimeTriggeredPlan
 plans.PartialOrderPlan
 plans.STNPlan
 plans.HierarchicalPlan
+plans.Schedule
 """
 
 base_dir = "api/"

--- a/docs/problem_representation.rst
+++ b/docs/problem_representation.rst
@@ -227,13 +227,13 @@ This means that it is possible to model actions having:
 
 Scheduling Example
 ------------------
-Scheduling is a restricted form of temporal planning where the set of actions (usually called activities) are known in advance and the problem consists in deciding the timing of the activities.
+Scheduling is a restricted form of temporal planning where the set of actions (usually called activities) are known in advance and the problem consists in deciding the timing and parameters of the activities.
 Generally, scheduled problems involve resources and constraints that define the feasible space of solutions.
 Since scheduling problems are very common and scheduling as a computer science problem belongs to a simpler complexity class (NP) with respect to temporal planning (PSPACE, under suitable assumptions) we created a dedicated representation for scheduling problems.
 We can represent a generic scheduling problem using the SchedulingProblem class as shown in the example below.
 
 .. literalinclude:: ./code_snippets/temporal_and_scheduling.py
-    :lines: 47-78
+    :lines: 47-67
 
 
 MultiAgent Example

--- a/unified_planning/grpc/proto_writer.py
+++ b/unified_planning/grpc/proto_writer.py
@@ -616,13 +616,13 @@ class ProtobufWriter(Converter):
         problem_name = str(problem.name) if problem.name is not None else ""
         goals = [
             proto.Goal(goal=self.convert(g), timing=self.convert(t))
-            for t, g in problem.base_conditions()
+            for t, g in problem.base_conditions
         ]
 
         sched = proto.SchedulingExtension(
             activities=[self.convert(a) for a in problem.activities],
             variables=[self.convert(v) for v in problem.base_variables],
-            constraints=[self.convert(c) for c in problem.base_constraints()],
+            constraints=[self.convert(c) for c in problem.base_constraints],
         )
 
         return proto.Problem(
@@ -639,7 +639,7 @@ class ProtobufWriter(Converter):
                 proto.TimedEffect(
                     occurrence_time=self.convert(timing), effect=self.convert(eff)
                 )
-                for (timing, eff) in problem.base_effects()
+                for (timing, eff) in problem.base_effects
             ],
             goals=goals,
             features=[map_feature(feature) for feature in problem.kind.features],

--- a/unified_planning/model/expression.py
+++ b/unified_planning/model/expression.py
@@ -38,7 +38,7 @@ BoolExpression = Union[
     bool,
 ]
 NumericConstant = Union[int, float, Fraction, str]
-NumericExpression = Union["up.model.fnode.FNode", NumericConstant]
+NumericExpression = Union[NumericConstant, "up.model.fnode.FNode"]
 ConstantExpression = Union[
     NumericExpression,
     "up.model.object.Object",

--- a/unified_planning/model/scheduling/scheduling_problem.py
+++ b/unified_planning/model/scheduling/scheduling_problem.py
@@ -173,19 +173,19 @@ class SchedulingProblem(  # type: ignore[misc]
         # note: auto promoted to discrete time in `finalize()` if that's what is said in the TimeModelMixin.
         factory.kind.set_time("CONTINUOUS_TIME")
 
-        if len(self.base_conditions()) > 0:
+        if len(self.base_conditions) > 0:
             factory.kind.set_time("TIMED_GOALS")
 
-        if len(self.base_effects()) > 0:
+        if len(self.base_effects) > 0:
             factory.kind.set_time("TIMED_EFFECTS")
 
-        for _, cond, _ in self.conditions():
+        for _, cond, _ in self.all_conditions():
             factory.update_problem_kind_expression(cond)
 
-        for constraint in self.base_constraints():
+        for constraint in self.base_constraints:
             factory.update_problem_kind_expression(constraint)
 
-        for _, eff in self.base_effects():
+        for _, eff in self.base_effects:
             factory.update_problem_kind_effect(eff)
 
         for act in self.activities:

--- a/unified_planning/model/scheduling/scheduling_problem.py
+++ b/unified_planning/model/scheduling/scheduling_problem.py
@@ -52,47 +52,13 @@ class SchedulingProblem(  # type: ignore[misc]
     MetricsMixin,
 ):
     """A scheduling problem shares most of its construct with a planning problem with the following differences:
-    - there are no action in a scheduling problem
-    - it defines a set of variables and timepoints over which constraints can be stated
+
+    - scheduling problems replaces *actions* with *activities*. While in planning, a solution plan may contain zero, one
+      or multiple instances of the same action, in scheduling the solution must contain *exactly one* instance of each activity.
+    - it defines a set of variables and timepoints over which constraints can be stated,
     - it provides some shortcuts to deal with typical scheduling constructs (activities, resources, ...)
+    - by default, a `SchedulingProblem` assumes a discrete time model with a minimal temporal separation (aka `epsilon`) of 1.
     """
-
-    @property
-    def kind(self) -> "up.model.problem_kind.ProblemKind":
-        factory = up.model.problem._KindFactory(self, "SCHEDULING", self.environment)
-
-        # note: auto promoted to discrete time in `finalize()` if that's what is said in the TimeModelMixin.
-        factory.kind.set_time("CONTINUOUS_TIME")
-
-        if len(self.base_conditions()) > 0:
-            factory.kind.set_time("TIMED_GOALS")
-
-        if len(self.base_effects()) > 0:
-            factory.kind.set_time("TIMED_EFFECTS")
-
-        for _, cond, _ in self.conditions():
-            factory.update_problem_kind_expression(cond)
-
-        for constraint in self.base_constraints():
-            factory.update_problem_kind_expression(constraint)
-
-        for _, eff in self.base_effects():
-            factory.update_problem_kind_effect(eff)
-
-        for act in self.activities:
-            factory.update_action_duration(act.duration)
-            for param in act.parameters:
-                factory.update_action_parameter(param)
-            for t, effs in act.effects.items():
-                for e in effs:
-                    factory.update_action_timed_effect(t, e)
-            for span, conds in act.conditions.items():
-                for cond in conds:
-                    factory.update_action_timed_condition(span, cond)
-            for constraint in act.constraints:
-                factory.update_problem_kind_expression(constraint)
-
-        return factory.finalize()
 
     def __init__(
         self,
@@ -123,9 +89,6 @@ class SchedulingProblem(  # type: ignore[misc]
         self._activities: List[Activity] = []
 
         self._metrics: List["up.model.metrics.PlanQualityMetric"] = []
-        print(
-            "WARNING: The SchedulingProblem class is currently unstable and not feature complete."
-        )
 
     def __repr__(self) -> str:
         s = []
@@ -203,7 +166,45 @@ class SchedulingProblem(  # type: ignore[misc]
         res += sum(map(hash, self._activities))
         return res
 
+    @property
+    def kind(self) -> "up.model.problem_kind.ProblemKind":
+        factory = up.model.problem._KindFactory(self, "SCHEDULING", self.environment)
+
+        # note: auto promoted to discrete time in `finalize()` if that's what is said in the TimeModelMixin.
+        factory.kind.set_time("CONTINUOUS_TIME")
+
+        if len(self.base_conditions()) > 0:
+            factory.kind.set_time("TIMED_GOALS")
+
+        if len(self.base_effects()) > 0:
+            factory.kind.set_time("TIMED_EFFECTS")
+
+        for _, cond, _ in self.conditions():
+            factory.update_problem_kind_expression(cond)
+
+        for constraint in self.base_constraints():
+            factory.update_problem_kind_expression(constraint)
+
+        for _, eff in self.base_effects():
+            factory.update_problem_kind_effect(eff)
+
+        for act in self.activities:
+            factory.update_action_duration(act.duration)
+            for param in act.parameters:
+                factory.update_action_parameter(param)
+            for t, effs in act.effects.items():
+                for e in effs:
+                    factory.update_action_timed_effect(t, e)
+            for span, conds in act.conditions.items():
+                for cond in conds:
+                    factory.update_action_timed_condition(span, cond)
+            for constraint in act.constraints:
+                factory.update_problem_kind_expression(constraint)
+
+        return factory.finalize()
+
     def clone(self):
+        """Returns an equivalent problem."""
         new_p = SchedulingProblem(self._name, self._env)
         UserTypesSetMixin._clone_to(self, new_p)
         ObjectsSetMixin._clone_to(self, new_p)
@@ -216,13 +217,10 @@ class SchedulingProblem(  # type: ignore[misc]
         new_p._activities = [a.clone() for a in self._activities]
         return new_p
 
-    def has_name(self, name: str) -> bool:
-        return name in self._base._parameters
-
     def add_variable(self, name: str, tpe: Type) -> Parameter:
         """Adds a new decision variable to the problem.
         Such variables essentially act as existentially quantified variables whose scope is
-        the entire problem, which allows referring to them everywhere and access their value in the solution.
+        the entire problem, which allows referring to them everywhere and access their values in the solution.
         """
         assert not self.has_name(name)
         param = Parameter(name, tpe)
@@ -233,19 +231,26 @@ class SchedulingProblem(  # type: ignore[misc]
         """Returns the existing decision variable with the given name."""
         return self._base.get_parameter(name)
 
+    def add_activity(self, name: str, duration: int = 0) -> "Activity":
+        """Creates a new activity with the given `name` in the problem.
+
+        :param name: Name that uniquely identifies the activity.
+        :param duration: (optional) Fixed duration of the activity. If not set, the duration to 0 (instantaneous activity).
+                         The duration can alter be overriden on the Activity object.
+        """
+        if any(a.name == name for a in self._activities):
+            raise ValueError(f"An activity with name '{name}' already exists.")
+        act = Activity(name=name, duration=duration)
+        self._activities.append(act)
+        return act
+
     @property
     def activities(self) -> List[Activity]:
         """Return a list of all potential activities in the problem."""
         return self._activities
 
-    def add_activity(self, name: str, duration: int = 0) -> "Activity":
-        """Creates a new activity with the given `name` in the problem."""
-        act = Activity(name=name, duration=duration)
-        self._activities.append(act)
-        return act
-
-    def get_activity(self, name) -> "Activity":
-        """Returns the activiy with the given name."""
+    def get_activity(self, name: str) -> "Activity":
+        """Returns the activity with the given name."""
         for act in self.activities:
             if act.name == name:
                 return act
@@ -253,9 +258,13 @@ class SchedulingProblem(  # type: ignore[misc]
             f"Unknown activity '{name}'. Available activity names: {[a.name for a in self.activities]}"
         )
 
-    def add_resource(self, name: str, capacity: int = 1) -> Fluent:
-        """Declares a new resource: a numeric fluent in `[0, CAPACITY]` where capacity is the
-        default initial value of the fluent and denote the capacity of the resource."""
+    def add_resource(self, name: str, capacity: int) -> Fluent:
+        """Declares a new resource: a bounded integer fluent in `[0, CAPACITY]` where capacity is the
+        default initial value of the fluent and denote the capacity of the resource.
+
+        :param name: Name of the fluent that will represent the resource.
+        :param capacity: Upper bound on the fluent value. By default, the fluent initial value is set to `capacity`.
+        """
         tpe = self._env.type_manager.IntType(0, capacity)
         return self.add_fluent(name, tpe, default_initial_value=capacity)
 
@@ -304,7 +313,38 @@ class SchedulingProblem(  # type: ignore[misc]
         self._base.add_decrease_effect(timing, fluent, value, condition)  # type: ignore
 
     @property
-    def variables(self) -> List[Tuple[Union[Parameter, Timepoint], Optional[Activity]]]:
+    def base_variables(self) -> List[Parameter]:
+        """Return all decisions variables that were defined in the base problem (i.e. not in the activities)"""
+        return self._base.parameters.copy()
+
+    @property
+    def base_constraints(self) -> List[FNode]:
+        """Returns all constraints defined in the base problem (ignoring any constraint defined in an activity)."""
+        return self._base.constraints.copy()
+
+    @property
+    def base_conditions(self) -> List[Tuple[TimeInterval, FNode]]:
+        """Returns all timed conditions defined in the base problem
+        (i.e. excluding those defined in activities)."""
+        return [
+            (timing, cond)
+            for (timing, conds) in self._base.conditions.items()
+            for cond in conds
+        ]
+
+    @property
+    def base_effects(self) -> List[Tuple[Timing, Effect]]:
+        """Returns all timed effects defined in the base problem
+        (i.e. excluding those defined in activities)."""
+        return [
+            (timing, eff)
+            for (timing, effs) in self._base.effects.items()
+            for eff in effs
+        ]
+
+    def all_variables(
+        self,
+    ) -> List[Tuple[Union[Parameter, Timepoint], Optional[Activity]]]:
         """Returns all decision variables (timepoints and parameters) defined in this problem and its activities.
         For each variable, the activity in which it was defined is also given."""
         vars: List[Tuple[Union[Parameter, Timepoint], Optional[Activity]]] = []
@@ -315,13 +355,7 @@ class SchedulingProblem(  # type: ignore[misc]
             vars += map(lambda param: (param, activity), activity.parameters)
         return vars
 
-    @property
-    def base_variables(self) -> List[Parameter]:
-        """Return all decisions variables that were defined in the base problem (i.e. not in the activities)"""
-        return self._base.parameters.copy()
-
-    @property
-    def constraints(self) -> List[Tuple[FNode, Optional[Activity]]]:
+    def all_constraints(self) -> List[Tuple[FNode, Optional[Activity]]]:
         """Returns all constraints enforced in this problem or in any of its activities.
         For each constraint, the activity in which it was defined is also given."""
         cs: List[Tuple[FNode, Optional[Activity]]] = list(
@@ -331,11 +365,7 @@ class SchedulingProblem(  # type: ignore[misc]
             cs += map(lambda c: (c, a), a.constraints)
         return cs
 
-    def base_constraints(self) -> List[FNode]:
-        """Returns all constraints defined in the base problem (ignoring any constraint defined in an activity)."""
-        return self._base.constraints.copy()
-
-    def conditions(self) -> List[Tuple[TimeInterval, FNode, Optional[Activity]]]:
+    def all_conditions(self) -> List[Tuple[TimeInterval, FNode, Optional[Activity]]]:
         """Returns all timed conditions enforced in this problem or in any of its activities.
         For each condition, the activity in which it was defined is also given."""
         cs: List[Tuple[TimeInterval, FNode, Optional[Activity]]] = []
@@ -346,16 +376,7 @@ class SchedulingProblem(  # type: ignore[misc]
                 cs += map(lambda cond: (timing, cond, act), conds)
         return cs
 
-    def base_conditions(self) -> List[Tuple[TimeInterval, FNode]]:
-        """Returns all timed conditions defined in the base problem
-        (i.e. excluding those defined in activities)."""
-        return [
-            (timing, cond)
-            for (timing, conds) in self._base.conditions.items()
-            for cond in conds
-        ]
-
-    def effects(self) -> List[Tuple[Timing, Effect, Optional[Activity]]]:
+    def all_effects(self) -> List[Tuple[Timing, Effect, Optional[Activity]]]:
         """Returns all timed effects enforced in this problem or in any of its activities.
         For each effect, the activity in which it was defined is also given."""
         es: List[Tuple[Timing, Effect, Optional[Activity]]] = []
@@ -365,15 +386,6 @@ class SchedulingProblem(  # type: ignore[misc]
             for timing, effs in act.effects.items():
                 es += map(lambda eff: (timing, eff, act), effs)
         return es
-
-    def base_effects(self) -> List[Tuple[Timing, Effect]]:
-        """Returns all timed effects defined in the base problem
-        (i.e. excluding those defined in activities)."""
-        return [
-            (timing, eff)
-            for (timing, effs) in self._base.effects.items()
-            for eff in effs
-        ]
 
     def normalize_plan(self, plan: "up.plans.Plan") -> "up.plans.Plan":
         """
@@ -386,3 +398,6 @@ class SchedulingProblem(  # type: ignore[misc]
         """
         raise NotImplementedError
         # TODO
+
+    def has_name(self, name: str) -> bool:
+        return name in self._base._parameters

--- a/unified_planning/model/timing.py
+++ b/unified_planning/model/timing.py
@@ -44,11 +44,17 @@ class TimepointKind(Enum):
 
 
 class Timepoint:
-    """Class used to define the point in the time from which a :class:`~unified_planning.model.Timing` is considered."""
+    """Temporal point of interest, one of:
+
+     - global start: temporal origin (time 0) at which the initial state is defined
+     - global end: plan horizon, at which the plan goals must hold.
+     - start time or end time of an action, activity or task/method.
+
+    Used to define the point in the time from which a :class:`~unified_planning.model.timing.Timing` is considered."""
 
     def __init__(self, kind: TimepointKind, container: Optional[str] = None):
         """
-        Creates a new `Timepoint`.
+        Creates a new :class:`Timepoint`.
 
         It is typically used to refer to:
          - the start/end of the containing action or method, or
@@ -96,7 +102,7 @@ class Timepoint:
 
     @property
     def kind(self) -> TimepointKind:
-        """Returns the `kind` of this `Timepoint`; the `kind` defines the semantic of the `Timepoint`."""
+        """Returns the `kind` of this :class:`Timepoint`; the `kind` defines the semantic of the `Timepoint`."""
         return self._kind
 
     @property
@@ -106,11 +112,12 @@ class Timepoint:
 
 
 class Timing:
-    """
-    Class that used a :class:`~unified_planning.model.Timepoint` to define from when this `Timing` is considered and a :func:`delay <unified_planning.model.Timing.delay>`,
+    """Time defined relatively to a :class:`Timepoint`.
+
+    Class that used a :class:`~unified_planning.model.timing.Timepoint` to define from when this `Timing` is considered and a :func:`delay <unified_planning.model.Timing.delay>`,
     representing the distance from the given `Timepoint`.
-    For example:
-    A `GLOBAL_START Timepoint` with a `delay` of `5` means `5` units of time after the start of the `Plan`.
+    For instance:
+    A `GLOBAL_START Timepoint` with a `delay` of `5` means `5` units of time after the initial state.
     """
 
     def __init__(self, delay: NumericConstant, timepoint: Timepoint):

--- a/unified_planning/test/examples/scheduling/jobshop.py
+++ b/unified_planning/test/examples/scheduling/jobshop.py
@@ -65,7 +65,7 @@ def parse(instance: str, instance_name: str) -> SchedulingProblem:
         f"sched:jobshop-{instance_name}-operators"
     )
     machine_objects = [
-        problem.add_resource(f"m{i}") for i in range(1, num_machines + 1)
+        problem.add_resource(f"m{i}", capacity=1) for i in range(1, num_machines + 1)
     ]
 
     # use the jobshop with operators extension: each activity requires an operator


### PR DESCRIPTION
This PR stabilizes the scheduling API, along with improvements to documentation for 1.0.

- chore(scheduling): Polish and document the scheduling API
- chore(scheduling): Fix tests that relied on the old API
- doc: Simplify scheduling problem example
