### PR TITLE
fix(htn): Remove `ACTION_BASED` class from HTN planning problem kind.

### DIFF
--- a/unified_planning/model/htn/hierarchical_problem.py
+++ b/unified_planning/model/htn/hierarchical_problem.py
@@ -130,6 +130,7 @@ class HierarchicalProblem(up.model.problem.Problem):
         minimum time as possible."""
         factory = self._kind_factory()
         factory.kind.set_problem_class("HIERARCHICAL")
+        factory.kind.unset_problem_class("ACTION_BASED")
         (TO, PO, TEMPORAL) = (0, 1, 2)
 
         def lvl(tn: AbstractTaskNetwork):

--- a/unified_planning/test/examples/hierarchical.py
+++ b/unified_planning/test/examples/hierarchical.py
@@ -242,6 +242,7 @@ def get_example_problems():
 
 
 if __name__ == "__main__":
-    for name, problem in get_example_problems().items():
-        print(f"======= {name} ======")
-        print(str(problem))
+    for name, test_case in get_example_problems().items():
+        print(f"\n======= {name} ======\n")
+        print(test_case.problem.kind)
+        print(test_case.problem)


### PR DESCRIPTION
While it historically made sense to have it there, it prevented pure HTN planners from declaring
that they do not support non-hierarchical planning.

Note that this is purely backward compatible (surprisingly).
