### PR TITLE
feat(undefined-initial-numeric-remover): support interpreted functions

### DIFF
--- a/unified_planning/engines/compilers/undefined_initial_numeric_remover.py
+++ b/unified_planning/engines/compilers/undefined_initial_numeric_remover.py
@@ -83,10 +83,12 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
 
     @property
     def name(self):
+        """Returns the name of this compiler."""
         return "undefined_initial_numeric_remover"
 
     @staticmethod
     def supported_kind() -> ProblemKind:
+        """Returns the `ProblemKind` supported by this compiler."""
         supported_kind = ProblemKind(version=LATEST_PROBLEM_KIND_VERSION)
         supported_kind.set_problem_class("ACTION_BASED")
         supported_kind.set_problem_class("TAMP")
@@ -148,18 +150,22 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
 
     @staticmethod
     def supports(problem_kind):
+        """Returns True if the given `ProblemKind` is supported by this compiler."""
         return problem_kind <= UndefinedInitialNumericRemover.supported_kind()
 
     @staticmethod
     def supports_compilation(compilation_kind: CompilationKind) -> bool:
+        """Returns True if the given `CompilationKind` is supported by this compiler."""
         return compilation_kind == CompilationKind.UNDEFINED_INITIAL_NUMERIC_REMOVING
 
     @staticmethod
     def resulting_problem_kind(
         problem_kind: ProblemKind, compilation_kind: Optional[CompilationKind] = None
     ) -> ProblemKind:
+        """Returns the `ProblemKind` of the problem resulting from this compilation."""
         new_kind = problem_kind.clone()
         if new_kind.has_undefined_initial_numeric():
+            # every fluent with an undefined initial value is given one by the compilation
             new_kind.unset_initial_state("UNDEFINED_INITIAL_NUMERIC")
         return new_kind
 
@@ -198,6 +204,8 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
         new_problem.name = f"{problem.name}_{self.name}"
         env = new_problem.environment
 
+        # give every fluent with an undefined initial value a concrete default, and
+        # create its companion "is_value_defined" boolean fluent, initialized to False
         undef_fluents = new_problem._fluents_with_undefined_values()
         default_initial_value = get_default_initial_values(new_problem, undef_fluents)
         is_value_defined_fluents = {}
@@ -214,12 +222,14 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
             new_problem.add_fluent(is_value_defined, default_initial_value=False)
             is_value_defined_fluents[fluent] = is_value_defined
 
+        # every ground instance that was explicitly initialized is, by definition, defined
         for fluent_exp in dict(new_problem.explicit_initial_values):
             fluent = fluent_exp.fluent()
             if fluent in is_value_defined_fluents:
                 is_value_defined = is_value_defined_fluents[fluent]
                 new_problem.set_initial_value(is_value_defined(*fluent_exp.args), True)
 
