### PR TITLE
Update pddl_planner.py - added errors='ignore' in byte string decode …

### DIFF
--- a/unified_planning/engines/pddl_planner.py
+++ b/unified_planning/engines/pddl_planner.py
@@ -183,7 +183,7 @@ class PDDLPlanner(engines.engine.Engine, mixins.OneshotPlannerMixin):
                 proc_err: List[str] = []
                 try:
                     out_err_bytes = process.communicate(timeout=timeout)
-                    proc_out, proc_err = [[x.decode()] for x in out_err_bytes]
+                    proc_out, proc_err = [[x.decode(errors='ignore')] for x in out_err_bytes]
                 except subprocess.TimeoutExpired:
                     timeout_occurred = True
                 retval = process.returncode


### PR DESCRIPTION
…in solve_

I tried to run some solver and the only problem was the exception that was thrown because of encoding failure of out_err_bytes, that anyway goes to logs and not critical to lack some non-unicode characters