### PR TITLE
fix(initial-state): stop initial_values from mutating explicit_initial_values

### DIFF
--- a/unified_planning/model/contingent/contingent_problem.py
+++ b/unified_planning/model/contingent/contingent_problem.py
@@ -149,7 +149,7 @@ class ContingentProblem(Problem):
 
         IMPORTANT NOTE: this property does a lot of computation, so it should be called as
         seldom as possible."""
-        res = self._initial_value
+        res = self._initial_value.copy()
         for f in self._fluents:
             for f_exp in get_all_fluent_exp(self, f):
                 if f_exp not in self._hidden_fluents:

--- a/unified_planning/model/mixins/initial_state.py
+++ b/unified_planning/model/mixins/initial_state.py
@@ -93,7 +93,7 @@ class InitialStateMixin:
         IMPORTANT NOTE: this property does a lot of computation, so it should be called as
         seldom as possible.
         """
-        res = self._initial_value
+        res = self._initial_value.copy()
         for f in self._fluent_set.fluents:
             for f_exp in get_all_fluent_exp(self._object_set, f):
                 value = self.initial_value(f_exp)

--- a/unified_planning/model/multi_agent/ma_problem.py
+++ b/unified_planning/model/multi_agent/ma_problem.py
@@ -261,7 +261,7 @@ class MultiAgentProblem(  # type: ignore[misc]
         IMPORTANT NOTE: this property does a lot of computation, so it should be called as
         seldom as possible.
         """
-        res = self._initial_value
+        res = self._initial_value.copy()
         for f in self.ma_environment.fluents:
             for f_exp in get_all_fluent_exp(self, f):
                 res[f_exp] = self.initial_value(f_exp)


### PR DESCRIPTION
## Summary
- `InitialStateMixin.initial_values` (`initial_state.py:88-102`) computed `res = self._initial_value`, an alias rather than a copy, then wrote every fluent's resolved value (including defaults from `initial_value()`) into `res`. Because `res` was the same dict object as `_initial_value`, simply reading `initial_values` had the side effect of permanently merging default-derived values into `_initial_value`.
- `explicit_initial_values` (`initial_state.py:104-114`) returns `_initial_value` directly and documents it as holding "only the initial values set with `set_initial_value`" — that invariant was silently violated after the first access to `initial_values`.
- The identical bug was independently reimplemented (not inherited from the mixin) in:
  - `ContingentProblem.initial_values` (`contingent/contingent_problem.py:146-159`)
  - `MultiAgentProblem.initial_values` (`multi_agent/ma_problem.py:256-273`)
- Fix: `res = self._initial_value.copy()` in all three so `initial_values` builds an independent dict and `_initial_value` / `explicit_initial_values` stay untouched.
- `explicit_initial_values` itself is left returning the live `_initial_value` reference, unchanged, as before.