+        # augment every place a formerly-undefined fluent is read or assigned
         self._compile_actions(new_problem, is_value_defined_fluents)
         self._compile_goals(new_problem, is_value_defined_fluents)
         self._compile_timed_effects_and_timed_goals(
@@ -237,8 +247,20 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
     def _compile_actions(
         self, problem: Problem, is_value_defined_fluents: Dict[Fluent, Fluent]
     ):
+        """
+        Mutates every action of `problem` in place so that, for each formerly-undefined
+        fluent it reads, the matching "is_value_defined" tracker is required wherever the
+        read happens, and for each one it assigns, the tracker is set to True (unless the
+        assignment already required the tracker to be True, e.g. an increase/decrease
+        effect, in which case it is a no-op and adding it again would be redundant).
+
+        `is_value_defined_fluents` maps each formerly-undefined fluent to its tracker.
+        """
         for action in problem.actions:
             if isinstance(action, InstantaneousAction):
+                # anywhere a fluent's current value is needed: preconditions, the
+                # expressions computing effect values, the fluent itself for
+                # increase/decrease effects (which read-then-write), and effect conditions
                 expressions = (
                     list(action.preconditions)
                     + [eff.value for eff in action.effects]
@@ -255,6 +277,7 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
                         if fluent_exp.fluent() in is_value_defined_fluents:
                             undef_fluent_exps.add(fluent_exp)
 
+                # fluents that are the target of some effect of this action
                 affected_undef_fluent_exps = set()
                 for eff in action.effects:
                     if eff.fluent.fluent() in is_value_defined_fluents:
@@ -266,6 +289,9 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
                     )
 
                 for fluent_exp in affected_undef_fluent_exps:
+                    # if this ground instance was already read above (increase/decrease
+                    # effects always are), its tracker is already a precondition and is
+                    # therefore already guaranteed to be True; no need to set it again
                     if fluent_exp not in undef_fluent_exps:
                         action.add_effect(
                             is_value_defined_fluents[fluent_exp.fluent()](
@@ -275,6 +301,9 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
                         )
 
             elif isinstance(action, DurativeAction):
+                # same idea as above, but expressions must be attributed to the timing
+                # they belong to, since the tracker precondition/effect they generate has
+                # to be added at that same timing
                 timing_to_expressions: Dict[Timing, List[FNode]] = defaultdict(list)
                 for timeinterval, conditions in action.conditions.items():
                     timing_to_expressions[timeinterval.lower] += conditions
@@ -296,6 +325,8 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
                         if eff.fluent.fluent() in is_value_defined_fluents
                     )
 
+                # the duration must be computable before the action starts, so any
+                # fluent it reads is attributed to the action's start
                 for fluent_exp in self._fve.get(action.duration.lower) | self._fve.get(
                     action.duration.upper
                 ):
@@ -319,6 +350,8 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
 
                 for timing, fluent_exps in affected_undef_fluent_exps_map.items():
                     for fluent_exp in fluent_exps:
+                        # see the InstantaneousAction case above: skip if already read
+                        # (and thus already required to be defined) at this same timing
                         if fluent_exp not in timing_to_undef_fluent_exps.get(
                             timing, set()
                         ):
@@ -333,6 +366,8 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
     def _compile_goals(
         self, problem: Problem, is_value_defined_fluents: Dict[Fluent, Fluent]
     ):
+        """Adds a goal requiring the tracker to be True for every formerly-undefined
+        fluent read in `problem`'s (non-timed) goals."""
         undef_fluent_exps = set()
         for exp in problem.goals:
             for fluent_exp in self._fve.get(exp):
@@ -347,6 +382,10 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
     def _compile_timed_effects_and_timed_goals(
         self, problem: Problem, is_value_defined_fluents: Dict[Fluent, Fluent]
     ):
+        """
+        Same augmentation as :func:`_compile_actions`'s `DurativeAction` case, but for
+        `problem`'s global timed goals and timed effects rather than a single action.
+        """
         timing_to_expressions: Dict[Timing, List[FNode]] = defaultdict(list)
         for timeinterval, goals in problem.timed_goals.items():
             timing_to_expressions[timeinterval.lower].extend(goals)
@@ -391,6 +430,14 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
     def _compile_quality_metrics(
         self, problem: Problem, is_value_defined_fluents: Dict[Fluent, Fluent]
     ):
+        """
+        For every `MinimizeActionCosts` metric, requires the tracker for each
+        formerly-undefined fluent read by an action's cost expression (as a
+        precondition for an `InstantaneousAction`, or a start condition for a
+        `DurativeAction`). Every quality metric is then re-added from scratch, since
+        the action instances used as `MinimizeActionCosts.costs` dictionary keys may
+        have been mutated above by :func:`_compile_actions`, invalidating their hash.
+        """
         for metric in problem.quality_metrics:
             if metric.is_minimize_action_costs():
                 assert isinstance(metric, MinimizeActionCosts)
@@ -434,6 +481,15 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
 def get_default_initial_values(
     problem: Problem, undef_fluents: List[Fluent]
 ) -> Dict[Fluent, Union[int, Fraction]]:
+    """
+    Picks the value each fluent in `undef_fluents` gets in `problem`'s initial state
+    once its initial value is no longer left undefined.
+
+    For a fluent that is unconditionally assigned a constant somewhere in the problem's
+    actions, the smallest such constant is used. Every other fluent
+    (never assigned a constant, or only assigned non-constant expressions, such as the
+    result of an interpreted function) falls back to ``0``.
+    """
     undef_fluents_set = set(undef_fluents)
     default_initial_value = {}
     for action in problem.actions:
@@ -472,6 +528,8 @@ def get_default_initial_values(
 
 
 def new_fluent_name(problem: Problem, name: str) -> str:
+    """Returns `name` if it is not already used by a fluent of `problem`, otherwise
+    the first `f"{name}_{i}"` (for increasing ``i`` starting at 0) that is free."""
     new_name = name
     i = 0
     while problem.has_fluent(new_name):

--- a/unified_planning/engines/compilers/undefined_initial_numeric_remover.py
+++ b/unified_planning/engines/compilers/undefined_initial_numeric_remover.py
@@ -62,6 +62,16 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
     - The boolean fluent is added to an action's conditions whenever the numeric fluent is used:
         * in any precondition of the action, or
         * in any expression used to compute the value of an effect of the action.
+    - A numeric fluent read inside the arguments of an :class:`~unified_planning.model.InterpretedFunction`
+      call still counts as a read, so the tracking fluent is added wherever the interpreted function
+      appears: in conditions, in durations, and in the expressions used to compute effect values.
+
+    Note:
+        Since conditions in this library are evaluated as non-short-circuiting conjunctions, an interpreted
+        function over an undefined numeric fluent is still called with that fluent's injected default value
+        (``0``, unless a constant assignment sets a lower default) even in states where the corresponding
+        tracking fluent is ``False`` and the overall condition is therefore unsatisfied regardless. The
+        interpreted function's callable must be able to handle this default value without raising.
 
     This `Compiler` supports only the the `UNDEFINED_INITIAL_NUMERIC_REMOVING` :class:`~unified_planning.engines.CompilationKind`.
     """
@@ -94,12 +104,14 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
         supported_kind.set_expression_duration("FLUENTS_IN_DURATIONS")
         supported_kind.set_expression_duration("INT_TYPE_DURATIONS")
         supported_kind.set_expression_duration("REAL_TYPE_DURATIONS")
+        supported_kind.set_expression_duration("INTERPRETED_FUNCTIONS_IN_DURATIONS")
         supported_kind.set_numbers("BOUNDED_TYPES")
         supported_kind.set_conditions_kind("NEGATIVE_CONDITIONS")
         supported_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
         supported_kind.set_conditions_kind("EQUALITIES")
         supported_kind.set_conditions_kind("EXISTENTIAL_CONDITIONS")
         supported_kind.set_conditions_kind("UNIVERSAL_CONDITIONS")
+        supported_kind.set_conditions_kind("INTERPRETED_FUNCTIONS_IN_CONDITIONS")
         supported_kind.set_effects_kind("CONDITIONAL_EFFECTS")
         supported_kind.set_effects_kind("INCREASE_EFFECTS")
         supported_kind.set_effects_kind("DECREASE_EFFECTS")
@@ -109,6 +121,9 @@ class UndefinedInitialNumericRemover(engines.engine.Engine, CompilerMixin):
         supported_kind.set_effects_kind("FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
         supported_kind.set_effects_kind("FLUENTS_IN_NUMERIC_ASSIGNMENTS")
         supported_kind.set_effects_kind("FLUENTS_IN_OBJECT_ASSIGNMENTS")
+        supported_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_BOOLEAN_ASSIGNMENTS")
+        supported_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_NUMERIC_ASSIGNMENTS")
+        supported_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_OBJECT_ASSIGNMENTS")
         supported_kind.set_typing("FLAT_TYPING")
         supported_kind.set_typing("HIERARCHICAL_TYPING")
         supported_kind.set_parameters("BOOL_FLUENT_PARAMETERS")

--- a/unified_planning/test/examples/interpreted_functions_examples.py
+++ b/unified_planning/test/examples/interpreted_functions_examples.py
@@ -593,4 +593,114 @@ def get_example_problems():
     )
     problems["interpreted_functions_minimal_chain_of_assignments"] = ifproblem
 
+    # interpreted functions combined with an undefined initial numeric value
+
+    UndefObj = UserType("UndefObj")
+
+    undef_value = Fluent("undef_value", IntType(), o=UndefObj)
+    undef_total = Fluent("undef_total", IntType())
+
+    def is_big(x):
+        return x >= 3
+
+    signature_is_big = OrderedDict()
+    signature_is_big["x"] = IntType()
+    is_big_if = InterpretedFunction("is_big", BoolType(), signature_is_big, is_big)
+
+    def double(x):
+        return 2 * x
+
+    signature_double = OrderedDict()
+    signature_double["x"] = IntType()
+    double_if = InterpretedFunction("double", IntType(), signature_double, double)
+
+    undef_o1 = Object("undef_o1", UndefObj)
+    undef_o2 = Object("undef_o2", UndefObj)
+
+    def choose_o1():
+        return undef_o1
+
+    choose_if = InterpretedFunction("choose", UndefObj, OrderedDict(), choose_o1)
+
+    use_value = InstantaneousAction("use_value", o=UndefObj)
+    use_value.add_precondition(is_big_if(undef_value(use_value.o)))
+    use_value.add_effect(undef_total, double_if(undef_value(use_value.o)))
+
+    set_value = InstantaneousAction("set_value", o=UndefObj)
+    set_value.add_effect(undef_value(set_value.o), double_if(undef_value(undef_o1)))
+
+    use_chosen = InstantaneousAction("use_chosen")
+    use_chosen.add_precondition(is_big_if(undef_value(choose_if())))
+    use_chosen.add_increase_effect(undef_total, 1)
+
+    problem = Problem("interpreted_functions_undef_numeric")
+    problem.add_fluent(undef_value)
+    problem.add_fluent(undef_total, default_initial_value=0)
+    problem.add_object(undef_o1)
+    problem.add_object(undef_o2)
+    problem.add_action(use_value)
+    problem.add_action(set_value)
+    problem.add_action(use_chosen)
+    problem.set_initial_value(
+        undef_value(undef_o1), 4
+    )  # undef_value(undef_o2) is left undefined
+    problem.add_goal(GE(undef_total, 1))
+
+    ifproblem = TestCase(
+        problem=problem,
+        solvable=True,
+        valid_plans=[
+            up.plans.SequentialPlan([use_value(undef_o1)]),
+            up.plans.SequentialPlan([use_chosen()]),
+            up.plans.SequentialPlan([set_value(undef_o2), use_value(undef_o2)]),
+        ],
+        invalid_plans=[  # invalid plans contain actions that rely on the undefined value
+            up.plans.SequentialPlan([use_value(undef_o2)]),
+            up.plans.SequentialPlan([use_chosen(), use_value(undef_o2)]),
+            up.plans.SequentialPlan([]),
+        ],
+    )
+    problems["interpreted_functions_undef_numeric"] = ifproblem
+
+    # interpreted functions in a durative action's duration, combined with an
+    # undefined initial numeric value
+
+    undef_durative_value = Fluent("undef_durative_value", IntType(), o=UndefObj)
+    undef_done = Fluent("undef_done", BoolType())
+
+    undef_move = DurativeAction("undef_move", o=UndefObj)
+    undef_move.set_fixed_duration(double_if(undef_durative_value(undef_move.o)))
+    undef_move.add_condition(
+        StartTiming(), Not(is_big_if(undef_durative_value(undef_move.o)))
+    )
+    undef_move.add_effect(EndTiming(), undef_done, True)
+
+    problem = Problem("interpreted_functions_undef_numeric_durative")
+    problem.add_fluent(undef_durative_value)
+    problem.add_fluent(undef_done, default_initial_value=False)
+    problem.add_object(undef_o1)
+    problem.add_object(undef_o2)
+    problem.add_action(undef_move)
+    problem.set_initial_value(
+        undef_durative_value(undef_o1), 2
+    )  # undef_durative_value(undef_o2) is left undefined
+    problem.add_goal(undef_done)
+
+    ifproblem = TestCase(
+        problem=problem,
+        solvable=True,
+        valid_plans=[
+            up.plans.TimeTriggeredPlan(
+                [(Fraction(0), undef_move(undef_o1), Fraction(4))]
+            ),
+        ],
+        invalid_plans=[  # invalid plans contain actions that rely on the undefined value
+            up.plans.TimeTriggeredPlan(
+                [(Fraction(0), undef_move(undef_o2), Fraction(4))]
+            ),
+            up.plans.TimeTriggeredPlan([]),
+        ],
+    )
+    problems["interpreted_functions_undef_numeric_durative"] = ifproblem
+
     return problems

--- a/unified_planning/test/test_problem.py
+++ b/unified_planning/test/test_problem.py
@@ -593,7 +593,12 @@ class TestProblem(unittest_TestCase):
         problem.set_initial_value(distance(l2, l1), "20")
 
     def test_undefined_initial_state(self):
-        undefs_num = ["basic_undef_numeric", "undef_numeric_with_timed_effects"]
+        undefs_num = [
+            "basic_undef_numeric",
+            "undef_numeric_with_timed_effects",
+            "interpreted_functions_undef_numeric",
+            "interpreted_functions_undef_numeric_durative",
+        ]
         undefs_sym = ["basic_undef_bool"]
         for pb_name in self.problems:
             problem = self.problems[pb_name].problem

--- a/unified_planning/test/test_undefined_initial_numeric_remover.py
+++ b/unified_planning/test/test_undefined_initial_numeric_remover.py
@@ -118,3 +118,103 @@ class TestUndefinedInitialNumericRemover(unittest_TestCase):
         }
         self.assertTrue(is_value_defined_value(o1) in timed_goals)
         self.assertTrue(is_value_defined_value(o2) in timed_goals)
+
+    def test_interpreted_functions_undef_numeric(self):
+        problem = self.problems["interpreted_functions_undef_numeric"].problem
+
+        with Compiler(
+            compilation_kind="UNDEFINED_INITIAL_NUMERIC_REMOVING",
+            problem_kind=problem.kind,
+        ) as compiler:
+            compilation_res = compiler.compile(problem)
+            compiled_problem = compilation_res.problem
+            assert isinstance(compiled_problem, Problem)
+
+        self.assertEqual(len(compiled_problem._fluents_with_undefined_values()), 0)
+        self.assertTrue(compiled_problem.has_fluent("is_value_defined_undef_value"))
+
+        undef_o1 = compiled_problem.object("undef_o1")
+        undef_o2 = compiled_problem.object("undef_o2")
+        is_value_defined_undef_value = compiled_problem.fluent(
+            "is_value_defined_undef_value"
+        )
+        is_value_defined_undef_value_o1 = compiled_problem.initial_value(
+            is_value_defined_undef_value(undef_o1)
+        )
+        is_value_defined_undef_value_o2 = compiled_problem.initial_value(
+            is_value_defined_undef_value(undef_o2)
+        )
+        self.assertTrue(
+            is_value_defined_undef_value_o1 is not None
+            and is_value_defined_undef_value_o1.constant_value()
+        )
+        self.assertTrue(
+            is_value_defined_undef_value_o2 is not None
+            and is_value_defined_undef_value_o2.constant_value() == False
+        )
+
+        for action in compiled_problem.actions:
+            assert isinstance(action, InstantaneousAction)
+            if action.name == "use_value":
+                # the interpreted-function precondition plus the tracker it reads
+                self.assertEqual(len(action.preconditions), 2)
+                self.assertEqual(len(action.effects), 1)
+            elif action.name == "set_value":
+                # only undef_o1 is read (inside the interpreted function); the
+                # assigned undef_value(o) gets its own tracker effect
+                self.assertEqual(len(action.preconditions), 1)
+                self.assertEqual(len(action.effects), 2)
+            elif action.name == "use_chosen":
+                # the tracker is instantiated on the interpreted-function argument
+                self.assertEqual(len(action.preconditions), 2)
+                self.assertEqual(len(action.effects), 1)
+                tracker_preconditions = [
+                    p
+                    for p in action.preconditions
+                    if p.is_fluent_exp() and p.fluent() == is_value_defined_undef_value
+                ]
+                self.assertEqual(len(tracker_preconditions), 1)
+                (arg,) = tracker_preconditions[0].args
+                self.assertTrue(arg.is_interpreted_function_exp())
+
+    def test_interpreted_functions_undef_numeric_durative(self):
+        problem = self.problems["interpreted_functions_undef_numeric_durative"].problem
+
+        with Compiler(
+            compilation_kind="UNDEFINED_INITIAL_NUMERIC_REMOVING",
+            problem_kind=problem.kind,
+        ) as compiler:
+            compilation_res = compiler.compile(problem)
+            compiled_problem = compilation_res.problem
+            assert isinstance(compiled_problem, Problem)
+
+        self.assertEqual(len(compiled_problem._fluents_with_undefined_values()), 0)
+        self.assertTrue(
+            compiled_problem.has_fluent("is_value_defined_undef_durative_value")
+        )
+
+        undef_o1 = compiled_problem.object("undef_o1")
+        undef_o2 = compiled_problem.object("undef_o2")
+        is_value_defined = compiled_problem.fluent(
+            "is_value_defined_undef_durative_value"
+        )
+        is_value_defined_o1 = compiled_problem.initial_value(is_value_defined(undef_o1))
+        is_value_defined_o2 = compiled_problem.initial_value(is_value_defined(undef_o2))
+        self.assertTrue(
+            is_value_defined_o1 is not None and is_value_defined_o1.constant_value()
+        )
+        self.assertTrue(
+            is_value_defined_o2 is not None
+            and is_value_defined_o2.constant_value() == False
+        )
+
+        undef_move = compiled_problem.action("undef_move")
+        assert isinstance(undef_move, DurativeAction)
+        # the duration is not rewritten, only conditions/effects are augmented
+        self.assertEqual(undef_move.duration.lower, undef_move.duration.upper)
+        self.assertTrue(undef_move.duration.lower.is_interpreted_function_exp())
+        self.assertEqual(len(undef_move.conditions), 1)
+        (conditions,) = undef_move.conditions.values()
+        # the original interpreted-function condition plus the tracker it reads
+        self.assertEqual(len(conditions), 2)
+        self.assertIn(is_value_defined(undef_move.o), conditions)


### PR DESCRIPTION
The compiler's traversal already handled interpreted-function arguments correctly via FreeVarsExtractor, but supported_kind() didn't declare any INTERPRETED_FUNCTIONS_* feature, so the factory never selected it for such problems. Declare the five features and add example/test coverage for interpreted functions in conditions, numeric assignments, durations, and as fluent arguments.