### PR TITLE
Fix minor bug in ANMLWriter

### DIFF
--- a/unified_planning/io/anml_writer.py
+++ b/unified_planning/io/anml_writer.py
@@ -445,7 +445,7 @@ class ANMLWriter:
 
     def _convert_anml_interval(self, interval: "up.model.TimeInterval") -> str:
         left_bracket = "(" if interval.is_left_open() else "["
-        right_bracket = ")" if interval.is_left_open() else "]"
+        right_bracket = ")" if interval.is_right_open() else "]"
         if interval.lower == interval.upper:
             return f"{left_bracket} {self._convert_anml_timing(interval.lower)} {right_bracket}"
         else:


### PR DESCRIPTION
Fixed a small bug in `unified_planning/io/anml_writer.py`.

When outputting to an ANML file for `RightOpenTimeInterval`, the left bracket was correctly output as `[`, but the right bracket was incorrectly output as `]` instead of `)`.

The issue was caused by the following code:

```py
right_bracket = ")" if interval.is_left_open() else "]"
```

This condition was incorrectly checking for the left-open interval, but it should have checked for the right-open interval. I corrected it as follows:

```py
right_bracket = ")" if interval.is_right_open() else "]"
```

As a result of this fix, the following minimal example:

```py
from unified_planning.io import ANMLWriter
from unified_planning.shortcuts import (
    BoolType,
    ClosedTimeInterval,
    DurativeAction,
    EndTiming,
    LeftOpenTimeInterval,
    OpenTimeInterval,
    Problem,
    RightOpenTimeInterval,
    StartTiming,
)

problem = Problem()

flag = problem.add_fluent("flag", BoolType(), default_initial_value=False)

## Durative action: test_action
test_action = DurativeAction("test_action")
test_action.set_fixed_duration(1)
test_action.add_condition(ClosedTimeInterval(StartTiming(), EndTiming()), flag)
test_action.add_condition(LeftOpenTimeInterval(StartTiming(), EndTiming()), flag)
test_action.add_condition(RightOpenTimeInterval(StartTiming(), EndTiming()), flag)
test_action.add_condition(OpenTimeInterval(StartTiming(), EndTiming()), flag)
test_action.add_effect(EndTiming(), flag, True)
problem.add_action(test_action)

anml_writer = ANMLWriter(problem)
anml_writer.write_problem("problem.anml")
```

Previously resulted in:

```
fluent boolean flag;
action test_action() {
   duration >= 1 and duration <= 1;
   [ start, end ] flag;
   ( start, end ) flag;
   [ start, end ] flag;
   ( start, end ) flag;
   [ end ] flag := true;
};
[ start ] flag := false;
```

After the fix, the output is now correct:

```
fluent boolean flag;
action test_action() {
   duration >= 1 and duration <= 1;
   [ start, end ] flag;
   ( start, end ] flag;
   [ start, end ) flag;
   ( start, end ) flag;
   [ end ] flag := true;
};
[ start ] flag := false;
```

