### PR TITLE
Small improvements in command-line and ActionInstance creation

### DIFF
--- a/unified_planning/cmd/up.py
+++ b/unified_planning/cmd/up.py
@@ -48,7 +48,7 @@ def main(args=None):
             show_supported_kind=parsed_args.show_kind,
         )
     else:
-        raise NotImplementedError
+        parser.print_help()
 
 
 def oneshot_planning(

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -685,7 +685,7 @@ class PDDLWriter:
                 pass
             else:
                 out.write(f" (= {converter.convert(f)} {converter.convert(v)})")
-        if self.problem.kind.has_actions_cost():
+        if self.problem.kind.has_actions_cost() or self.problem.kind.has_plan_length():
             out.write(f" (= (total-cost) 0)")
         out.write(")\n")
         goals_str: List[str] = []

--- a/unified_planning/plans/plan.py
+++ b/unified_planning/plans/plan.py
@@ -49,12 +49,16 @@ class ActionInstance:
         ), "Typing not respected"
         self._agent = agent
         self._action = action
-        self._params = tuple(auto_promote(params))
+        self._params: Tuple["up.model.FNode", ...] = tuple(auto_promote(params))
         assert len(action.parameters) == len(self._params)
         for param, assigned_value in zip(action.parameters, self._params):
             if not param.type.is_compatible(assigned_value.type):
                 raise UPTypeError(
                     f"Incompatible parameter type assignment. {assigned_value} can't be assigned to: {param}"
+                )
+            if not assigned_value.is_constant():
+                raise UPTypeError(
+                    f"An ActionInstance parameter must be a constant: {assigned_value} is not."
                 )
         assert motion_paths is None or isinstance(
             motion_paths, dict


### PR DESCRIPTION
This PR adds some small improvements:
- Fix(command-line): Now when using just the up command it's equal to up -h (instead of NotImplementedError)
- Added-check(ActionInstance): Added check where the actual parameters of an ActionInstance must be constants