### PR TITLE
Fix PDDLWriter._write_plan renamings 

### DIFF
--- a/unified_planning/io/pddl_reader.py
+++ b/unified_planning/io/pddl_reader.py
@@ -1684,15 +1684,7 @@ class PDDLReader:
         get_item_named: typing.Optional[
             Callable[
                 [str],
-                Union[
-                    "up.model.Type",
-                    "up.model.Action",
-                    "up.model.Fluent",
-                    "up.model.Object",
-                    "up.model.Parameter",
-                    "up.model.Variable",
-                    "up.model.multi_agent.Agent",
-                ],
+                "up.io.pddl_writer.WithName",
             ]
         ] = None,
     ) -> "up.plans.Plan":

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -794,8 +794,8 @@ class PDDLWriter:
         def _format_action_instance(action_instance: ActionInstance) -> str:
             param_str = ""
             if action_instance.actual_parameters:
-                param_str = f" {' '.join((p.object().name for p in action_instance.actual_parameters))}"
-            return f"({action_instance.action.name}{param_str})"
+                param_str = f" {' '.join((self._get_mangled_name(p.object()) for p in action_instance.actual_parameters))}"
+            return f"({self._get_mangled_name(action_instance.action)}{param_str})"
 
         if isinstance(plan, SequentialPlan):
             for ai in plan.actions:
@@ -914,14 +914,7 @@ class PDDLWriter:
 
     def get_pddl_name(
         self,
-        item: Union[
-            "up.model.Type",
-            "up.model.Action",
-            "up.model.Fluent",
-            "up.model.Object",
-            "up.model.Parameter",
-            "up.model.Variable",
-        ],
+        item: WithName,
     ) -> str:
         """
         This method takes an item in the :class:`~unified_planning.model.Problem` and returns the chosen name for the same item in the `PDDL` problem

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -344,7 +344,7 @@ class TestPddlIO(unittest_TestCase):
             pddl_domain,
         )
 
-    def test_arenamings(self):
+    def test_renamings(self):
         problem = self.problems["hierarchical_blocks_world"].problem
         problem = problem.clone()
         move = problem.action("move")

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -26,8 +26,9 @@ from unified_planning.test import (
 from unified_planning.io import PDDLWriter, PDDLReader
 from unified_planning.test.examples import get_example_problems
 from unified_planning.exceptions import UPProblemDefinitionError
-from unified_planning.model.problem_kind import simple_numeric_kind
 from unified_planning.model.metrics import MinimizeSequentialPlanLength
+from unified_planning.plans import SequentialPlan
+from unified_planning.model.problem_kind import simple_numeric_kind
 from unified_planning.model.types import _UserType
 
 
@@ -342,6 +343,27 @@ class TestPddlIO(unittest_TestCase):
             ":effect (and (at start (not (handfree))) (at end (fuse_mended ?f)) (at end (handfree))))",
             pddl_domain,
         )
+
+    def test_arenamings(self):
+        problem = self.problems["hierarchical_blocks_world"].problem
+        problem = problem.clone()
+        move = problem.action("move")
+        move.name = "move-move"
+
+        Block = problem.user_type("Block")
+        block_4 = Object("block-4", Block)
+        problem.add_object(block_4)
+
+        w = PDDLWriter(problem)
+        plan = SequentialPlan(
+            [move(block_4, problem.object("block_3"), problem.object("block_2"))]
+        )
+        plan_str = w.get_plan(plan)
+
+        r = PDDLReader()
+        test_plan = r.parse_plan_string(problem, plan_str, w.get_item_named)
+
+        self.assertEqual(plan, test_plan)
 
     def test_depot_reader(self):
         reader = PDDLReader()


### PR DESCRIPTION
This PR fixes a bug where the writing of the plan did not consider the renamings.