### PR TITLE
Fix Replanner error disabling

### DIFF
--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -672,7 +672,12 @@ class Factory:
                 ):
                     msg = f"The problem has no quality metrics but the engine is required to be optimal!"
                     raise up.exceptions.UPUsageError(msg)
-                res = EngineClass(problem=problem, **params)
+                res = EngineClass(
+                    problem=problem,
+                    error_on_failed_checks=error_failed_checks,
+                    **params,
+                )
+                assert isinstance(res, ReplannerMixin)
             elif operation_mode == OperationMode.SEQUENTIAL_SIMULATOR:
                 assert problem is not None
                 res = EngineClass(

--- a/unified_planning/engines/mixins/replanner.py
+++ b/unified_planning/engines/mixins/replanner.py
@@ -26,13 +26,13 @@ class ReplannerMixin(ABC):
     def __init__(
         self,
         problem: "up.model.AbstractProblem",
-        error_on_failed_checks: "bool",
+        error_on_failed_checks: bool,
     ):
         self._problem = problem.clone()
         self_class = type(self)
         assert issubclass(self_class, up.engines.engine.Engine)
         assert isinstance(self, up.engines.engine.Engine)
-        self.error_on_failed_checks = error_on_failed_checks
+        self._error_on_failed_checks: bool = error_on_failed_checks
         if not self.skip_checks and not self_class.supports(problem.kind):
             msg = f"We cannot establish whether {self.name} is able to handle this problem!"
             if self.error_on_failed_checks:

--- a/unified_planning/engines/mixins/replanner.py
+++ b/unified_planning/engines/mixins/replanner.py
@@ -24,7 +24,9 @@ class ReplannerMixin(ABC):
     """Base class that must be extended by an :class:`~unified_planning.engines.Engine` that is also a `Replanner`."""
 
     def __init__(
-        self, problem: "up.model.AbstractProblem", error_on_failed_checks: bool
+        self,
+        problem: "up.model.AbstractProblem",
+        error_on_failed_checks: "bool",
     ):
         self._problem = problem.clone()
         self_class = type(self)

--- a/unified_planning/engines/mixins/replanner.py
+++ b/unified_planning/engines/mixins/replanner.py
@@ -23,11 +23,14 @@ from warnings import warn
 class ReplannerMixin(ABC):
     """Base class that must be extended by an :class:`~unified_planning.engines.Engine` that is also a `Replanner`."""
 
-    def __init__(self, problem: "up.model.AbstractProblem"):
+    def __init__(
+        self, problem: "up.model.AbstractProblem", error_on_failed_checks: bool
+    ):
         self._problem = problem.clone()
         self_class = type(self)
         assert issubclass(self_class, up.engines.engine.Engine)
         assert isinstance(self, up.engines.engine.Engine)
+        self.error_on_failed_checks = error_on_failed_checks
         if not self.skip_checks and not self_class.supports(problem.kind):
             msg = f"We cannot establish whether {self.name} is able to handle this problem!"
             if self.error_on_failed_checks:

--- a/unified_planning/engines/mixins/sequential_simulator.py
+++ b/unified_planning/engines/mixins/sequential_simulator.py
@@ -45,7 +45,7 @@ class SequentialSimulatorMixin(ABC):
             self_class, up.engines.engine.Engine
         ), "SequentialSimulatorMixin does not implement the up.engines.Engine class"
         assert isinstance(self, up.engines.engine.Engine)
-        self.error_on_failed_checks = error_on_failed_checks
+        self._error_on_failed_checks: bool = error_on_failed_checks
         if not self.skip_checks and not self_class.supports(problem.kind):
             msg = f"We cannot establish whether {self.name} is able to handle this problem!"
             if self.error_on_failed_checks:

