### PR TITLE
feat(timed-to-sequential): support interpreted functions

### DIFF
--- a/unified_planning/engines/compilers/timed_to_sequential.py
+++ b/unified_planning/engines/compilers/timed_to_sequential.py
@@ -128,6 +128,21 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
     transform a problem with durative actions into one only using instantaneous actions.
     Every durative action is compiled into an instantaneous action by condensing
     all all conditions at start time and all effects at end time.
+
+    Interpreted functions are treated as ordinary sub-expressions: calls appearing in
+    conditions, effect values and durations are carried over unchanged, and calls appearing
+    in end-time conditions/effects have their arguments rewritten by the start-time effect
+    substitution, exactly like any other fluent-based expression.
+
+    Note:
+        Since a durative action's start and end collapse into a single instant, an interpreted
+        function that the temporal semantics would evaluate once at start and once at end is
+        evaluated only once here; this is consistent with the library-wide assumption that
+        interpreted functions are deterministic.
+
+        An interpreted function used in a duration is not part of the compiled (instantaneous)
+        problem: it is re-evaluated by :func:`plan_back_conversion_callable` against the simulated
+        state, so its callable must be able to handle whatever values are reachable in that state.
     """
 
     def __init__(self):
@@ -161,6 +176,7 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
         supported_kind.set_conditions_kind("EQUALITIES")
         supported_kind.set_conditions_kind("EXISTENTIAL_CONDITIONS")
         supported_kind.set_conditions_kind("UNIVERSAL_CONDITIONS")
+        supported_kind.set_conditions_kind("INTERPRETED_FUNCTIONS_IN_CONDITIONS")
         supported_kind.set_effects_kind("INCREASE_EFFECTS")
         supported_kind.set_effects_kind("DECREASE_EFFECTS")
         supported_kind.set_effects_kind("STATIC_FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
@@ -169,6 +185,9 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
         supported_kind.set_effects_kind("FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
         supported_kind.set_effects_kind("FLUENTS_IN_NUMERIC_ASSIGNMENTS")
         supported_kind.set_effects_kind("FLUENTS_IN_OBJECT_ASSIGNMENTS")
+        supported_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_BOOLEAN_ASSIGNMENTS")
+        supported_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_NUMERIC_ASSIGNMENTS")
+        supported_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_OBJECT_ASSIGNMENTS")
         supported_kind.set_effects_kind("FORALL_EFFECTS")
         supported_kind.set_time("CONTINUOUS_TIME")
         supported_kind.set_time("DISCRETE_TIME")
@@ -177,6 +196,7 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
         supported_kind.set_expression_duration("REAL_TYPE_DURATIONS")
         supported_kind.set_expression_duration("STATIC_FLUENTS_IN_DURATIONS")
         supported_kind.set_expression_duration("FLUENTS_IN_DURATIONS")
+        supported_kind.set_expression_duration("INTERPRETED_FUNCTIONS_IN_DURATIONS")
         supported_kind.set_quality_metrics("ACTIONS_COST")
         supported_kind.set_actions_cost_kind("STATIC_FLUENTS_IN_ACTIONS_COST")
         supported_kind.set_actions_cost_kind("FLUENTS_IN_ACTIONS_COST")
@@ -206,6 +226,19 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
             new_kind.unset_time(timefeat)
         for durfeat in FEATURES["EXPRESSION_DURATION"]:
             new_kind.unset_expression_duration(durfeat)
+        # Start-time effect values are substituted into end-time conditions and into the
+        # values of end-time effects, so an interpreted function call appearing in any effect
+        # value can end up in a condition or in an effect of a different kind; declare all of
+        # them as a sound over-approximation.
+        if (
+            problem_kind.has_interpreted_functions_in_boolean_assignments()
+            or problem_kind.has_interpreted_functions_in_numeric_assignments()
+            or problem_kind.has_interpreted_functions_in_object_assignments()
+        ):
+            new_kind.set_conditions_kind("INTERPRETED_FUNCTIONS_IN_CONDITIONS")
+            new_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_BOOLEAN_ASSIGNMENTS")
+            new_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_NUMERIC_ASSIGNMENTS")
+            new_kind.set_effects_kind("INTERPRETED_FUNCTIONS_IN_OBJECT_ASSIGNMENTS")
         return new_kind
 
     def get_effects_data_structures(

--- a/unified_planning/test/examples/interpreted_functions_examples.py
+++ b/unified_planning/test/examples/interpreted_functions_examples.py
@@ -703,4 +703,54 @@ def get_example_problems():
     )
     problems["interpreted_functions_undef_numeric_durative"] = ifproblem
 
+    # interpreted functions in a durative action's duration inequality and in a start
+    # effect whose value is substituted into an end-time condition and an end-time effect
+
+    def if_charge_time(level):
+        return 10 - level
+
+    signature_charge_time = OrderedDict()
+    signature_charge_time["level"] = IntType(0, 10)
+    charge_time_if = InterpretedFunction(
+        "charge_time", IntType(0, 10), signature_charge_time, if_charge_time
+    )
+
+    def if_boost(level):
+        return min(level + 3, 10)
+
+    signature_boost = OrderedDict()
+    signature_boost["level"] = IntType(0, 10)
+    boost_if = InterpretedFunction("boost", IntType(0, 10), signature_boost, if_boost)
+
+    battery = Fluent("battery", IntType(0, 10))
+    charged = Fluent("charged")
+
+    charge = DurativeAction("charge")
+    charge.set_closed_duration_interval(charge_time_if(battery), 20)
+    charge.add_condition(StartTiming(), LT(battery, 10))
+    charge.add_effect(StartTiming(), battery, boost_if(battery))
+    charge.add_condition(EndTiming(), GE(battery, 5))
+    charge.add_effect(EndTiming(), charged, GE(battery, 5))
+
+    problem = Problem("interpreted_functions_in_durative_start_effects")
+    problem.add_fluent(battery)
+    problem.add_fluent(charged)
+    problem.add_action(charge)
+    problem.set_initial_value(battery, 2)
+    problem.set_initial_value(charged, False)
+    problem.add_goal(charged)
+
+    ifproblem = TestCase(
+        problem=problem,
+        solvable=True,
+        valid_plans=[
+            up.plans.TimeTriggeredPlan([(Fraction(0), charge(), Fraction(8))]),
+        ],
+        invalid_plans=[  # duration shorter than charge_time_if(battery) == 8
+            up.plans.TimeTriggeredPlan([(Fraction(0), charge(), Fraction(4))]),
+            up.plans.TimeTriggeredPlan([]),
+        ],
+    )
+    problems["interpreted_functions_in_durative_start_effects"] = ifproblem
+
     return problems

--- a/unified_planning/test/test_t2s.py
+++ b/unified_planning/test/test_t2s.py
@@ -23,7 +23,18 @@ from unified_planning.engines.compilers.timed_to_sequential import TimedToSequen
 from unified_planning.plans import SequentialPlan, TimeTriggeredPlan
 from unified_planning.engines.results import ValidationResultStatus
 from unified_planning.engines.plan_validator import TimeTriggeredPlanValidator
+from unified_planning.model.walkers import InterpretedFunctionsExtractor
 from fractions import Fraction
+
+
+def _get_interpreted_function(*expressions):
+    """Extracts the single `InterpretedFunction` used across the given expressions."""
+    ife = InterpretedFunctionsExtractor()
+    if_functions = set()
+    for e in expressions:
+        if_functions |= {if_exp.interpreted_function() for if_exp in ife.get(e)}
+    (if_function,) = if_functions
+    return if_function
 
 
 class TestT2S(unittest_TestCase):
@@ -179,6 +190,133 @@ class TestT2S(unittest_TestCase):
         expected_d.add_effect(counter_f, Minus(counter_f, 1))
         self.assertEqual(compiled_d, expected_d)
         self.assertEqual(compiled_i, expected_i)
+
+    def test_interpreted_functions_in_durative_conditions(self):
+        problem = self.problems["interpreted_functions_in_durative_conditions"].problem
+        assert isinstance(problem, Problem)
+        self.assertTrue(TimedToSequential.supports(problem.kind))
+        t2s = TimedToSequential()
+        comp_res = t2s.compile(problem)
+        assert isinstance(comp_res.problem, Problem)
+
+        original = problem.action("durative_action_i_f_condition")
+        assert isinstance(original, DurativeAction)
+        ione = problem.fluent("ione")
+        itwo = problem.fluent("itwo")
+        end_goal = problem.fluent("end_goal")
+        all_conditions = [oc for ocl in original.conditions.values() for oc in ocl]
+        funx = _get_interpreted_function(*all_conditions)
+
+        # no start effects exist on this action, so the end-time conditions are
+        # carried over unchanged (identity substitution) alongside the start-time ones
+        expected = InstantaneousAction("durative_action_i_f_condition")
+        expected.add_precondition(And(GE(ione, 10), Not(funx(itwo, itwo))))
+        expected.add_precondition(funx(ione, itwo))
+        expected.add_precondition(Not(And(GE(ione, 15), LE(itwo, 5))))
+        expected.add_effect(end_goal, True)
+
+        compiled = comp_res.problem.action("durative_action_i_f_condition")
+        self.assertEqual(expected, compiled)
+
+    def test_go_home_with_rain_and_interpreted_functions(self):
+        problem = self.problems["go_home_with_rain_and_interpreted_functions"].problem
+        assert isinstance(problem, Problem)
+        self.assertTrue(TimedToSequential.supports(problem.kind))
+        t2s = TimedToSequential()
+        comp_res = t2s.compile(problem)
+        assert isinstance(comp_res.problem, Problem)
+
+        original_gohome = problem.action("gohome")
+        assert isinstance(original_gohome, DurativeAction)
+        athome = problem.fluent("athome")
+        atwork = problem.fluent("atwork")
+        house_wet = problem.fluent("house_wet")
+        wet_clothes = problem.fluent("wet_clothes")
+        rain = problem.fluent("rain")
+        have_umbrella = problem.fluent("have_umbrella")
+        effect_values = [
+            oe.value for oel in original_gohome.effects.values() for oe in oel
+        ]
+        wet_if = _get_interpreted_function(*effect_values)
+
+        # the start effect wet_clothes := wet_if(rain, have_umbrella) has no matching
+        # end effect on wet_clothes, so it is kept as-is; house_wet's end effect value
+        # (wet_clothes) is substituted with that same interpreted-function expression
+        expected_gohome = InstantaneousAction("gohome")
+        expected_gohome.add_precondition(Not(athome))
+        expected_gohome.add_precondition(atwork)
+        expected_gohome.add_effect(athome, True)
+        expected_gohome.add_effect(atwork, False)
+        expected_gohome.add_effect(house_wet, wet_if(rain, have_umbrella))
+        expected_gohome.add_effect(wet_clothes, wet_if(rain, have_umbrella))
+
+        compiled_gohome = comp_res.problem.action("gohome")
+        self.assertEqual(expected_gohome, compiled_gohome)
+
+        sp = SequentialPlan(
+            [
+                comp_res.problem.action("takeumbrella")(),
+                compiled_gohome(),
+            ]
+        )
+        assert comp_res.plan_back_conversion is not None
+        mapped_back = comp_res.plan_back_conversion(sp)
+        expected_ttp = TimeTriggeredPlan(
+            [
+                (Fraction(0), problem.action("takeumbrella")(), Fraction(1)),
+                (Fraction(101, 100), problem.action("gohome")(), Fraction(20)),
+            ]
+        )
+        self.assertEqual(expected_ttp, mapped_back)
+        with TimeTriggeredPlanValidator() as validator:
+            val_result = validator.validate(problem, mapped_back)
+        self.assertEqual(val_result.status, ValidationResultStatus.VALID)
+
+    def test_interpreted_functions_in_durative_start_effects(self):
+        problem = self.problems[
+            "interpreted_functions_in_durative_start_effects"
+        ].problem
+        assert isinstance(problem, Problem)
+        self.assertTrue(TimedToSequential.supports(problem.kind))
+        t2s = TimedToSequential()
+        comp_res = t2s.compile(problem)
+        assert isinstance(comp_res.problem, Problem)
+        # the resulting kind is a sound over-approximation of the compiled problem's kind
+        self.assertTrue(
+            comp_res.problem.kind
+            <= TimedToSequential.resulting_problem_kind(problem.kind)
+        )
+
+        original_charge = problem.action("charge")
+        assert isinstance(original_charge, DurativeAction)
+        battery = problem.fluent("battery")
+        charged = problem.fluent("charged")
+        effect_values = [
+            oe.value for oel in original_charge.effects.values() for oe in oel
+        ]
+        boost_if = _get_interpreted_function(*effect_values)
+
+        # the start effect battery := boost_if(battery) is substituted into both the
+        # end-time condition (now a precondition) and the end-time effect on charged
+        expected_charge = InstantaneousAction("charge")
+        expected_charge.add_precondition(LT(battery, 10))
+        expected_charge.add_precondition(GE(boost_if(battery), 5))
+        expected_charge.add_effect(charged, GE(boost_if(battery), 5))
+        expected_charge.add_effect(battery, boost_if(battery))
+
+        compiled_charge = comp_res.problem.action("charge")
+        self.assertEqual(expected_charge, compiled_charge)
+
+        sp = SequentialPlan([compiled_charge()])
+        assert comp_res.plan_back_conversion is not None
+        mapped_back = comp_res.plan_back_conversion(sp)
+        expected_ttp = TimeTriggeredPlan(
+            [(Fraction(0), problem.action("charge")(), Fraction(8))]
+        )
+        self.assertEqual(expected_ttp, mapped_back)
+        with TimeTriggeredPlanValidator() as validator:
+            val_result = validator.validate(problem, mapped_back)
+        self.assertEqual(val_result.status, ValidationResultStatus.VALID)
 
     @skipIfNoOneshotPlannerForProblemKind(classical_kind)
     def test_logistic_with_planner_map_back_validity(self):


### PR DESCRIPTION
TimedToSequential.supported_kind() declared no INTERPRETED_FUNCTIONS_* feature, so compile() rejected any problem using interpreted functions even though the compiler's traversal (FreeVarsExtractor, Substituter, Simplifier) already handles interpreted-function expressions transparently, in conditions, effect values and durations.

Declare the five features, extend resulting_problem_kind() to soundly over-approximate the case where a start-effect value containing an interpreted function is substituted into an end-time condition or effect of a different kind, and add example/test coverage for interpreted functions in durative conditions, in a start effect substituted into an end condition and effect, and in a duration inequality.