### PR TITLE
Domain constants

### DIFF
--- a/unified_planning/io/ma_pddl_writer.py
+++ b/unified_planning/io/ma_pddl_writer.py
@@ -31,7 +31,6 @@ from unified_planning.io.pddl_writer import (
     GENERAL_PDDL_KEYWORDS,
     PDDL3_KEYWORDS,
     TEMPORAL_PDDL_KEYWORDS,
-    ObjectsExtractor,
     ConverterToPDDLString,
     MangleFunction,
     WithName,
@@ -125,9 +124,8 @@ class MAPDDLWriter:
             str,
             WithName,
         ] = {}
-        # those 2 maps are "simmetrical", meaning that "(otn[k] == v) implies (nto[v] == k)"
-        self.domain_objects: Optional[Dict[_UserType, Set[Object]]] = None
-        self.domain_objects_agents: Dict[up.model.multi_agent.Agent, str]
+        # those 2 maps are "symmetrical", meaning that "(otn[k] == v) implies (nto[v] == k)"
+        self.domain_objects_agents: Dict[up.model.multi_agent.Agent, str] = {}
         self.all_public_fluents: Set[Fluent] = set()
         self.pddl_keywords = MA_PDDL_KEYWORDS
 
@@ -146,7 +144,6 @@ class MAPDDLWriter:
                 raise UPProblemDefinitionError(
                     "PDDL2.1 does not support timed effects or timed goals."
                 )
-            obe = ObjectsExtractor()
             out.write("(define ")
             if self.problem.name is None:
                 name = "ma-pddl"
@@ -227,36 +224,28 @@ class MAPDDLWriter:
                 )
                 out.write(" )\n")
 
-            if self.domain_objects is None:
-                if self.unfactored:
-                    temp_domain_objects: Dict[_UserType, Set[Object]] = {}
-                    for ag in self.problem.agents:
-                        self._populate_domain_objects(obe, ag)
-                        assert self.domain_objects is not None
-                        temp_domain_objects = temp_domain_objects | self.domain_objects
-                        self.domain_objects = None
-                    self.domain_objects = temp_domain_objects
-                else:
-                    # This method populates the self._domain_objects map
-                    self._populate_domain_objects(obe, ag)
-            assert self.domain_objects is not None
+            if self.unfactored:
+                for ags in self.problem.agents:
+                    self._populate_domain_objects(agent=ags)
+            else:
+                self._populate_domain_objects(agent=ag)
 
             if len(self.all_public_fluents) == 0:
                 self._all_public_fluents(self.all_public_fluents, self.problem.agents)
 
-            if len(self.domain_objects) > 0:
+            domain_objects = self.problem.domain_constants
+            if len(domain_objects) + len(self.domain_objects_agents) > 0:
                 out.write(" (:constants")
-                for ut, os in self.domain_objects.items():
-                    if len(os) > 0:
-                        out.write(
-                            f'\n   {" ".join([self._get_mangled_name(o) for o in os])} - {self._get_mangled_name(ut)}'
-                        )
-            if len(self.domain_objects_agents) > 0:
+                for o in domain_objects:
+                    out.write(
+                        f"\n   {self._get_mangled_name(o)} - {self._get_mangled_name(o.type)}"
+                    )
+
                 for k, v in self.domain_objects_agents.items():
                     if len(v) > 0:
                         out.write(f"\n   {self._get_mangled_name(k)} - {v}")
 
