### PR TITLE
fix(timed-to-sequential): prune fluents left unreferenced by compilation

### DIFF
--- a/unified_planning/engines/compilers/timed_to_sequential.py
+++ b/unified_planning/engines/compilers/timed_to_sequential.py
@@ -30,10 +30,11 @@ from unified_planning.model import (
     ExpressionManager,
     Fluent,
     FNode,
+    MinimizeActionCosts,
 )
 from unified_planning.model.timing import StartTiming, EndTiming, Interval
 from unified_planning.model.problem_kind_versioning import LATEST_PROBLEM_KIND_VERSION
-from typing import Dict, Optional, List, Tuple, OrderedDict, cast
+from typing import Dict, Optional, List, Set, Tuple, OrderedDict, cast
 from fractions import Fraction
 from functools import partial
 from unified_planning.exceptions import (
@@ -49,12 +50,17 @@ from unified_planning.plans import (
     ActionInstance,
 )
 from unified_planning.model.problem_kind import FEATURES
+from unified_planning.engines.compilers.utils import remove_fluents
 from unified_planning.engines.sequential_simulator import UPSequentialSimulator
 
 
 def plan_back_conversion_callable(
-    sp: SequentialPlan, problem: Problem, new_problem: Problem, new_to_old: Dict
-):
+    sp: SequentialPlan,
+    problem: Problem,
+    new_problem: Problem,
+    new_to_old: Dict,
+    pruned_fluents: Set[Fluent],
+) -> TimeTriggeredPlan:
     if not isinstance(sp, SequentialPlan):
         raise UPUsageError("Plan to map back is not sequential")
     if problem.epsilon is not None:
