### PR TITLE
Very minor fix in tests

### DIFF
--- a/unified_planning/model/problem_kind.py
+++ b/unified_planning/model/problem_kind.py
@@ -376,6 +376,9 @@ temporal_kind.set_time("TIMED_GOALS")
 temporal_kind.set_time("DURATION_INEQUALITIES")
 temporal_kind.set_expression_duration("STATIC_FLUENTS_IN_DURATIONS")
 
+int_duration_kind = ProblemKind(version=LATEST_PROBLEM_KIND_VERSION)
+int_duration_kind.set_expression_duration("INT_TYPE_DURATIONS")
+
 quality_metrics_kind = ProblemKind(version=LATEST_PROBLEM_KIND_VERSION)
 quality_metrics_kind.set_quality_metrics("PLAN_LENGTH")
 quality_metrics_kind.set_quality_metrics("ACTIONS_COST")

--- a/unified_planning/test/test_ttp_to_stn.py
+++ b/unified_planning/test/test_ttp_to_stn.py
@@ -1,9 +1,17 @@
 from itertools import chain
 from unified_planning.shortcuts import *
+from unified_planning.model.problem_kind import (
+    temporal_kind,
+    classical_kind,
+    int_duration_kind,
+)
 from unified_planning.plans import TimeTriggeredPlan
 from unified_planning.test.examples import get_example_problems
 from unified_planning.test import unittest_TestCase
-from unified_planning.test import skipIfNoPlanValidatorForProblemKind
+from unified_planning.test import (
+    skipIfNoPlanValidatorForProblemKind,
+    skipIfNoOneshotPlannerForProblemKind,
+)
 
 
 up.shortcuts.get_environment().credits_stream = None
@@ -53,6 +61,9 @@ class TestTTPToSTN(unittest_TestCase):
         unittest_TestCase.setUp(self)
         self.problems = get_example_problems()
 
+    @skipIfNoOneshotPlannerForProblemKind(
+        classical_kind.union(temporal_kind).union(int_duration_kind)
+    )
     def test_matchcellar_to_stn(self):
         problem = self.problems["matchcellar"].problem
         with OneshotPlanner(problem_kind=problem.kind) as planner:


### PR DESCRIPTION
Fix(test): A test should have been skipped if there are no engines able to solve matchcellar, but it was not skipped