### PR TITLE
fix: proto explicit init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "fast-downward": ["up-fast-downward==0.4.1"],
         "lpg": ["up-lpg==0.0.10"],
         "fmap": ["up-fmap==0.0.13"],
-        "aries": ["up-aries>=0.3.2"],
+        "aries": ["up-aries>=0.3.3"],
         "symk": ["up-symk>=1.0.1"],
         "engines": [
             "tarski[arithmetic]",

--- a/unified_planning/grpc/proto_writer.py
+++ b/unified_planning/grpc/proto_writer.py
@@ -603,7 +603,7 @@ class ProtobufWriter(Converter):
             actions=[self.convert(a) for a in problem.actions],
             initial_state=[
                 proto.Assignment(fluent=self.convert(x), value=self.convert(v))
-                for (x, v) in problem.initial_values.items()
+                for (x, v) in problem.explicit_initial_values.items()
             ],
             timed_effects=timed_effects,
             goals=goals,

--- a/unified_planning/grpc/unified_planning.proto
+++ b/unified_planning/grpc/unified_planning.proto
@@ -116,7 +116,6 @@ message Fluent {
     // If non-empty, then any state variable using this fluent that is not explicitly given a value in the initial state
     // will be assumed to have this default value.
     // This allows mimicking the closed world assumption by setting a "false" default value to predicates.
-    // Note that in the initial state of the problem message, it is assumed that all default values are set.
     Expression default_value = 4;
 }
 
@@ -539,7 +538,8 @@ message Problem {
     // features: ACTION_BASED
     repeated Action actions = 6;
 
-    // Initial state, including default values of state variables.
+    // Explicit assignments to state variables in the initial state.
+    // State variables not assigned there and will take the default value of their fluent, if any.
     repeated Assignment initial_state = 7;
 
     // Facts and effects that are expected to occur strictly later than the initial state.

--- a/unified_planning/test/examples/minimals.py
+++ b/unified_planning/test/examples/minimals.py
@@ -363,6 +363,31 @@ def get_example_problems():
     )
     problems["basic_with_costs"] = basic_with_costs
 
+    # basic with defaults
+    problem = Problem("basic_with_default_values")
+    object = UserType("object")
+    objects = [problem.add_object(f"o{i}", object) for i in range(0, 5)]
+    available = Fluent("available", BoolType(), a=object)
+
+    on = Fluent("on", object, a=object)
+    problem.add_fluent(available, default_initial_value=True)
+    problem.add_fluent(on, default_initial_value=objects[0])
+    goal = problem.add_fluent("g", default_initial_value=False)
+    for i in [0, 1, 3, 4]:  # override default for all but objects[2]
+        problem.set_initial_value(on(objects[i]), objects[4])
+    act_a = InstantaneousAction("a", obj=object)
+    act_a.add_precondition(available(objects[0]))
+    act_a.add_precondition(Equals(on(act_a.obj), objects[0]))
+    act_a.add_effect(goal, True)
+    problem.add_action(act_a)
+    problem.add_goal(goal)
+
+    problems["basic_with_default_values"] = TestCase(
+        problem=problem,
+        solvable=True,
+        valid_plans=[up.plans.SequentialPlan([act_a(objects[2])])],
+    )
+
     # counter
     counter_1 = Fluent("counter_1", IntType(0, 10))
     counter_2 = Fluent("counter_2", IntType(0, 10))


### PR DESCRIPTION
Until now, all initial values (including implicit ones) written in the initial state when converting to protobuf. 
This is problematic as it means the problem reconstructed after export and importing to protobuf was not strictly equivalent: some implicit values were made explicit in process.

A bad consequence is that it made protobuf conversions much more expensive that it had too (even after the optimization of #559, 90% of the time spend remains in the initial state generation in at least some non trivial problems).

This PR only save to protobuf the explicitly set initial values. The defaults values of the fluent were already there.