-            if len(self.domain_objects) > 0 or len(self.domain_objects_agents) > 0:
+            if len(domain_objects) + len(self.domain_objects_agents) > 0:
                 out.write("\n )\n")
 
             (
@@ -594,40 +583,33 @@ class MAPDDLWriter:
                 name = _get_pddl_name(self.problem, self.pddl_keywords)
             out.write(f"(define (problem {name}-problem)\n")
             out.write(f" (:domain {name}-domain)\n")
-            if self.domain_objects is None:
-                if self.unfactored:
-                    temp_domain_objects: Dict[_UserType, Set[Object]] = {}
-                    for ag in self.problem.agents:
-                        self._populate_domain_objects(ObjectsExtractor(), ag)
-                        assert self.domain_objects is not None
-                        temp_domain_objects = temp_domain_objects | self.domain_objects
-                        self.domain_objects = None
-                    self.domain_objects = temp_domain_objects
-                else:
-                    # This method populates the self._domain_objects map
-                    self._populate_domain_objects(ObjectsExtractor(), ag)
-            assert self.domain_objects is not None
-            if len(self.problem.user_types) > 0:
+
+            if self.unfactored:
+                for ag in self.problem.agents:
+                    self._populate_domain_objects(ag)
+            else:
+                # This method populates the self._domain_objects map
+                self._populate_domain_objects(ag)
+
+            domain_objects = self.problem.domain_constants
+            if len(self.problem.user_types) + len(self.problem.agents) > 0:
                 out.write(" (:objects")
                 for t in self.problem.user_types:
-                    constants_of_this_type = self.domain_objects.get(
-                        cast(_UserType, t), None
+                    constants_of_this_type = set(
+                        o for o in domain_objects if o.type == t
                     )
-                    if constants_of_this_type is None:
-                        objects = [o for o in self.problem.all_objects if o.type == t]
-                    else:
-                        objects = [
-                            o
-                            for o in self.problem.all_objects
-                            if o.type == t and o not in constants_of_this_type
-                        ]
+
+                    objects = [
+                        o
+                        for o in self.problem.all_objects
+                        if o.type == t and o not in constants_of_this_type
+                    ]
                     if len(objects) > 0:
                         out.write(
                             f'\n   {" ".join([self._get_mangled_name(o) for o in objects])} - {self._get_mangled_name(t)}'
                         )
 
-            # If agents are not defined as "constant" in the domain, they are defined in the problem
-            if len(self.problem.agents) > 0:
+                # If agents are not defined as "constant" in the domain, they are defined in the problem
                 for agent in self.problem.agents:
                     if agent not in self.domain_objects_agents.keys():
                         out.write(
@@ -636,7 +618,8 @@ class MAPDDLWriter:
                     else:
                         out.write(f"")
 
-            out.write("\n )\n")
+                out.write("\n )\n")
+
             converter = ConverterToMAPDDLString(
                 self.problem, self._get_mangled_name, ag, unfactored=self.unfactored
             )
@@ -702,7 +685,6 @@ class MAPDDLWriter:
             out.write("\n)")
             ag_problems[self._get_mangled_name(ag)] = out.getvalue()
             out.close()
-            self.domain_objects = None
             self.domain_objects_agents = {}
             # self.all_public_fluents = []
             if self.unfactored:
@@ -906,15 +888,12 @@ class MAPDDLWriter:
             for fluent in agent.public_fluents:
                 list_to_update.add(fluent)
 
-    def _populate_domain_objects(
-        self, obe: ObjectsExtractor, agent: "up.model.multi_agent.Agent"
-    ):
-        self.domain_objects = {}
+    def _populate_domain_objects(self, agent: "up.model.multi_agent.Agent"):
         self.domain_objects_agents = {}
         # Iterate the actions to retrieve domain objects
         import unified_planning.model.walkers as walkers
 
-        get_dots = walkers.AnyGetter(lambda x: x.is_dot())
+        get_dots = walkers.AnyGetter["up.model.FNode"](lambda x: x.is_dot())
         for a in agent.actions:
             if isinstance(a, up.model.InstantaneousAction):
                 for p in a.preconditions:
@@ -922,37 +901,6 @@ class MAPDDLWriter:
                         _update_domain_objects_ag(
                             self.domain_objects_agents, self.problem.agent(d.agent())
                         )
-                    _update_domain_objects(self.domain_objects, obe.get(p))
-                for e in a.effects:
-                    if e.is_conditional():
-                        _update_domain_objects(
-                            self.domain_objects, obe.get(e.condition)
-                        )
-                    _update_domain_objects(self.domain_objects, obe.get(e.fluent))
-                    _update_domain_objects(self.domain_objects, obe.get(e.value))
-            elif isinstance(a, DurativeAction):
-                _update_domain_objects(self.domain_objects, obe.get(a.duration.lower))
-                _update_domain_objects(self.domain_objects, obe.get(a.duration.upper))
-                for cl in a.conditions.values():
-                    for c in cl:
-                        _update_domain_objects(self.domain_objects, obe.get(c))
-                for el in a.effects.values():
-                    for e in el:
-                        if e.is_conditional():
-                            _update_domain_objects(
-                                self.domain_objects, obe.get(e.condition)
-                            )
-                        _update_domain_objects(self.domain_objects, obe.get(e.fluent))
-                        _update_domain_objects(self.domain_objects, obe.get(e.value))
-
-
-def _update_domain_objects(
-    dict_to_update: Dict[_UserType, Set[Object]], values: Dict[_UserType, Set[Object]]
-) -> None:
-    """Small utility method that updated a UserType -> Set[Object] dict with another dict of the same type."""
-    for ut, os in values.items():
-        os_to_update = dict_to_update.setdefault(ut, set())
-        os_to_update |= os
 
 
 def _update_domain_objects_ag(

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -160,39 +160,6 @@ WithName = Union[
 MangleFunction = Callable[[WithName], str]
 
 
-class ObjectsExtractor(walkers.DagWalker):
-    """Returns the object instances appearing in the expression."""
-
-    def __init__(self):
-        walkers.dag.DagWalker.__init__(self)
-
-    def get(self, expression: "up.model.FNode") -> Dict[_UserType, Set[Object]]:
-        """Returns all the free vars of the given expression."""
-        return self.walk(expression)
-
-    def walk_object_exp(
-        self, expression: "up.model.FNode", args: List[Dict[_UserType, Set[Object]]]
-    ) -> Dict[_UserType, Set[Object]]:
-        res: Dict[_UserType, Set[Object]] = {}
-        for a in args:
-            _update_domain_objects(res, a)
-        obj = expression.object()
-        assert obj.type.is_user_type()
-        res.setdefault(cast(_UserType, obj.type), set()).add(obj)
-        return res
-
-    @walkers.handles(
-        set(up.model.OperatorKind).difference((up.model.OperatorKind.OBJECT_EXP,))
-    )
-    def walk_all_types(
-        self, expression: "up.model.FNode", args: List[Dict[_UserType, Set[Object]]]
-    ) -> Dict[_UserType, Set[Object]]:
-        res: Dict[_UserType, Set[Object]] = {}
-        for a in args:
-            _update_domain_objects(res, a)
-        return res
-
-
 class ConverterToPDDLString(walkers.DagWalker):
     """Expression converter to a PDDL string."""
 
@@ -374,7 +341,6 @@ class PDDLWriter:
             WithName,
         ] = {}
         # those 2 maps are "simmetrical", meaning that "(otn[k] == v) implies (nto[v] == k)"
-        self.domain_objects: Optional[Dict[_UserType, Set[Object]]] = None
 
         # construct keywords set
         self.pddl_keywords = GENERAL_PDDL_KEYWORDS
@@ -408,7 +374,7 @@ class PDDLWriter:
             )
         if self.problem_kind.has_timed_goals():
             raise UPProblemDefinitionError("PDDL does not support timed goals.")
-        obe = ObjectsExtractor()
+
         out.write("(define ")
         if self.problem.name is None:
             name = "pddl"
@@ -508,18 +474,13 @@ class PDDLWriter:
                 f' (:types {" ".join(pddl_types)})\n' if len(pddl_types) > 0 else ""
             )
 
-        if self.domain_objects is None:
-            # This method populates the self._domain_objects map
-            self._populate_domain_objects(obe)
-        assert self.domain_objects is not None
-
-        if len(self.domain_objects) > 0:
+        domain_objects = self.problem.domain_constants
+        if len(domain_objects) > 0:
             out.write(" (:constants")
-            for ut, os in self.domain_objects.items():
-                if len(os) > 0:
-                    out.write(
-                        f'\n   {" ".join([self._get_mangled_name(o) for o in os])} - {self._get_mangled_name(ut)}'
-                    )
+            for o in domain_objects:
+                out.write(
+                    f"\n   {self._get_mangled_name(o)} - {self._get_mangled_name(o.type)}"
+                )
             out.write("\n )\n")
 
         predicates = []
@@ -579,8 +540,6 @@ class PDDLWriter:
                 for a in self.problem.actions:
                     cost_exp = metric.get_action_cost(a)
                     costs[a] = cost_exp
-                    if cost_exp is not None:
-                        _update_domain_objects(self.domain_objects, obe.get(cost_exp))
             elif metric.is_minimize_sequential_plan_length():
                 for a in self.problem.actions:
                     costs[a] = self.problem.environment.expression_manager.Int(1)
@@ -789,24 +748,16 @@ class PDDLWriter:
             name = _get_pddl_name(self.problem, self.pddl_keywords)
         out.write(f"(define (problem {name}-problem)\n")
         out.write(f" (:domain {name}-domain)\n")
-        if self.domain_objects is None:
-            # This method populates the self._domain_objects map
-            self._populate_domain_objects(ObjectsExtractor())
-        assert self.domain_objects is not None
+        domain_objects = self.problem.domain_constants
         if len(self.problem.user_types) > 0:
             out.write(" (:objects")
             for t in self.problem.user_types:
-                constants_of_this_type = self.domain_objects.get(
-                    cast(_UserType, t), None
-                )
-                if constants_of_this_type is None:
-                    objects = [o for o in self.problem.all_objects if o.type == t]
-                else:
-                    objects = [
-                        o
-                        for o in self.problem.all_objects
-                        if o.type == t and o not in constants_of_this_type
-                    ]
+                constants_of_this_type = set(o for o in domain_objects if o.type == t)
+                objects = [
+                    o
+                    for o in self.problem.all_objects
+                    if o.type == t and o not in constants_of_this_type
+                ]
                 if len(objects) > 0:
                     out.write(
                         f'\n   {" ".join([self._get_mangled_name(o) for o in objects])} - {self._get_mangled_name(t)}'
@@ -1045,63 +996,6 @@ class PDDLWriter:
                 f"The item {item} does not correspond to any item renamed."
             )
 
-    def _populate_domain_objects(self, obe: ObjectsExtractor):
-        self.domain_objects = {}
-        # Iterate the actions to retrieve domain objects
-        for a in self.problem.actions:
-            if isinstance(a, up.model.InstantaneousAction):
-                for p in a.preconditions:
-                    _update_domain_objects(self.domain_objects, obe.get(p))
-                for e in a.effects:
-                    if e.is_conditional():
-                        _update_domain_objects(
-                            self.domain_objects, obe.get(e.condition)
-                        )
-                    _update_domain_objects(self.domain_objects, obe.get(e.fluent))
-                    _update_domain_objects(self.domain_objects, obe.get(e.value))
-                if isinstance(a, SensingAction):
-                    for of in a.observed_fluents:
-                        _update_domain_objects(self.domain_objects, obe.get(of))
-            elif isinstance(a, DurativeAction):
-                _update_domain_objects(self.domain_objects, obe.get(a.duration.lower))
-                _update_domain_objects(self.domain_objects, obe.get(a.duration.upper))
-                for interval, cl in a.conditions.items():
-                    for c in cl:
-                        _update_domain_objects(self.domain_objects, obe.get(c))
-                for t, el in a.effects.items():
-                    for e in el:
-                        if e.is_conditional():
-                            _update_domain_objects(
-                                self.domain_objects, obe.get(e.condition)
-                            )
-                        _update_domain_objects(self.domain_objects, obe.get(e.fluent))
-                        _update_domain_objects(self.domain_objects, obe.get(e.value))
-        for ev in self.problem.events:
-            for p in ev.preconditions:
-                _update_domain_objects(self.domain_objects, obe.get(p))
-            for e in ev.effects:
-                if e.is_conditional():
-                    _update_domain_objects(self.domain_objects, obe.get(e.condition))
-                _update_domain_objects(self.domain_objects, obe.get(e.fluent))
-                _update_domain_objects(self.domain_objects, obe.get(e.value))
-        for pro in self.problem.processes:
-            for p in pro.preconditions:
-                _update_domain_objects(self.domain_objects, obe.get(p))
-            for e in pro.effects:
-                if e.is_conditional():
-                    _update_domain_objects(self.domain_objects, obe.get(e.condition))
-                _update_domain_objects(self.domain_objects, obe.get(e.fluent))
-                _update_domain_objects(self.domain_objects, obe.get(e.value))
-        if isinstance(self.problem, HierarchicalProblem):
-            for m in self.problem.methods:
-                for p in m.preconditions:
-                    _update_domain_objects(self.domain_objects, obe.get(p))
-                for subtask in m.subtasks:
-                    for targ in subtask.parameters:
-                        _update_domain_objects(self.domain_objects, obe.get(targ))
-                for c in m.non_temporal_constraints():
-                    _update_domain_objects(self.domain_objects, obe.get(c))
-
     def _write_task_network(
         self,
         tn: up.model.htn.task_network.AbstractTaskNetwork,
@@ -1206,15 +1100,6 @@ def _get_pddl_name(
     if isinstance(item, up.model.Parameter) or isinstance(item, up.model.Variable):
         name = f"?{name}"
     return name
-
-
-def _update_domain_objects(
-    dict_to_update: Dict[_UserType, Set[Object]], values: Dict[_UserType, Set[Object]]
-) -> None:
-    """Small utility method that updated a UserType -> Set[Object] dict with another dict of the same type."""
-    for ut, os in values.items():
-        os_to_update = dict_to_update.setdefault(ut, set())
-        os_to_update |= os
 
 
 def _write_effect(

--- a/unified_planning/model/htn/hierarchical_problem.py
+++ b/unified_planning/model/htn/hierarchical_problem.py
@@ -248,9 +248,7 @@ class HierarchicalProblem(up.model.problem.Problem):
         extractor = AnyGetter["up.model.Object"](
             predicate=lambda x: x.is_object_exp(), extractor=lambda x: x.object()
         )
-        domain_constants: Set[
-            "up.model.Object"
-        ] = up.model.problem.Problem.domain_constants(self)
+        domain_constants: Set["up.model.Object"] = super().domain_constants
         for m in self.methods:
             for p in m.preconditions:
                 domain_constants.update(extractor.get(p))

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -26,7 +26,6 @@ from unified_planning.model.metrics import (
 from unified_planning.model.metrics import MinimizeExpressionOnFinalState
 import unified_planning as up
 from unified_planning.model.action import DurativeAction, InstantaneousAction
-from unified_planning.model.contingent.sensing_action import SensingAction
 from unified_planning.model.effect import EffectKind
 from unified_planning.model import Fluent
 from unified_planning.model.abstract_problem import AbstractProblem
@@ -54,9 +53,6 @@ from unified_planning.exceptions import (
 )
 
 from unified_planning.model.walkers.any import AnyGetter
-
-# Needed for mypy, even if it is not used in this module
-import unified_planning.model.tamp
 
 
 class Problem(  # type: ignore[misc]
@@ -761,7 +757,7 @@ class Problem(  # type: ignore[misc]
                     domain_constants.update(extractor.get(e.fluent))
                     domain_constants.update(extractor.get(e.value))
                     domain_constants.update(extractor.get(e.condition))
-                if isinstance(action, SensingAction):
+                if isinstance(action, up.model.contingent.SensingAction):
                     for of in action.observed_fluents:
                         domain_constants.update(extractor.get(of))
             elif isinstance(action, DurativeAction):

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -14,12 +14,23 @@
 #
 """This module defines the problem class."""
 
-
 from itertools import chain, product
+import networkx as nx
+from fractions import Fraction
+from typing import Any, Optional, List, Dict, Set, Tuple, Union, cast, Iterable
+
+from unified_planning.model.metrics import (
+    MaximizeExpressionOnFinalState,
+    MinimizeActionCosts,
+)
+from unified_planning.model.metrics import MinimizeExpressionOnFinalState
 import unified_planning as up
+from unified_planning.model.action import DurativeAction, InstantaneousAction
+from unified_planning.model.contingent.sensing_action import SensingAction
 from unified_planning.model.effect import EffectKind
 from unified_planning.model import Fluent
 from unified_planning.model.abstract_problem import AbstractProblem
+from unified_planning.model.metrics import Oversubscription, TemporalOversubscription
 from unified_planning.model.mixins import (
     ActionsSetMixin,
     NaturalTransitionsSetMixin,
@@ -42,9 +53,10 @@ from unified_planning.exceptions import (
     UPUnsupportedProblemTypeError,
 )
 
-import networkx as nx
-from fractions import Fraction
-from typing import Any, Optional, List, Dict, Set, Tuple, Union, cast, Iterable
+from unified_planning.model.walkers.any import AnyGetter
+
+# Needed for mypy, even if it is not used in this module
+import unified_planning.model.tamp
 
 
 class Problem(  # type: ignore[misc]
@@ -730,6 +742,78 @@ class Problem(  # type: ignore[misc]
         seldom as possible.
         """
         return self._kind_factory().finalize()
+
+    @property
+    def domain_constants(self) -> Set["up.model.Object"]:
+        """Returns the `Objects` that are used as constants in the `Problem`,
+        that is those that appear in the expressions within actions, effects,
+        processes or quality metrics"""
+        domain_constants = set()
+        extractor = AnyGetter["up.model.Object"](
+            predicate=lambda x: x.is_object_exp(), extractor=lambda x: x.object()
+        )
+        for action in self._actions:
+            # Extract all the objects appearning in any expression within the action
+            if isinstance(action, InstantaneousAction):
+                for p in action.preconditions:
+                    domain_constants.update(extractor.get(p))
+                for e in action.effects:
+                    domain_constants.update(extractor.get(e.fluent))
+                    domain_constants.update(extractor.get(e.value))
+                    domain_constants.update(extractor.get(e.condition))
+                if isinstance(action, SensingAction):
+                    for of in action.observed_fluents:
+                        domain_constants.update(extractor.get(of))
+            elif isinstance(action, DurativeAction):
+                for _, cnds in action.conditions.items():
+                    for c in cnds:
+                        domain_constants.update(extractor.get(c))
+                for _, effs in action.effects.items():
+                    for e in effs:
+                        domain_constants.update(extractor.get(e.fluent))
+                        domain_constants.update(extractor.get(e.value))
+                        domain_constants.update(extractor.get(e.condition))
+                domain_constants.update(extractor.get(action.duration.lower))
+                domain_constants.update(extractor.get(action.duration.upper))
+            else:
+                raise ValueError(f"Unsupported action type: {type(action)}")
+
+        for ev in self.events:
+            for p in ev.preconditions:
+                domain_constants.update(extractor.get(p))
+            for e in ev.effects:
+                domain_constants.update(extractor.get(e.fluent))
+                domain_constants.update(extractor.get(e.value))
+                domain_constants.update(extractor.get(e.condition))
+
+        for proc in self.processes:
+            for p in proc.preconditions:
+                domain_constants.update(extractor.get(p))
+            for e in proc.effects:
+                domain_constants.update(extractor.get(e.fluent))
+                domain_constants.update(extractor.get(e.value))
+                domain_constants.update(extractor.get(e.condition))
+
+        for qm in self.quality_metrics:
+            if isinstance(
+                qm,
+                (
+                    MinimizeExpressionOnFinalState,
+                    MaximizeExpressionOnFinalState,
+                ),
+            ):
+                domain_constants.update(extractor.get(qm.expression))
+            elif isinstance(qm, Oversubscription):
+                for g in qm.goals.keys():
+                    domain_constants.update(extractor.get(g))
+            elif isinstance(qm, TemporalOversubscription):
+                for _, g in qm.goals.keys():
+                    domain_constants.update(extractor.get(g))
+            elif isinstance(qm, MinimizeActionCosts):
+                for c in qm.costs.values():
+                    domain_constants.update(extractor.get(c))
+
+        return domain_constants
 
 
 class _KindFactory:


### PR DESCRIPTION
This PR adds a `domain_constants` property in `Problem` (and derived classes). The property corresponds to the PDDL concept of  `constants`, i.e. objects that are used in the domain file.

This property simplifies the PDDL printers and is useful to distinguish objecvts that can be "renamed" from objects that have special roles in the domain.