### PR TITLE
Ubuntu 20 to 22 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,8 +89,8 @@ jobs:
         run: make html
         working-directory: ./docs
 
-  run-tests-ubuntu-20-04:
-    runs-on: ubuntu-20.04
+  run-tests-ubuntu-22-04:
+    runs-on: ubuntu-22.04
     needs: [
         basic-check,
         check-protobuf,


### PR DESCRIPTION
Update test on ubuntu 20.04 to 22.04 due to 20.04 being not supported anymore