### PR TITLE
Fix plan validation via command line interface.

### DIFF
--- a/unified_planning/cmd/up.py
+++ b/unified_planning/cmd/up.py
@@ -155,7 +155,7 @@ def plan_validation(
     args: argparse.Namespace,
 ):
     problem = parse_problem(parser, args)
-    engine_name, engine_names = args.engine_name, args.engine_names
+    engine_name, engine_names = args.engine_name, None
     plan_filename = args.plan_filename
     if plan_filename is None:
         parser.error("plan-validation mode requires the --plan option")


### PR DESCRIPTION
The `args.engine_names` attribute is not present in validation mode.