### PR TITLE
Implememt SparseState, a more efficient version of UPState

### DIFF
--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -38,7 +38,9 @@ from unified_planning.model import (
     Fluent,
     FNode,
     ExpressionManager,
+    State,
     UPState,
+    SparseState,
     Problem,
     MinimizeActionCosts,
     MinimizeExpressionOnFinalState,
@@ -180,7 +182,7 @@ class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
         """
         assert isinstance(self._problem, Problem), "supported_kind not respected"
         if self._initial_state is None:
-            self._initial_state = UPState(self._problem.initial_values)
+            self._initial_state = SparseState(self._problem.explicit_initial_values,self._problem)
             for si in self._state_invariants:
                 if not self._se.evaluate(si, self._initial_state).bool_constant_value():
                     raise UPProblemDefinitionError(
@@ -268,9 +270,9 @@ class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
         action, params = self._get_action_and_parameters(
             action_or_action_instance, parameters
         )
-        if not isinstance(state, up.model.UPState):
+        if not isinstance(state, up.model.State):
             raise UPUsageError(
-                f"The UPSequentialSimulator uses the UPState but {type(state).__name__} is given."
+                f"The UPSequentialSimulator expects a State but {type(state).__name__} is given."
             )
         grounded_action = self._ground_action(action, params)
         if grounded_action is None:
@@ -555,9 +557,9 @@ class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
                                         "Conflicting effects should be caught above"
                                     )
 
-            if not isinstance(state, up.model.UPState):
+            if not isinstance(state, up.model.State):
                 raise UPUsageError(
-                    f"The UPSequentialSimulator uses the UPState but {type(state).__name__} is given."
+                    f"The UPSequentialSimulator expects a State but {type(state).__name__} is given."
                 )
             new_partial_state = state.make_child(updated_values)
             for si in self._state_invariants:

--- a/unified_planning/model/__init__.py
+++ b/unified_planning/model/__init__.py
@@ -48,7 +48,7 @@ from unified_planning.model.problem import Problem, generate_causal_graph
 from unified_planning.model.contingent_problem import ContingentProblem
 from unified_planning.model.delta_stn import DeltaSimpleTemporalNetwork
 from unified_planning.model.problem_kind import ProblemKind
-from unified_planning.model.state import State, UPState
+from unified_planning.model.state import State, UPState, SparseState
 from unified_planning.model.timing import (
     Timepoint,
     TimepointKind,
@@ -114,6 +114,7 @@ __all__ = [
     "ProblemKind",
     "State",
     "UPState",
+    "SparseState",
     "Timepoint",
     "TimepointKind",
     "Timing",


### PR DESCRIPTION
Fixes aiplan4eu/unified-planning#689 where additional details are already explained.

In a nutshell, `SparseState` does not need every ground fact to be explicitly represented, which is important especially with fluents with large arities (thus large groundings) from which only very few instances are true in every reachable state.

On the IPC benchmark `nomystery/p07.pddl` (Problem name: `transport-l10-t1-p9---int100n150-m25---int100c150---s1---e0`), the original `SequentialSimulator` takes 85.8 seconds (on my laptop) just to return from `get_initial_state` whereas with `SparseState` this goes down to 0.05s.

Note: arguably, the old `UPState` could be replaced by the new one, instead of keeping both.