### PR TITLE
deps: require numpy version 1.X.Y

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ jupyter
 tarski
 networkx
 pyparsing
+numpy<2  # work around to avoid incompatibilities in transitive dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyparsing
 networkx
 ConfigSpace
+numpy<2 # required as transitive dependencies seems to install version 2 by default that is incompatible with other dependecies


### PR DESCRIPTION
The recent release of numpy 2.0 seem to break some of our dependencies.
If you were to re-run the CI on master before this commit, it would fail due to incompatible depenndencies.

This introduces a work around to ensure that we remain on a 1.X.Y version of numpy. I expect this to be removable once the ecosystem fixes their required dependencies.﻿
