### PR TITLE
Updates for pddl_writer in order to adapt to val syntax

### DIFF
--- a/unified_planning/engines/results.py
+++ b/unified_planning/engines/results.py
@@ -53,6 +53,7 @@ class FailedValidationReason(Enum):
 
     INAPPLICABLE_ACTION = auto()
     UNSATISFIED_GOALS = auto()
+    MUTEX_CONFLICT = auto()
 
 
 class PlanGenerationResultStatus(Enum):

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -337,7 +337,7 @@ class PDDLWriter:
     needs_requirements determines if the printed problem must have the :requirements,
     rewrite_bool_assignments determines if this writer will write
     non constant boolean assignment as conditional effects.
-    empty_prec determines if this writer will write ':precondition ()' in case of an instantenuous 
+    empty_preco determines if this writer will write ':precondition ()' in case of an instantenuous
     action without preconditions instead of writing nothing or similar with conditions in durative actions.
     """
 
@@ -347,13 +347,13 @@ class PDDLWriter:
         needs_requirements: bool = True,
         rewrite_bool_assignments: bool = False,
         *,
-        empty_prec: bool = False,
+        empty_preco: bool = False,
     ):
         self.problem = problem
         self.problem_kind = self.problem.kind
         self.needs_requirements = needs_requirements
         self.rewrite_bool_assignments = rewrite_bool_assignments
-        self.empty_prec = empty_prec
+        self.empty_preco = empty_preco
         # otn represents the old to new renamings
         self.otn_renamings: Dict[
             WithName,
@@ -581,10 +581,8 @@ class PDDLWriter:
                             else:
                                 precond_str.append(converter.convert(p))
                     out.write(f'\n  :precondition (and {" ".join(precond_str)})')
-                elif len(m.preconditions) == 0 and self.empty_prec: 
-                    out.write(
-                        f"\n  :precondition ()"
-                    )
+                elif len(m.preconditions) == 0 and self.empty_preco:
+                    out.write(f"\n  :precondition ()")
                 self._write_task_network(m, out, converter)
                 out.write(")\n")
 
@@ -611,10 +609,8 @@ class PDDLWriter:
                             else:
                                 precond_str.append(converter.convert(p))
                     out.write(f'\n  :precondition (and {" ".join(precond_str)})')
-                elif len(a.preconditions) == 0 and self.empty_prec: 
-                    out.write(
-                        f"\n  :precondition ()"
-                    )
+                elif len(a.preconditions) == 0 and self.empty_preco:
+                    out.write(f"\n  :precondition ()")
                 if len(a.effects) > 0:
                     out.write("\n  :effect (and")
                     for e in a.effects:
@@ -680,10 +676,8 @@ class PDDLWriter:
                                 if not interval.is_right_open():
                                     out.write(f"(at end {converter.convert(c)})")
                     out.write(")")
-                elif len(a.conditions) == 0 and self.empty_prec: 
-                    out.write(
-                        f"\n  :condition (and )"
-                    )
+                elif len(a.conditions) == 0 and self.empty_preco:
+                    out.write(f"\n  :condition (and )")
                 if len(a.effects) > 0:
                     out.write("\n  :effect (and")
                     for t, el in a.effects.items():

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -337,7 +337,7 @@ class PDDLWriter:
     needs_requirements determines if the printed problem must have the :requirements,
     rewrite_bool_assignments determines if this writer will write
     non constant boolean assignment as conditional effects.
-    empty_preco determines if this writer will write ':precondition ()' in case of an instantenuous
+    empty_preconditions determines if this writer will write ':precondition ()' in case of an instantenuous
     action without preconditions instead of writing nothing or similar with conditions in durative actions.
     """
 
@@ -346,14 +346,13 @@ class PDDLWriter:
         problem: "up.model.Problem",
         needs_requirements: bool = True,
         rewrite_bool_assignments: bool = False,
-        *,
-        empty_preco: bool = False,
+        empty_preconditions: bool = False,
     ):
         self.problem = problem
         self.problem_kind = self.problem.kind
         self.needs_requirements = needs_requirements
         self.rewrite_bool_assignments = rewrite_bool_assignments
