### PR TITLE
Add .DS_store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ unified_planning/__pycache__/
 *~
 .venv/
 *_build*
+.DS_Store


### PR DESCRIPTION
.DS_Store files are hidden macOS system files that store folder-specific metadata such as icon positions, view settings, and custom attributes. They are often created automatically, without the user's knowledge or consent. This PR adds these files to `.gitignore` to prevent macOS developers from accidentally committing these files to the repo.