### PR TITLE
fix(engines): widen params type to Dict[str, Any]

### DIFF
--- a/unified_planning/engines/factory.py
+++ b/unified_planning/engines/factory.py
@@ -817,7 +817,7 @@ class Factory:
         self,
         *,
         name: Optional[str] = None,
-        params: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
         problem_kind: ProblemKind = ProblemKind(version=LATEST_PROBLEM_KIND_VERSION),
         anytime_guarantee: Optional[Union["AnytimeGuarantee", str]] = None,
     ) -> "up.engines.engine.Engine":
@@ -860,7 +860,7 @@ class Factory:
         *,
         name: Optional[str] = None,
         names: Optional[Sequence[str]] = None,
-        params: Optional[Union[Dict[str, str], Sequence[Dict[str, str]]]] = None,
+        params: Optional[Union[Dict[str, Any], Sequence[Dict[str, Any]]]] = None,
         problem_kind: ProblemKind = ProblemKind(),
         plan_kind: Optional[Union["PlanKind", str]] = None,
     ) -> "up.engines.engine.Engine":
@@ -946,7 +946,7 @@ class Factory:
         problem: "up.model.AbstractProblem",
         *,
         name: Optional[str] = None,
-        params: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> "up.engines.engine.Engine":
         """
         Returns a sequential simulator. There are two ways to call this method:
@@ -970,7 +970,7 @@ class Factory:
         problem: "up.model.AbstractProblem",
         *,
         name: Optional[str] = None,
-        params: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
         optimality_guarantee: Optional[Union["OptimalityGuarantee", str]] = None,
     ) -> "up.engines.engine.Engine":
         """
@@ -1041,7 +1041,7 @@ class Factory:
         problem: "up.model.AbstractProblem",
         *,
         name: Optional[str] = None,
-        params: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> "up.engines.engine.Engine":
         """
         Returns an ActionSelector. There are two ways to call this method:

--- a/unified_planning/shortcuts.py
+++ b/unified_planning/shortcuts.py
@@ -590,7 +590,7 @@ def OneshotPlanner(
 def AnytimePlanner(
     *,
     name: Optional[str] = None,
-    params: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
     problem_kind: ProblemKind = ProblemKind(version=LATEST_PROBLEM_KIND_VERSION),
     anytime_guarantee: Optional[Union["up.engines.AnytimeGuarantee", str]] = None,
 ) -> Engine:
@@ -624,7 +624,7 @@ def PlanValidator(
     *,
     name: Optional[str] = None,
     names: Optional[Sequence[str]] = None,
-    params: Optional[Union[Dict[str, str], Sequence[Dict[str, str]]]] = None,
+    params: Optional[Union[Dict[str, Any], Sequence[Dict[str, Any]]]] = None,
     problem_kind: ProblemKind = ProblemKind(version=LATEST_PROBLEM_KIND_VERSION),
     plan_kind: Optional[Union["up.plans.PlanKind", str]] = None,
 ) -> Engine:
@@ -689,7 +689,7 @@ def SequentialSimulator(
     problem: "up.model.AbstractProblem",
     *,
     name: Optional[str] = None,
-    params: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
 ) -> "up.engines.engine.Engine":
     """
     Returns a sequential simulator. There are two ways to call this method:
@@ -708,7 +708,7 @@ def Replanner(
     problem: "up.model.AbstractProblem",
     *,
     name: Optional[str] = None,
-    params: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
     optimality_guarantee: Optional[Union["up.engines.OptimalityGuarantee", str]] = None,
 ) -> "up.engines.engine.Engine":
     """
@@ -756,7 +756,7 @@ def ActionSelector(
     problem: "up.model.AbstractProblem",
     *,
     name: Optional[str] = None,
-    params: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
 ) -> "up.engines.engine.Engine":
     """
     Returns an ActionSelector. There are two ways to call this method:


### PR DESCRIPTION
## Summary
- `params: Dict[str, str]` was too narrow for `AnytimePlanner`,
  `PlanValidator`, `SequentialSimulator`, `Replanner`, and
  `ActionSelector` — other operation modes (`OneshotPlanner`,
  `Compiler`, `PlanRepairer`, `PortfolioSelector`) already used
  `Dict[str, Any]`.
- Widened to `Optional[Dict[str, Any]]` (or the `Union[..., Sequence[...]]`
  variant for `PlanValidator`) consistently in both `shortcuts.py`
  (public API) and `engines/factory.py` (`Factory` methods backing
  those shortcuts), so the two stay in sync.