-        self.empty_preco = empty_preco
+        self.empty_preconditions = empty_preconditions
         # otn represents the old to new renamings
         self.otn_renamings: Dict[
             WithName,
@@ -581,7 +580,7 @@ class PDDLWriter:
                             else:
                                 precond_str.append(converter.convert(p))
                     out.write(f'\n  :precondition (and {" ".join(precond_str)})')
-                elif len(m.preconditions) == 0 and self.empty_preco:
+                elif len(m.preconditions) == 0 and self.empty_preconditions:
                     out.write(f"\n  :precondition ()")
                 self._write_task_network(m, out, converter)
                 out.write(")\n")
@@ -609,7 +608,7 @@ class PDDLWriter:
                             else:
                                 precond_str.append(converter.convert(p))
                     out.write(f'\n  :precondition (and {" ".join(precond_str)})')
-                elif len(a.preconditions) == 0 and self.empty_preco:
+                elif len(a.preconditions) == 0 and self.empty_preconditions:
                     out.write(f"\n  :precondition ()")
                 if len(a.effects) > 0:
                     out.write("\n  :effect (and")
@@ -676,7 +675,7 @@ class PDDLWriter:
                                 if not interval.is_right_open():
                                     out.write(f"(at end {converter.convert(c)})")
                     out.write(")")
-                elif len(a.conditions) == 0 and self.empty_preco:
+                elif len(a.conditions) == 0 and self.empty_preconditions:
                     out.write(f"\n  :condition (and )")
                 if len(a.effects) > 0:
                     out.write("\n  :effect (and")

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -333,10 +333,12 @@ class ConverterToPDDLString(walkers.DagWalker):
 class PDDLWriter:
     """
     This class can be used to write a :class:`~unified_planning.model.Problem` in `PDDL`.
-    The constructor of this class takes the problem to write and 2 flags:
+    The constructor of this class takes the problem to write and 3 flags:
     needs_requirements determines if the printed problem must have the :requirements,
     rewrite_bool_assignments determines if this writer will write
     non constant boolean assignment as conditional effects.
+    empty_prec determines if this writer will write ':precondition ()' in case of an instantenuous 
+    action without preconditions instead of writing nothing or similar with conditions in durative actions.
     """
 
     def __init__(
@@ -344,11 +346,14 @@ class PDDLWriter:
         problem: "up.model.Problem",
         needs_requirements: bool = True,
         rewrite_bool_assignments: bool = False,
+        *,
+        empty_prec: bool = False,
     ):
         self.problem = problem
         self.problem_kind = self.problem.kind
         self.needs_requirements = needs_requirements
         self.rewrite_bool_assignments = rewrite_bool_assignments
+        self.empty_prec = empty_prec
         # otn represents the old to new renamings
         self.otn_renamings: Dict[
             WithName,
@@ -576,6 +581,10 @@ class PDDLWriter:
                             else:
                                 precond_str.append(converter.convert(p))
                     out.write(f'\n  :precondition (and {" ".join(precond_str)})')
+                elif len(m.preconditions) == 0 and self.empty_prec: 
+                    out.write(
+                        f"\n  :precondition ()"
+                    )
                 self._write_task_network(m, out, converter)
                 out.write(")\n")
 
@@ -602,6 +611,10 @@ class PDDLWriter:
                             else:
                                 precond_str.append(converter.convert(p))
                     out.write(f'\n  :precondition (and {" ".join(precond_str)})')
+                elif len(a.preconditions) == 0 and self.empty_prec: 
+                    out.write(
+                        f"\n  :precondition ()"
+                    )
                 if len(a.effects) > 0:
                     out.write("\n  :effect (and")
                     for e in a.effects:
@@ -667,6 +680,10 @@ class PDDLWriter:
                                 if not interval.is_right_open():
                                     out.write(f"(at end {converter.convert(c)})")
                     out.write(")")
+                elif len(a.conditions) == 0 and self.empty_prec: 
+                    out.write(
+                        f"\n  :condition (and )"
+                    )
                 if len(a.effects) > 0:
                     out.write("\n  :effect (and")
                     for t, el in a.effects.items():


### PR DESCRIPTION
Added flag for PDDLWriter class and ´:precondition ()´ for actions with no conditions. Similarly for durative actions.
Moreover, we add a new FailedValidationReason due to mutex conflict according to VAL syntax. 