### PR TITLE
Validator Tracing and TimeTriggeredValidator

### DIFF
--- a/unified_planning/engines/__init__.py
+++ b/unified_planning/engines/__init__.py
@@ -21,7 +21,10 @@ from unified_planning.engines.factory import Factory
 from unified_planning.engines.parallel import Parallel
 from unified_planning.engines.pddl_planner import PDDLPlanner
 from unified_planning.engines.pddl_anytime_planner import PDDLAnytimePlanner
-from unified_planning.engines.plan_validator import SequentialPlanValidator
+from unified_planning.engines.plan_validator import (
+    SequentialPlanValidator,
+    TimeTriggeredPlanValidator,
+)
 from unified_planning.engines.oversubscription_planner import OversubscriptionPlanner
 from unified_planning.engines.replanner import Replanner
 from unified_planning.engines.results import (

--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -143,6 +143,7 @@ DEFAULT_ENGINES_PREFERENCE_LIST = [
     "tamer",
     "sequential_plan_validator",
     "sequential_simulator",
+    "up_time_triggered_validator",
     "up_bounded_types_remover",
     "up_conditional_effects_remover",
     "up_disjunctive_conditions_remover",

--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -63,6 +63,10 @@ DEFAULT_ENGINES = {
         "unified_planning.engines.plan_validator",
         "SequentialPlanValidator",
     ),
+    "up_time_triggered_validator": (
+        "unified_planning.engines.plan_validator",
+        "TimeTriggeredPlanValidator",
+    ),
     "sequential_simulator": (
         "unified_planning.engines.sequential_simulator",
         "UPSequentialSimulator",

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -150,12 +150,10 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                 if unsat_conds:
                     assert reason == InapplicabilityReasons.VIOLATES_CONDITIONS
                     msg = f"Preconditions {unsat_conds} of {str(i)}-th action instance {str(ai)} are not satisfied."
+                else:
+                    next_state = simulator.apply_unsafe(trace[-1], ai)
             except UPUsageError as e:
                 msg = f"{str(i)}-th action instance {str(ai)} creates a UsageError: {str(e)}"
-            except UPInvalidActionError as e:
-                msg = f"{str(i)}-th action instance {str(ai)} creates an Invalid Action: {str(e)}"
-            try:
-                next_state = simulator.apply_unsafe(trace[-1], ai)
             except UPInvalidActionError as e:
                 msg = f"{str(i)}-th action instance {str(ai)} creates an Invalid Action: {str(e)}"
             except UPConflictingEffectsException as e:

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -14,12 +14,21 @@
 #
 
 
-from typing import List, Optional, cast
+from collections import OrderedDict
+from dataclasses import dataclass
+from fractions import Fraction
+import heapq
+from typing import Dict, List, Optional, Tuple, cast
 import warnings
 import unified_planning as up
 import unified_planning.environment
 import unified_planning.engines as engines
 import unified_planning.engines.mixins as mixins
+from unified_planning.model.action import InstantaneousAction
+from unified_planning.model.effect import Effect
+from unified_planning.model.fnode import FNode
+from unified_planning.model.state import UPState
+from unified_planning.model.timing import TimeInterval, TimepointKind, Timing
 import unified_planning.model.walkers as walkers
 from unified_planning.model import (
     AbstractProblem,
@@ -41,6 +50,7 @@ from unified_planning.engines.sequential_simulator import (
     evaluate_quality_metric,
     evaluate_quality_metric_in_initial_state,
 )
+from unified_planning.model.walkers.state_evaluator import StateEvaluator
 from unified_planning.plans import SequentialPlan, PlanKind
 from unified_planning.exceptions import (
     UPConflictingEffectsException,
@@ -48,6 +58,7 @@ from unified_planning.exceptions import (
     UPProblemDefinitionError,
     UPInvalidActionError,
 )
+from unified_planning.plans.plan import ActionInstance
 from unified_planning.plans.time_triggered_plan import TimeTriggeredPlan
 
 
@@ -234,6 +245,87 @@ class TimeTriggeredPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixi
     def supports(problem_kind):
         return problem_kind <= SequentialPlanValidator.supported_kind()
 
+    # TODO: support simulated effects, action parameters and quantifiers
+    def apply_effects(
+        self,
+        state: UPState,
+        se: StateEvaluator,
+        effects: List[Tuple[List[Effect], ActionInstance]],
+    ) -> UPState:
+        updates: Dict[FNode, FNode] = {}
+        for effs, ai in effects:
+            for eff in effs:
+                if self.check_condition(
+                    state, se, self.ground_expression(eff.condition, ai)
+                ):
+                    g_fluent = self.ground_expression(eff.fluent, ai)
+                    g_value = self.ground_expression(eff.value, ai)
+                    if g_fluent in updates:
+                        raise RuntimeError("Double effect")
+                    updates[g_fluent] = se.evaluate(g_value, state=state)
+        return state.make_child(updated_values=updates)
+
+    def states_in_interval(
+        self,
+        trace: Dict[Fraction, UPState],
+        start: Fraction,
+        end: Fraction,
+        open_interval: bool,
+    ) -> UPState:
+        print("*" * 80)
+        print(["%.2f" % float(x) for x in trace.keys()])
+        print(("%.2f" % start, "%.2f" % end, open_interval))
+        before_time = -1
+        equal_time = -1
+        inside_indexes = []
+        for x in trace:
+            if x < start and x > before_time:
+                before_time = x
+            if x <= start and x > equal_time:
+                equal_time = x
+            if start < x < end:
+                inside_indexes.append(x)
+
+        print(inside_indexes)
+        print(before_time)
+        print(equal_time)
+        print("*" * 80)
+
+        if not open_interval:
+            yield before_time, trace[before_time]
+        if equal_time != before_time and equal_time != end:
+            yield equal_time, trace[equal_time]
+        for x in inside_indexes:
+            yield x, trace[x]
+
+    def check_condition(
+        self, state: UPState, se: StateEvaluator, condition: FNode
+    ) -> bool:
+        return se.evaluate(condition, state=state).bool_constant_value()
+
+    def _instantiate_timing(
+        self, timing: Timing, action_start: Fraction, action_duration: Fraction
+    ) -> Fraction:
+        if timing.is_from_start():
+            return action_start + timing.delay
+        else:
+            return action_start + action_duration + timing.delay
+
+    def _instantiate_interval(
+        self, interval: TimeInterval, action_start: Fraction, action_duration: Fraction
+    ) -> Tuple[Fraction, Fraction, bool]:
+        return (
+            self._instantiate_timing(interval.lower, action_start, action_duration),
+            self._instantiate_timing(interval.upper, action_start, action_duration),
+            interval.is_left_open(),
+        )
+
+    def ground_expression(self, formula: FNode, ai: ActionInstance) -> FNode:
+        params = {}
+        for p, ap in zip(ai.action.parameters, ai.actual_parameters):
+            params[p] = ap
+        return formula.substitute(params)
+
     def _validate(
         self, problem: "AbstractProblem", plan: "unified_planning.plans.Plan"
     ) -> "up.engines.results.ValidationResult":
@@ -249,4 +341,83 @@ class TimeTriggeredPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixi
         """
         assert isinstance(plan, TimeTriggeredPlan)
         assert isinstance(problem, Problem)
-        raise NotImplementedError
+
+        se = StateEvaluator(problem=problem)
+
+        start_actions = list(plan.timed_actions)
+        start_actions.sort(key=lambda x: (x[0], x[2]), reverse=True)
+
+        scheduled_effects = []  # TODO: add TILs
+        durative_conditions = []  # TODO: add Timed Goals
+
+        time = 0
+        last_state = UPState(problem.initial_values)
+        trace = {-1: last_state}
+        effect_id = 0
+        while len(start_actions) + len(scheduled_effects) > 0:
+            if start_actions and (
+                len(scheduled_effects) == 0
+                or start_actions[-1][0] <= scheduled_effects[0][0]
+            ):
+                start_time, ai, duration = start_actions.pop()
+                for timing, event in ai.action.effects.items():
+                    real_timing = self._instantiate_timing(timing, start_time, duration)
+                    heapq.heappush(
+                        scheduled_effects, (real_timing, effect_id, event, ai)
+                    )
+                    effect_id += 1
+                for interval, conditions in ai.action.conditions.items():
+                    real_interval = self._instantiate_interval(
+                        interval, start_time, duration
+                    )
+                    for c in conditions:
+                        durative_conditions.append(
+                            (
+                                real_interval,
+                                effect_id,
+                                self.ground_expression(c, ai),
+                                ai,
+                            )
+                        )
+                        effect_id += 1
+                time = start_time
+
+            elif scheduled_effects:
+                time = scheduled_effects[0][0]
+                effects = []
+                while scheduled_effects and scheduled_effects[0][0] == time:
+                    _, _, add_effs, ai = heapq.heappop(scheduled_effects)
+                    effects.append((add_effs, ai))
+                print("%s -> %s" % (time, effects))
+                new_state = self.apply_effects(last_state, se, effects)
+                trace[time] = new_state
+                last_state = new_state
+
+        print("*" * 80)
+        print(trace)
+
+        print(problem)
+        print(plan)
+
+        # Check (durative) conditions
+        for (start, end, is_open), _, c, ai in durative_conditions:
+            for t, state in self.states_in_interval(trace, start, end, is_open):
+                print((t, state))
+                if not self.check_condition(state=state, se=se, condition=c):
+                    return ValidationResult(
+                        status=ValidationResultStatus.INVALID,
+                        engine_name=self.name,
+                        log_messages="",
+                        metric_evaluations=None,
+                        reason=FailedValidationReason.INAPPLICABLE_ACTION,
+                        inapplicable_action=ai,
+                        trace=trace,
+                    )
+
+        return ValidationResult(
+            ValidationResultStatus.VALID,
+            self.name,
+            "",
+            None,
+            trace=trace,
+        )

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -417,7 +417,7 @@ class TimeTriggeredPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixi
         start_actions: List[Tuple[Fraction, ActionInstance, Optional[Fraction]]] = list(
             plan.timed_actions
         )
-        start_actions.sort(key=lambda x: (x[0], x[2]), reverse=True)
+        start_actions.sort(key=lambda x: x[0], reverse=True)
 
         scheduled_effects: List[
             Tuple[
@@ -486,7 +486,7 @@ class TimeTriggeredPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixi
         time = Fraction(0)
         last_state = UPState(problem.initial_values)
         trace: Dict[Fraction, State] = {Fraction(-1): last_state}
-        scheduled_effects = sorted(scheduled_effects, key=lambda x: x[0])
+        scheduled_effects.sort(key=lambda x: x[0])
         while len(start_actions) + len(scheduled_effects) > 0:
             if start_actions and (
                 len(scheduled_effects) == 0

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -486,6 +486,7 @@ class TimeTriggeredPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixi
         time = Fraction(0)
         last_state = UPState(problem.initial_values)
         trace: Dict[Fraction, State] = {Fraction(-1): last_state}
+        scheduled_effects = sorted(scheduled_effects, key=lambda x: x[0])
         while len(start_actions) + len(scheduled_effects) > 0:
             if start_actions and (
                 len(scheduled_effects) == 0

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -14,7 +14,7 @@
 #
 
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 import warnings
 import unified_planning as up
 import unified_planning.environment
@@ -48,6 +48,7 @@ from unified_planning.exceptions import (
     UPProblemDefinitionError,
     UPInvalidActionError,
 )
+from unified_planning.plans.time_triggered_plan import TimeTriggeredPlan
 
 
 class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
@@ -66,8 +67,6 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                 options.get("environment", None)
             )
         )
-        self.manager = self._env.expression_manager
-        self._substituter = walkers.Substituter(self._env)
 
     @property
     def name(self):
@@ -79,52 +78,7 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
 
     @staticmethod
     def supported_kind() -> ProblemKind:
-        supported_kind = ProblemKind(version=LATEST_PROBLEM_KIND_VERSION)
-        supported_kind.set_problem_class("ACTION_BASED")
-        supported_kind.set_typing("FLAT_TYPING")
-        supported_kind.set_typing("HIERARCHICAL_TYPING")
-        supported_kind.set_parameters("BOOL_FLUENT_PARAMETERS")
-        supported_kind.set_parameters("BOUNDED_INT_FLUENT_PARAMETERS")
-        supported_kind.set_parameters("BOOL_ACTION_PARAMETERS")
-        supported_kind.set_parameters("BOUNDED_INT_ACTION_PARAMETERS")
-        supported_kind.set_parameters("UNBOUNDED_INT_ACTION_PARAMETERS")
-        supported_kind.set_parameters("REAL_ACTION_PARAMETERS")
-        supported_kind.set_numbers("BOUNDED_TYPES")
-        supported_kind.set_problem_type("SIMPLE_NUMERIC_PLANNING")
-        supported_kind.set_problem_type("GENERAL_NUMERIC_PLANNING")
-        supported_kind.set_conditions_kind("NEGATIVE_CONDITIONS")
-        supported_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
-        supported_kind.set_conditions_kind("EQUALITIES")
-        supported_kind.set_conditions_kind("EXISTENTIAL_CONDITIONS")
-        supported_kind.set_conditions_kind("UNIVERSAL_CONDITIONS")
-        supported_kind.set_effects_kind("CONDITIONAL_EFFECTS")
-        supported_kind.set_effects_kind("INCREASE_EFFECTS")
-        supported_kind.set_effects_kind("DECREASE_EFFECTS")
-        supported_kind.set_effects_kind("STATIC_FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
-        supported_kind.set_effects_kind("STATIC_FLUENTS_IN_NUMERIC_ASSIGNMENTS")
-        supported_kind.set_effects_kind("STATIC_FLUENTS_IN_OBJECT_ASSIGNMENTS")
-        supported_kind.set_effects_kind("FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
-        supported_kind.set_effects_kind("FLUENTS_IN_NUMERIC_ASSIGNMENTS")
-        supported_kind.set_effects_kind("FLUENTS_IN_OBJECT_ASSIGNMENTS")
-        supported_kind.set_effects_kind("FORALL_EFFECTS")
-        supported_kind.set_fluents_type("INT_FLUENTS")
-        supported_kind.set_fluents_type("REAL_FLUENTS")
-        supported_kind.set_fluents_type("OBJECT_FLUENTS")
-        supported_kind.set_constraints_kind("STATE_INVARIANTS")
-        supported_kind.set_quality_metrics("ACTIONS_COST")
-        supported_kind.set_simulated_entities("SIMULATED_EFFECTS")
-        supported_kind.set_actions_cost_kind("STATIC_FLUENTS_IN_ACTIONS_COST")
-        supported_kind.set_actions_cost_kind("FLUENTS_IN_ACTIONS_COST")
-        supported_kind.set_quality_metrics("PLAN_LENGTH")
-        supported_kind.set_quality_metrics("OVERSUBSCRIPTION")
-        supported_kind.set_quality_metrics("TEMPORAL_OVERSUBSCRIPTION")
-        supported_kind.set_quality_metrics("MAKESPAN")
-        supported_kind.set_quality_metrics("FINAL_VALUE")
-        supported_kind.set_oversubscription_kind("INT_NUMBERS_IN_OVERSUBSCRIPTION")
-        supported_kind.set_oversubscription_kind("REAL_NUMBERS_IN_OVERSUBSCRIPTION")
-        supported_kind.set_actions_cost_kind("INT_NUMBERS_IN_ACTIONS_COST")
-        supported_kind.set_actions_cost_kind("REAL_NUMBERS_IN_ACTIONS_COST")
-        return supported_kind
+        return UPSequentialSimulator.supported_kind()
 
     @staticmethod
     def supports(problem_kind):
@@ -168,16 +122,14 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                 raise up.exceptions.UPUsageError(msg)
             else:
                 warnings.warn(cast(str, msg))
-        prev_state: Optional[State] = simulator.get_initial_state()
-        next_state: Optional[State] = prev_state
         if metric is not None:
             metric_value = evaluate_quality_metric_in_initial_state(simulator, metric)
         msg = None
+        trace: List[State] = [simulator.get_initial_state()]
         for i, ai in zip(range(1, len(plan.actions) + 1), plan.actions):
-            assert prev_state is not None
             try:
                 unsat_conds, reason = simulator.get_unsatisfied_conditions(
-                    prev_state, ai
+                    trace[-1], ai
                 )
                 if unsat_conds:
                     assert reason == InapplicabilityReasons.VIOLATES_CONDITIONS
@@ -187,7 +139,7 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
             except UPInvalidActionError as e:
                 msg = f"{str(i)}-th action instance {str(ai)} creates an Invalid Action: {str(e)}"
             try:
-                next_state = simulator.apply_unsafe(prev_state, ai)
+                next_state = simulator.apply_unsafe(trace[-1], ai)
             except UPInvalidActionError as e:
                 msg = f"{str(i)}-th action instance {str(ai)} creates an Invalid Action: {str(e)}"
             except UPConflictingEffectsException as e:
@@ -195,12 +147,13 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
             if msg is not None:
                 logs = [LogMessage(LogLevel.INFO, msg)]
                 return ValidationResult(
-                    ValidationResultStatus.INVALID,
-                    self.name,
-                    logs,
-                    None,
-                    FailedValidationReason.INAPPLICABLE_ACTION,
-                    ai,
+                    status=ValidationResultStatus.INVALID,
+                    engine_name=self.name,
+                    log_messages=logs,
+                    metric_evaluations=None,
+                    reason=FailedValidationReason.INAPPLICABLE_ACTION,
+                    inapplicable_action=ai,
+                    trace=trace,
                 )
             assert next_state is not None
             if metric is not None:
@@ -208,21 +161,25 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                     simulator,
                     metric,
                     metric_value,
-                    prev_state,
+                    trace[-1],
                     ai.action,
                     ai.actual_parameters,
                     next_state,
                 )
-            prev_state = next_state
-        assert next_state is not None
-        unsatisfied_goals = simulator.get_unsatisfied_goals(next_state)
+            trace.append(next_state)
+
+        unsatisfied_goals = simulator.get_unsatisfied_goals(trace[-1])
         if not unsatisfied_goals:
             metric_evalutations = None
             if metric is not None:
                 metric_evalutations = {metric: metric_value}
             logs = []
             return ValidationResult(
-                ValidationResultStatus.VALID, self.name, logs, metric_evalutations
+                ValidationResultStatus.VALID,
+                self.name,
+                logs,
+                metric_evalutations,
+                trace=trace,
             )
         else:
             msg = f"Goals {unsatisfied_goals} are not satisfied by the plan."
@@ -233,4 +190,63 @@ class SequentialPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
                 logs,
                 None,
                 FailedValidationReason.UNSATISFIED_GOALS,
+                trace=trace,
             )
+
+
+class TimeTriggeredPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixin):
+    """
+    Performs :class:`~unified_planning.plans.Plan` validation.
+
+    If the given :class:`~unified_planning.model.Problem` has any quality metric,
+    the metric is simply ignored because it predicates over the Optimality of
+    the Plan, but not the Validity!
+    """
+
+    def __init__(self, **options):
+        engines.engine.Engine.__init__(self)
+        self._env: "unified_planning.environment.Environment" = (
+            unified_planning.environment.get_environment(
+                options.get("environment", None)
+            )
+        )
+
+    @property
+    def name(self):
+        return "time_triggered_plan_validator"
+
+    @staticmethod
+    def supports_plan(plan_kind: "up.plans.PlanKind") -> bool:
+        return plan_kind == PlanKind.TIME_TRIGGERED_PLAN
+
+    @staticmethod
+    def supported_kind() -> ProblemKind:
+        kind = UPSequentialSimulator.supported_kind().clone()
+        kind.set_time("CONTINUOUS_TIME")
+        kind.set_time("INTERMEDIATE_CONDITIONS_AND_EFFECTS")
+        kind.set_time("TIMED_EFFECTS")
+        kind.set_time("TIMED_GOALS")
+        kind.set_time("DURATION_INEQUALITIES")
+        kind.set_expression_duration("STATIC_FLUENTS_IN_DURATIONS")
+        return kind
+
+    @staticmethod
+    def supports(problem_kind):
+        return problem_kind <= SequentialPlanValidator.supported_kind()
+
+    def _validate(
+        self, problem: "AbstractProblem", plan: "unified_planning.plans.Plan"
+    ) -> "up.engines.results.ValidationResult":
+        """
+        Returns True if and only if the plan given in input is a valid plan for the problem given in input.
+        This means that from the initial state of the problem, by following the plan, you can reach the
+        problem goal. Otherwise False is returned.
+
+        :param problem: The problem for which the plan to validate was generated.
+        :param plan: The plan that must be validated.
+        :return: The generated up.engines.results.ValidationResult; a data structure containing the information
+            about the plan validity and eventually some additional log messages for the user.
+        """
+        assert isinstance(plan, TimeTriggeredPlan)
+        assert isinstance(problem, Problem)
+        raise NotImplementedError

--- a/unified_planning/engines/results.py
+++ b/unified_planning/engines/results.py
@@ -275,6 +275,10 @@ class ValidationResult(Result):
     reason: Optional[FailedValidationReason] = field(default=None)
     inapplicable_action: Optional[up.plans.ActionInstance] = field(default=None)
     metrics: Optional[Dict[str, str]] = field(default=None)
+    # The trace is either the sequences of states until the first validation error or a map from time to state for each event up to the first validation error
+    trace: Optional[
+        Union[List[up.model.State], Dict[Fraction, up.model.State]]
+    ] = field(default=None)
 
     def __post_init__(self):
         assert (

--- a/unified_planning/test/test_validator.py
+++ b/unified_planning/test/test_validator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unified_planning as up
+from unified_planning.plans.time_triggered_plan import TimeTriggeredPlan
 from unified_planning.shortcuts import *
 from unified_planning.engines import SequentialPlanValidator, FailedValidationReason
 from unified_planning.plans import SequentialPlan, ActionInstance
@@ -117,6 +118,26 @@ class TestPlanValidator(unittest_TestCase):
         res = up_validator.validate(problem, invalid_action_plan)
         self.assertEqual(res.reason, FailedValidationReason.INAPPLICABLE_ACTION)
         self.assertEqual(res.inapplicable_action, invalid_action)
+
+    def test_time_triggered(self):
+        example = self.problems["matchcellar"]
+        problem, plan = example.problem, example.valid_plans[0]
+
+        with PlanValidator(
+            name="up_time_triggered_validator",
+            problem_kind=problem.kind,
+            plan_kind=plan.kind,
+        ) as validator:
+            self.assertNotEqual(validator, None)
+
+            res = validator.validate(problem, plan)
+            self.assertEqual(res.status, up.engines.ValidationResultStatus.VALID)
+
+            p = list(plan.timed_actions)
+            p[1] = (0, p[1][1], p[1][2])
+            broken_plan = TimeTriggeredPlan(actions=p)
+            res = validator.validate(problem, broken_plan)
+            self.assertEqual(res.status, up.engines.ValidationResultStatus.INVALID)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this PR we extend the internal sequential validation engine to return the sequence of states encountered by executing a sequential plan and we add support for validation (and tracing) of TimeTriggeredPlans