@@ -64,6 +70,19 @@ def plan_back_conversion_callable(
     simulator = UPSequentialSimulator(new_problem)
     simplifier = Simplifier(problem.environment)
     fve = FreeVarsExtractor()
+    # NOTE the fluents pruned from the compiled problem are not part of its state
+    # anymore, so the ones still needed to compute a duration are resolved against
+    # the original problem. A pruned fluent is never written in the compiled problem
+    # and is never written in the original one either, so its initial value is its
+    # value at any point of the plan.
+    original_state = UPState(
+        {
+            fluent_exp: value
+            for fluent_exp, value in problem.explicit_initial_values.items()
+            if fluent_exp.fluent() in pruned_fluents
+        },
+        problem,
+    )
     state: Optional[State] = simulator.get_initial_state()
     assert isinstance(state, UPState)
     time_now = Fraction(0)
@@ -98,7 +117,10 @@ def plan_back_conversion_callable(
                     tlower_with_pars = tinterval.lower.substitute(par_sub_dict)
                     flu_subs_dict: Dict = {}
                     for flu_obj in fve.get(tlower_with_pars):
-                        flu_subs_dict[flu_obj] = state.get_value(flu_obj)
+                        if flu_obj.fluent() in pruned_fluents:
+                            flu_subs_dict[flu_obj] = original_state.get_value(flu_obj)
+                        else:
+                            flu_subs_dict[flu_obj] = state.get_value(flu_obj)
                     tlower_constant = simplifier.simplify(
                         tlower_with_pars.substitute(flu_subs_dict)
                     )
@@ -132,6 +154,9 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
     in end-time conditions/effects have their arguments rewritten by the start-time effect
     substitution, exactly like any other fluent-based expression.
 
+    The `TimedToSequential` class can also optionally take a flag `remove_unused_fluents` to
+    enable/disable the pruning of the fluents that become unused in the compiled problem.
+
     Note:
         Since a durative action's start and end collapse into a single instant, an interpreted
         function that the temporal semantics would evaluate once at start and once at end is
@@ -141,11 +166,16 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
         An interpreted function used in a duration is not part of the compiled (instantaneous)
         problem: it is re-evaluated by :func:`plan_back_conversion_callable` against the simulated
         state, so its callable must be able to handle whatever values are reachable in that state.
+        Fluents that only ever appear inside a duration expression become unused once the
+        duration is dropped from the compiled problem; such fluents are pruned from the compiled
+        problem (see :func:`~unified_planning.engines.compilers.utils.remove_fluents`) and are
+        instead resolved from the original problem's initial value when the duration is reconstructed.
     """
 
-    def __init__(self):
+    def __init__(self, remove_unused_fluents: bool = True):
         engines.engine.Engine.__init__(self)
         CompilerMixin.__init__(self, CompilationKind.TIMED_TO_SEQUENTIAL)
+        self._remove_unused_fluents = remove_unused_fluents
 
     @property
     def name(self):
@@ -446,6 +476,24 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
             new_to_old[new_action] = action
             new_problem.add_action(new_action)
 
+        # Fluents used only inside a duration expression (e.g. a fluent feeding a durative
+        # action's fixed duration) become unreferenced once the duration is dropped by the
+        # compilation above. `remove_unused_fluents` controls whether they get pruned:
+        # a fluent used only in a `MinimizeActionCosts` cost is always exempted, since
+        # `get_unused_fluents` deliberately reports it as unused too.
+        pruned_fluents: Set[Fluent] = set()
+        if self._remove_unused_fluents:
+            metric_exprs: List[FNode] = []
+            for qm in new_problem.quality_metrics:
+                if qm.is_minimize_action_costs():
+                    assert isinstance(qm, MinimizeActionCosts)
+                    metric_exprs.extend(qm.costs.values())
+                    if qm.default is not None:
+                        metric_exprs.append(qm.default)
+            fluents_in_metrics = {f.fluent() for e in metric_exprs for f in fve.get(e)}
+            pruned_fluents = new_problem.get_unused_fluents() - fluents_in_metrics
+            remove_fluents(new_problem, pruned_fluents)
+
         return CompilerResult(
             problem=new_problem,
             plan_back_conversion=partial(
@@ -453,6 +501,7 @@ class TimedToSequential(engines.engine.Engine, CompilerMixin):
                 problem=problem,
                 new_problem=new_problem,
                 new_to_old=new_to_old,
+                pruned_fluents=pruned_fluents,
             ),
             engine_name=self.name,
             map_back_action_instance=None,

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -29,6 +29,7 @@ from unified_planning.model import (
     Problem,
     Effect,
     Expression,
+    Fluent,
     BoolExpression,
     NumericConstant,
     SimulatedEffect,
@@ -52,6 +53,7 @@ from typing import (
     Optional,
     OrderedDict,
     Sequence,
+    Set,
     Tuple,
     Union,
     cast,
@@ -545,6 +547,27 @@ def updated_minimize_action_costs(
         else:
             new_costs[new_act] = environment.expression_manager.Int(0)
     return MinimizeActionCosts(new_costs, environment=environment)
+
+
+def remove_fluents(problem: Problem, fluents: Set[Fluent]) -> None:
+    """
+    Removes the given `fluents` from the given `problem`, together with their
+    default values and all their `initial values`.
+
+    This is meant to be used by a compiler on a problem it owns (typically a
+    clone of the original one).
+
+    :param problem: The `Problem` to remove the `fluents` from; modified in place.
+    :param fluents: The `fluents` to remove; must all belong to the given `problem`.
+    """
+    for fluent in fluents:
+        problem._fluents.remove(fluent)
+        problem._fluents_defaults.pop(fluent, None)
+    problem._initial_value = {
+        fluent_exp: value
+        for fluent_exp, value in problem._initial_value.items()
+        if fluent_exp.fluent() not in fluents
+    }
 
 
 def split_all_ands(exp_list: List[FNode]) -> List[FNode]:

--- a/unified_planning/test/test_t2s.py
+++ b/unified_planning/test/test_t2s.py
@@ -21,9 +21,13 @@ from unified_planning.test.examples import get_example_problems
 from unified_planning.model.problem_kind import classical_kind
 from unified_planning.engines.compilers.timed_to_sequential import TimedToSequential
 from unified_planning.plans import SequentialPlan, TimeTriggeredPlan
-from unified_planning.engines.results import ValidationResultStatus
+from unified_planning.engines.results import (
+    ValidationResultStatus,
+    POSITIVE_OUTCOMES,
+)
 from unified_planning.engines.plan_validator import TimeTriggeredPlanValidator
 from unified_planning.model.walkers import InterpretedFunctionsExtractor
+from unified_planning.io import PDDLWriter
 from fractions import Fraction
 
 
@@ -145,6 +149,13 @@ class TestT2S(unittest_TestCase):
         self.assertTrue(problem.kind.has_continuous_time())
         self.assertFalse(comp_res.problem.kind.has_continuous_time())
 
+        # distance/velocity are only used in the move action's duration, which is
+        # dropped by this compilation; since they become unreferenced, they must be
+        # pruned from the compiled problem
+        compiled_fluent_names = {f.name for f in comp_res.problem.fluents}
+        self.assertNotIn("distance", compiled_fluent_names)
+        self.assertNotIn("velocity", compiled_fluent_names)
+
         compiled_move = comp_res.problem.action("move")
         Robot = problem.user_type("Robot")
         Location = problem.user_type("Location")
@@ -248,6 +259,11 @@ class TestT2S(unittest_TestCase):
         comp_res = t2s.compile(problem)
         assert isinstance(comp_res.problem, Problem)
 
+        # normaltime is only used inside the interpreted function call that computes
+        # gohome's duration; once the duration is dropped it becomes unreferenced and
+        # must be pruned, same as distance/velocity in test_logistic
+        self.assertNotIn("normaltime", {f.name for f in comp_res.problem.fluents})
+
         original_gohome = problem.action("gohome")
         assert isinstance(original_gohome, DurativeAction)
         athome = problem.fluent("athome")
@@ -349,8 +365,105 @@ class TestT2S(unittest_TestCase):
         assert isinstance(comp_res.problem, Problem)
         with OneshotPlanner(problem_kind=comp_res.problem.kind) as planner:
             plan_result = planner.solve(comp_res.problem)
+        self.assertIn(
+            plan_result.status,
+            POSITIVE_OUTCOMES,
+            f"Planner failed to solve the problem: {plan_result.log_messages}",
+        )
         assert comp_res.plan_back_conversion is not None
         found_plan_mapped_back = comp_res.plan_back_conversion(plan_result.plan)
         with TimeTriggeredPlanValidator() as validator:
             val_result = validator.validate(original_problem, found_plan_mapped_back)
         self.assertEqual(val_result.status, ValidationResultStatus.VALID)
+
+    def test_fluent_used_only_in_action_cost_metric_is_not_pruned(self):
+        # get_unused_fluents() deliberately reports a fluent used only in a
+        # MinimizeActionCosts cost as unused; without an explicit guard it would
+        # wrongly be pruned away even though the metric still needs it
+        problem = Problem("cost_over_static")
+        rate = Fluent("rate", IntType())
+        problem.add_fluent(rate)
+        problem.set_initial_value(rate, 5)
+
+        x = Fluent("x", IntType())
+        problem.add_fluent(x, default_initial_value=0)
+        mv = InstantaneousAction("mv")
+        mv.add_increase_effect(x, 1)
+        problem.add_action(mv)
+        problem.add_quality_metric(MinimizeActionCosts({mv: rate}))
+
+        t2s = TimedToSequential()
+        comp_res = t2s.compile(problem)
+        assert isinstance(comp_res.problem, Problem)
+        self.assertIn("rate", {f.name for f in comp_res.problem.fluents})
+
+    def test_object_fluent_nested_in_duration_is_pruned_and_resolves(self):
+        # OBJECT_FLUENTS: a duration expression where a fluent is nested inside
+        # another fluent's arguments (dist(l1, tgt(l1))) must keep resolving
+        # correctly at map-back time once both fluents are pruned
+        Location = UserType("Location")
+        l1 = Object("l1", Location)
+        l2 = Object("l2", Location)
+
+        tgt = Fluent("tgt", Location, l=Location)
+        dist = Fluent("dist", IntType(), a=Location, b=Location)
+
+        problem = Problem("nested_duration")
+        problem.add_objects([l1, l2])
+        problem.add_fluent(tgt)
+        problem.add_fluent(dist, default_initial_value=7)
+        problem.set_initial_value(tgt(l1), l2)
+
+        mv = DurativeAction("mv")
+        mv.set_fixed_duration(dist(l1, tgt(l1)))
+        problem.add_action(mv)
+
+        t2s = TimedToSequential()
+        t2s.skip_checks = True
+        comp_res = t2s.compile(problem)
+        assert isinstance(comp_res.problem, Problem)
+        compiled_fluent_names = {f.name for f in comp_res.problem.fluents}
+        self.assertNotIn("tgt", compiled_fluent_names)
+        self.assertNotIn("dist", compiled_fluent_names)
+
+        sp = SequentialPlan([comp_res.problem.action("mv")()])
+        assert comp_res.plan_back_conversion is not None
+        mapped_back = comp_res.plan_back_conversion(sp)
+        expected_ttp = TimeTriggeredPlan([(Fraction(0), mv(), Fraction(7))])
+        self.assertEqual(expected_ttp, mapped_back)
+
+    def test_remove_unused_fluents_flag(self):
+        # "speed" is only read by the duration expression, so it is unreferenced in the
+        # compiled problem: the default prunes it, remove_unused_fluents=False keeps it.
+        # Either way the duration must be reconstructed identically, from the original
+        # problem's initial value when pruned and from the simulated state when not.
+        problem = Problem("duration_only_fluent")
+        speed = Fluent("speed", IntType())
+        problem.add_fluent(speed)
+        problem.set_initial_value(speed, 3)
+        done = Fluent("done", BoolType())
+        problem.add_fluent(done, default_initial_value=False)
+
+        act = DurativeAction("act")
+        act.set_fixed_duration(speed())
+        act.add_effect(EndTiming(), done, True)
+        problem.add_action(act)
+        problem.add_goal(done())
+
+        self.assertTrue(TimedToSequential.supports(problem.kind))
+
+        pruning_res = TimedToSequential().compile(problem)
+        assert isinstance(pruning_res.problem, Problem)
+        self.assertNotIn("speed", {f.name for f in pruning_res.problem.fluents})
+
+        keeping_res = TimedToSequential(remove_unused_fluents=False).compile(problem)
+        assert isinstance(keeping_res.problem, Problem)
+        self.assertIn("speed", {f.name for f in keeping_res.problem.fluents})
+        self.assertEqual(Int(3), keeping_res.problem.initial_value(speed()))
+
+        expected_ttp = TimeTriggeredPlan([(Fraction(0), act(), Fraction(3))])
+        for comp_res in (pruning_res, keeping_res):
+            assert isinstance(comp_res.problem, Problem)
+            assert comp_res.plan_back_conversion is not None
+            sp = SequentialPlan([comp_res.problem.action("act")()])
+            self.assertEqual(expected_ttp, comp_res.plan_back_conversion(sp))


### PR DESCRIPTION
## Summary
- `TimedToSequential` left fluents that only fed a (now-dropped) duration
  expression declared in the compiled problem, unreferenced.
- `_compile` now prunes any fluent left unused in the compiled problem
  (excluding ones used only in a `MinimizeActionCosts` cost), and
  `plan_back_conversion_callable` resolves a pruned fluent's duration-time
  value from the original problem's initial value.
- Added a `remove_unused_fluents: bool = True` constructor flag to disable
  this pruning and restore the previous behavior.

Fixes #768