--- a/unified_planning/engines/mixins/sequential_simulator.py
+++ b/unified_planning/engines/mixins/sequential_simulator.py
@@ -30,7 +30,9 @@ class SequentialSimulatorMixin(ABC):
     Important NOTE: The `AbstractProblem` instance is given at the constructor.
     """
 
-    def __init__(self, problem: "up.model.AbstractProblem") -> None:
+    def __init__(
+        self, problem: "up.model.AbstractProblem", error_on_failed_checks: bool
+    ) -> None:
         """
         Takes an instance of a `problem` and eventually some parameters, that represent
         some specific settings of the `SequentialSimulatorMixin`.
@@ -43,6 +45,7 @@ class SequentialSimulatorMixin(ABC):
             self_class, up.engines.engine.Engine
         ), "SequentialSimulatorMixin does not implement the up.engines.Engine class"
         assert isinstance(self, up.engines.engine.Engine)
+        self.error_on_failed_checks = error_on_failed_checks
         if not self.skip_checks and not self_class.supports(problem.kind):
             msg = f"We cannot establish whether {self.name} is able to handle this problem!"
             if self.error_on_failed_checks:

--- a/unified_planning/engines/replanner.py
+++ b/unified_planning/engines/replanner.py
@@ -27,7 +27,7 @@ from typing import Type, IO, Callable, Optional, Union, List, Tuple
 from fractions import Fraction
 
 
-class Replanner(MetaEngine, mixins.ReplannerMixin):
+class Replanner(MetaEngine, mixins.ReplannerMixin):  # type: ignore[misc]
     """
     This :class:`~unified_planning.engines.MetaEngine` implements the :func:`~unified_planning.engines.Factory.Replanner>` operation mode starting
     a new oneshot planning query with the updated :class:`~unified_planning.model.AbstractProblem` instance.
@@ -36,12 +36,14 @@ class Replanner(MetaEngine, mixins.ReplannerMixin):
     def __init__(
         self,
         problem: "up.model.AbstractProblem",
-        error_on_failed_checks: bool,
+        error_on_failed_checks: "bool",
         *args,
         **kwargs,
     ):
         MetaEngine.__init__(self, *args, **kwargs)
-        mixins.ReplannerMixin.__init__(self, problem, error_on_failed_checks)
+        mixins.ReplannerMixin.__init__(
+            self, problem=problem, error_on_failed_checks=error_on_failed_checks
+        )
 
     @property
     def name(self) -> str:

--- a/unified_planning/engines/replanner.py
+++ b/unified_planning/engines/replanner.py
@@ -27,7 +27,7 @@ from typing import Type, IO, Callable, Optional, Union, List, Tuple
 from fractions import Fraction
 
 
-class Replanner(MetaEngine, mixins.ReplannerMixin):  # type: ignore[misc]
+class Replanner(MetaEngine, mixins.ReplannerMixin):
     """
     This :class:`~unified_planning.engines.MetaEngine` implements the :func:`~unified_planning.engines.Factory.Replanner>` operation mode starting
     a new oneshot planning query with the updated :class:`~unified_planning.model.AbstractProblem` instance.

--- a/unified_planning/engines/replanner.py
+++ b/unified_planning/engines/replanner.py
@@ -33,9 +33,15 @@ class Replanner(MetaEngine, mixins.ReplannerMixin):
     a new oneshot planning query with the updated :class:`~unified_planning.model.AbstractProblem` instance.
     """
 
-    def __init__(self, problem: "up.model.AbstractProblem", *args, **kwargs):
+    def __init__(
+        self,
+        problem: "up.model.AbstractProblem",
+        error_on_failed_checks: bool,
+        *args,
+        **kwargs,
+    ):
         MetaEngine.__init__(self, *args, **kwargs)
-        mixins.ReplannerMixin.__init__(self, problem)
+        mixins.ReplannerMixin.__init__(self, problem, error_on_failed_checks)
 
     @property
     def name(self) -> str:

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -82,7 +82,7 @@ class InapplicabilityReasons(Enum):
     VIOLATES_STATE_INVARIANTS = auto()
 
 
-class UPSequentialSimulator(Engine, SequentialSimulatorMixin):  # type: ignore[misc]
+class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
     """
     Sequential SequentialSimulatorMixin implementation.
 
