### PR TITLE
Format PDDL timed effects on single lines

### DIFF
--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -801,8 +801,8 @@ class PDDLWriter:
             out.write(" (= (total-cost) 0)")
         for tm, le in self.problem.timed_effects.items():
             for e in le:
-                out.write(f" (at {str(converter.convert_fraction(tm.delay))}")
                 out.write(f"\n             ")
+                out.write(f" (at {str(converter.convert_fraction(tm.delay))}")
                 _write_effect(
                     e,
                     None,
@@ -811,7 +811,7 @@ class PDDLWriter:
                     self.rewrite_bool_assignments,
                     self._get_mangled_name,
                 )
-                out.write(f"\n          )")
+                out.write(f")")
         out.write(f"\n )\n")
         goals_str: List[str] = []
         for g in (c.simplify() for c in self.problem.goals):

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -151,6 +151,39 @@ class TestPddlIO(unittest_TestCase):
         self.assertIn("(:init (y o1))", pddl_problem)
         self.assertIn("(:goal (and (x)))", pddl_problem)
 
+    def test_basic_tils_writer(self):
+        problem = self.problems["basic_tils"].problem
+
+        w = PDDLWriter(problem)
+
+        pddl_domain = self._normalized_pddl_str(w.get_domain())
+        self.assertIn(
+            "(:requirements :strips :durative-actions :timed-initial-literals)",
+            pddl_domain,
+        )
+        self.assertIn("(:predicates (x) (y))", pddl_domain)
+        self.assertIn("(:durative-action a", pddl_domain)
+        self.assertIn(":parameters ()", pddl_domain)
+        self.assertIn(":duration (= ?duration 1)", pddl_domain)
+        self.assertIn(
+            ":condition (and (at start (y))(over all (y))(at end (y)))",
+            pddl_domain,
+        )
+        self.assertIn(":effect (and (at end (x)))", pddl_domain)
+
+        norm_pddl_problem = self._normalized_pddl_str(w.get_problem())
+        self.assertIn("(:domain basic_tils-domain)", norm_pddl_problem)
+        self.assertIn(
+            "(:init (at 5.0 (not (x))) (at 2.0 (y)) (at 8.0 (not (y))))",
+            norm_pddl_problem,
+        )
+        self.assertIn("(:goal (and (x)))", norm_pddl_problem)
+
+        pddl_problem = w.get_problem()
+        self.assertIn("(at 5.0 (not (x)))", pddl_problem)
+        self.assertIn("(at 2.0 (y))", pddl_problem)
+        self.assertIn("(at 8.0 (not (y)))", pddl_problem)
+
     def test_robot_writer(self):
         problem = self.problems["robot"].problem
 


### PR DESCRIPTION
## Summary

Fix PDDL timed effects formatting to write TILs (Timed Initial Literals) on single lines for better readability and planner compatibility.

## Problem

The previous implementation wrote timed effects across multiple lines, which:
- Made the PDDL output harder to read for humans
- Caused parsing issues with some planners like LPG that expect single-line format

## Solution

Updated the timed effects formatting in `pddl_writer.py` to write each timed effect on a single line while maintaining proper syntax.

**Before:**
```pddl
(at 5.0
    (not (x))
)
```

**After:**
```pddl
(at 5.0 (not (x)))
```

## Tests

- Added test over problem `basic_tils` in `test_pddl_io.py`
- Verified that timed effects are properly formatted on single lines