### PR TITLE
deps: allow numpy>=2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,5 +9,4 @@ pddl
 tarski
 networkx
 pyparsing
-numpy<2  # work around to avoid incompatibilities in transitive dependencies
 docutils<0.21

--- a/plot-requirements.txt
+++ b/plot-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 plotly
-matplotlib==3.7.3
+matplotlib
 kaleido
 pandas
 pygraphviz

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ pddl
 pyparsing
 networkx
 ConfigSpace
-numpy<2 # required as transitive dependencies seems to install version 2 by default that is incompatible with other dependecies
 pysmt

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         ],
         "plot": [
             "plotly",
-            "matplotlib==3.7.3",
+            "matplotlib",
             "kaleido",
             "pygraphviz",
             "graphviz",


### PR DESCRIPTION
numpy is only a transitive dependency (unified_planning does not import it directly). The `numpy<2` pins were a workaround from when numpy 2.0 first released and transitive deps were still built against the numpy 1.x ABI.

That is no longer the case: configspace, scipy, pysmt and tarski all support numpy 2. The only remaining cap was the exact `matplotlib==3.7.3` pin in the `plot` extra, whose metadata forbids numpy 2, so bump it to `matplotlib>=3.8`.