@@ -94,7 +94,7 @@ class UPSequentialSimulator(Engine, SequentialSimulatorMixin):  # type: ignore[m
         self, problem: "up.model.Problem", error_on_failed_checks: bool = True, **kwargs
     ):
         Engine.__init__(self)
-        SequentialSimulatorMixin.__init__(self, problem, error_on_failed_checks)  # type: ignore
+        SequentialSimulatorMixin.__init__(self, problem, error_on_failed_checks)
         pk = problem.kind
         if not Grounder.supports(pk):
             msg = f"The Grounder used in the {type(self).__name__} does not support the given problem"

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -82,7 +82,7 @@ class InapplicabilityReasons(Enum):
     VIOLATES_STATE_INVARIANTS = auto()
 
 
-class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
+class UPSequentialSimulator(Engine, SequentialSimulatorMixin):  # type: ignore[misc]
     """
     Sequential SequentialSimulatorMixin implementation.
 
@@ -94,7 +94,7 @@ class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
         self, problem: "up.model.Problem", error_on_failed_checks: bool = True, **kwargs
     ):
         Engine.__init__(self)
-        SequentialSimulatorMixin.__init__(self, problem, error_on_failed_checks)
+        SequentialSimulatorMixin.__init__(self, problem, error_on_failed_checks)  # type: ignore
         pk = problem.kind
         if not Grounder.supports(pk):
             msg = f"The Grounder used in the {type(self).__name__} does not support the given problem"

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -94,8 +94,7 @@ class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
         self, problem: "up.model.Problem", error_on_failed_checks: bool = True, **kwargs
     ):
         Engine.__init__(self)
-        self.error_on_failed_checks = error_on_failed_checks
-        SequentialSimulatorMixin.__init__(self, problem)
+        SequentialSimulatorMixin.__init__(self, problem, error_on_failed_checks)
         pk = problem.kind
         if not Grounder.supports(pk):
             msg = f"The Grounder used in the {type(self).__name__} does not support the given problem"

--- a/unified_planning/model/htn/hierarchical_problem.py
+++ b/unified_planning/model/htn/hierarchical_problem.py
@@ -196,7 +196,7 @@ class HierarchicalProblem(up.model.problem.Problem):
         else:
             assert len(kwargs) == 0
         if self.has_name(task.name):
-            msg = f"Name of task {task.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_named is disabled."
+            msg = f"Name of task {task.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_name is disabled."
             if self._env.error_used_name or any(
                 task.name == t for t in self._abstract_tasks
             ):
@@ -221,7 +221,7 @@ class HierarchicalProblem(up.model.problem.Problem):
             method.achieved_task is not None
         ), f"No achieved task was specified for this method."
         if self.has_name(method.name):
-            msg = f"Name of method {method.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_named is disabled."
+            msg = f"Name of method {method.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_name is disabled."
             if self._env.error_used_name or any(
                 method.name == m for m in self._methods
             ):

--- a/unified_planning/model/mixins/actions_set.py
+++ b/unified_planning/model/mixins/actions_set.py
@@ -137,7 +137,7 @@ class ActionsSetMixin:
             action.environment == self._env
         ), "Action does not have the same environment of the problem"
         if self._has_name_method(action.name):
-            msg = f"Name {action.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_named is disabled."
+            msg = f"Name {action.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_name is disabled."
             if self._env.error_used_name or any(
                 action.name == a.name for a in self._actions
             ):

--- a/unified_planning/model/mixins/agents_set.py
+++ b/unified_planning/model/mixins/agents_set.py
@@ -43,7 +43,7 @@ class AgentsSetMixin:
         """This method adds an Agent"""
         if agent not in self._agents:
             if self._has_name_method(agent.name):
-                msg = f"The agent name {agent.name} is already used in the problem!  Different elements of a problem can have the same name if the environment flag error_used_named is disabled."
+                msg = f"The agent name {agent.name} is already used in the problem!  Different elements of a problem can have the same name if the environment flag error_used_name is disabled."
                 if self._env.error_used_name or any(
                     agent.name == a.name for a in self._agents
                 ):

--- a/unified_planning/model/mixins/fluents_set.py
+++ b/unified_planning/model/mixins/fluents_set.py
@@ -137,7 +137,7 @@ class FluentsSetMixin:
                 fluent_or_name, typename, None, environment=self.environment, **kwargs
             )
         if self._has_name_method(fluent.name):
-            msg = f"Name {fluent.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_named is disabled."
+            msg = f"Name {fluent.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_name is disabled."
             if self._env.error_used_name or any(
                 fluent.name == f.name for f in self._fluents
             ):

--- a/unified_planning/model/mixins/objects_set.py
+++ b/unified_planning/model/mixins/objects_set.py
@@ -72,7 +72,7 @@ class ObjectsSetMixin:
             assert typename is not None, "Missing type of the object"
             obj = up.model.object.Object(obj_or_name, typename, self._env)
         if self._has_name_method(obj.name):
-            msg = f"Name {obj.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_named is disabled."
+            msg = f"Name {obj.name} already defined! Different elements of a problem can have the same name if the environment flag error_used_name is disabled."
             if self._env.error_used_name or any(
                 obj.name == o.name for o in self._objects
             ):

--- a/unified_planning/model/mixins/user_types_set.py
+++ b/unified_planning/model/mixins/user_types_set.py
@@ -44,7 +44,7 @@ class UserTypesSetMixin:
         if type not in self._user_types:
             ut = cast(_UserType, type)
             if self._has_name_method(ut.name):
-                msg = f"The type name {ut.name} is already used in the problem! Different elements of a problem can have the same name if the environment flag error_used_named is disabled."
+                msg = f"The type name {ut.name} is already used in the problem! Different elements of a problem can have the same name if the environment flag error_used_name is disabled."
                 if self._env.error_used_name or any(
                     ut.name == cast(_UserType, t).name for t in self._user_types
                 ):

--- a/unified_planning/test/test_replanner.py
+++ b/unified_planning/test/test_replanner.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import pytest
 import unified_planning as up
 from unified_planning.shortcuts import *
 from unified_planning.model.problem_kind import classical_kind
 from unified_planning.engines.results import POSITIVE_OUTCOMES, NEGATIVE_OUTCOMES
 from unified_planning.test import TestCase, main
-from unified_planning.test import skipIfNoOneshotPlannerForProblemKind
+from unified_planning.test import (
+    skipIfNoOneshotPlannerForProblemKind,
+    skipIfEngineNotAvailable,
+)
 from unified_planning.test.examples import get_example_problems
 
 
@@ -61,3 +66,16 @@ class TestReplanner(TestCase):
             replanner.add_action(a)
             res = replanner.resolve()
             self.assertIn(res.status, POSITIVE_OUTCOMES)
+
+    @skipIfEngineNotAvailable("opt-pddl-planner")
+    def test_robot(self):
+        problem = self.problems["robot"].problem
+
+        warn_str = "We cannot establish whether ENHSP can solve this problem!"
+        with pytest.warns(UserWarning, match=warn_str) as warns:
+            with OneshotPlanner(name="opt-pddl-planner") as planner:
+                res = planner.solve(problem)
+
+        with pytest.warns(UserWarning, match=warn_str) as warns:
+            with Replanner(problem, name="replanner[opt-pddl-planner]") as replanner:
+                res = replanner.resolve()


### PR DESCRIPTION
This PR:
- Adds the possibility of disabling the checks in the replanner constructor 
- cleans the SequentialSimulator structure 
- fixes small error report when the name in a problem is duplicated