### PR TITLE
fix(compilers): normalize effect targets consistently across grounding, validation, and simulation

### DIFF
--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -34,6 +34,7 @@ from unified_planning.model.problem_kind_versioning import LATEST_PROBLEM_KIND_V
 from unified_planning.engines.compilers.utils import (
     lift_action_instance,
     create_action_with_given_subs,
+    normalize_ground_action_effects,
     split_all_ands,
 )
 from typing import Dict, List, Optional, Set, Tuple, Iterator, cast
@@ -139,7 +140,9 @@ class GrounderHelper:
                     self._grounding_actions_map is None
                     or self._grounding_actions_map.get(action, None) is not None
                 ):
-                    new_action = action.clone()
+                    new_action = normalize_ground_action_effects(
+                        self._problem, action.clone(), self._simplifier
+                    )
                 else:
                     new_action = None
             else:

--- a/unified_planning/engines/compilers/ks0_compiler.py
+++ b/unified_planning/engines/compilers/ks0_compiler.py
@@ -474,7 +474,11 @@ class Ks0Compiler(engines.engine.Engine, CompilerMixin):
             normalized_problem = disjunction_result.problem
             normalization_results.append(disjunction_result)
 
-        grounder = Grounder()
+        # prune_actions=False: this problem's declared initial values are just
+        # placeholders (the real semantics come from the possible_initial_states
+        # supplied to the compiler), so a fluent that happens to be static here
+        # must not be folded into its declared initial value.
+        grounder = Grounder(prune_actions=False)
         grounder.skip_checks = True
         grounding_result = grounder.compile(
             normalized_problem, CompilationKind.GROUNDING

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -154,6 +154,77 @@ def create_effect_with_given_subs(
         )
 
 
+def normalize_ground_action_effects(
+    problem: Problem,
+    action: Action,
+    simplifier,
+) -> Optional[Action]:
+    """
+    Rebuilds the effects (and simulated effect(s)) of an already parameter-less
+    action (typically a clone of an action that had no parameters to begin with,
+    so it never goes through :func:`create_action_with_given_subs`) through
+    :func:`create_effect_with_given_subs` with an empty substitution.
+
+    This gives the action the same target/value/condition normalization applied
+    to actions that do have parameters, and re-runs the conflicting-effects check
+    that a plain ``clone()`` bypasses, since it copies the conflict-checking
+    bookkeeping verbatim instead of re-adding each effect.
+
+    :param problem: The `Problem` the action belongs to.
+    :param action: The parameter-less action to normalize; it is mutated in place.
+    :param simplifier: The `Simplifier` used to normalize effect targets/values/conditions.
+    :return: The same `action`, mutated, or `None` if the normalized effects (or
+        simulated effect) conflict with each other.
+    """
+    empty_subs: Dict[Expression, Expression] = {}
+    if isinstance(action, InstantaneousAction):
+        old_effects = list(action.effects)
+        old_simulated_effect = action.simulated_effect
+        action.clear_effects()
+        for old_effect in old_effects:
+            new_effect = create_effect_with_given_subs(
+                problem, old_effect, simplifier, empty_subs
+            )
+            if new_effect is not None:
+                try:
+                    action._add_effect_instance(new_effect)
+                except UPConflictingEffectsException:
+                    return None
+        if old_simulated_effect is not None:
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    action.set_simulated_effect(old_simulated_effect)
+            except UPConflictingEffectsException:
+                return None
+        return action
+    elif isinstance(action, DurativeAction):
+        old_effects_by_timing = {t: list(el) for t, el in action.effects.items()}
+        old_simulated_effects = dict(action.simulated_effects)
+        action.clear_effects()
+        for timing, effects_list in old_effects_by_timing.items():
+            for old_effect in effects_list:
+                new_effect = create_effect_with_given_subs(
+                    problem, old_effect, simplifier, empty_subs
+                )
+                if new_effect is not None:
+                    try:
+                        action._add_effect_instance(timing, new_effect)
+                    except UPConflictingEffectsException:
+                        return None
+        for timing, old_simulated_effect in old_simulated_effects.items():
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    action.set_simulated_effect(timing, old_simulated_effect)
+            except UPConflictingEffectsException:
+                return None
+        return action
+    else:
+        # Unknown/unsupported action type: leave it untouched
+        return action
+
+
 def create_action_with_given_subs(
     problem: Problem,
     old_action: Action,

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -137,10 +137,16 @@ def create_effect_with_given_subs(
     simplifier,
     subs: Dict[Expression, Expression],
 ) -> Optional[Effect]:
+    em = problem.environment.expression_manager
     new_fluent = old_effect.fluent.substitute(subs)
+    if new_fluent.is_fluent_exp():
+        new_fluent = em.FluentExp(
+            new_fluent.fluent(),
+            tuple(simplifier.simplify(a) for a in new_fluent.args),
+        )
     new_value = simplifier.simplify(old_effect.value.substitute(subs))
     new_condition = simplifier.simplify(old_effect.condition.substitute(subs))
-    if new_condition == problem.environment.expression_manager.FALSE():
+    if new_condition == em.FALSE():
         return None
     else:
         return Effect(

--- a/unified_planning/engines/plan_validator.py
+++ b/unified_planning/engines/plan_validator.py
@@ -421,6 +421,13 @@ class TimeTriggeredPlanValidator(engines.engine.Engine, mixins.PlanValidatorMixi
                 state, se, self._ground_expression(instantiated_effect.condition, ai)
             ):
                 g_fluent = self._ground_expression(instantiated_effect.fluent, ai)
+                if g_fluent.is_fluent_exp():
+                    # The target's arguments must be evaluated in the current state, as the
+                    # UPSequentialSimulator does, otherwise the update is stored under a
+                    # non-normalized key that no read matches.
+                    g_fluent = g_fluent.fluent()(
+                        *(se.evaluate(arg, state=state) for arg in g_fluent.args)
+                    )
                 g_value = self._ground_expression(instantiated_effect.value, ai)
                 if instantiated_effect.kind == EffectKind.ASSIGN:
                     result[g_fluent] = se.evaluate(g_value, state=state)

--- a/unified_planning/engines/sequential_simulator.py
+++ b/unified_planning/engines/sequential_simulator.py
@@ -107,7 +107,12 @@ class UPSequentialSimulator(Engine, SequentialSimulatorMixin):
             else:
                 warn(msg)
         assert isinstance(self._problem, up.model.Problem)
-        self._grounder = GrounderHelper(problem)
+        # prune_actions=False: a fluent that never appears as an effect target is
+        # "static" and would otherwise be folded into its declared initial value,
+        # but the simulator must also support simulating from States that assign
+        # such a fluent a different value (e.g. one of several hypothetical
+        # initial states in a conformant setting), not just the declared one.
+        self._grounder = GrounderHelper(problem, prune_actions=False)
         self._actions = set(self._problem.actions)
         self._se = StateEvaluator(self._problem)
         self._initial_state: Optional[UPState] = None

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -337,6 +337,37 @@ class TestGrounder(unittest_TestCase):
         self.assertEqual(grounded_problem.actions[0].name, "act_a")
         self.assertEqual(len(grounded_problem.actions[0].parameters), 0)
 
+    def test_effect_target_arguments_are_simplified(self):
+        # the effect's target fluent must be normalized like its value: f(x + 1) grounded
+        # with x := 1 must become f(2), not the unevaluated f((1 + 1)). A second effect on
+        # the constant f(2) makes x = 1 target the same fluent instance twice with different
+        # values, so that grounding must be dropped as conflicting-effects, exactly like it
+        # would be if the first effect had been written as f(2) directly.
+        f = Fluent("f", IntType(), i=IntType(0, 3))
+        action = InstantaneousAction("act", x=IntType(0, 2))
+        x = action.parameter("x")
+        action.add_effect(f(Plus(x, 1)), Plus(x, 1))
+        action.add_effect(f(Int(2)), 99)
+
+        problem = Problem("arith_target")
+        problem.add_fluent(f, default_initial_value=0)
+        problem.add_action(action)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        # act_1 (x = 1) is dropped: f(1 + 1) and f(2) conflict once both are simplified to f(2)
+        self.assertEqual(len(grounded_problem.actions), 2)
+        em = problem.environment.expression_manager
+        for i in (0, 2):
+            a = cast(InstantaneousAction, grounded_problem.action(f"act_{i}"))
+            first_effect, second_effect = a.effects
+            self.assertEqual(first_effect.fluent, f(em.Int(i + 1)))
+            self.assertEqual(first_effect.value, em.Int(i + 1))
+            self.assertEqual(second_effect.fluent, f(em.Int(2)))
+            self.assertEqual(second_effect.value, em.Int(99))
+
     @skipIfEngineNotAvailable("pyperplan")
     def test_pyperplan_grounder(self):
         problem = self.problems["robot_no_negative_preconditions"].problem

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -14,6 +14,7 @@
 #
 
 from typing import cast
+import warnings
 import unified_planning
 from unified_planning.shortcuts import *
 from unified_planning.model.problem_kind import (
@@ -367,6 +368,102 @@ class TestGrounder(unittest_TestCase):
             self.assertEqual(first_effect.value, em.Int(i + 1))
             self.assertEqual(second_effect.fluent, f(em.Int(2)))
             self.assertEqual(second_effect.value, em.Int(99))
+
+    def test_zero_parameter_action_effect_target_is_normalized(self):
+        # a zero-parameter action is never routed through create_action_with_given_subs
+        # (there is nothing to substitute), so its effects must still be normalized
+        # explicitly; otherwise a hand-written f(1 + 1) target survives grounding unevaluated.
+        f = Fluent("f", IntType(), i=IntType(0, 3))
+        action = InstantaneousAction("act")
+        action.add_effect(f(Plus(Int(1), Int(1))), 1)
+
+        problem = Problem("zero_param_arith_target")
+        problem.add_fluent(f, default_initial_value=0)
+        problem.add_action(action)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(len(grounded_problem.actions), 1)
+        # the action keeps its original name: normalization must not reroute it through
+        # get_fresh_name, which would rename it to "act_0".
+        ga = cast(InstantaneousAction, grounded_problem.action("act"))
+        em = problem.environment.expression_manager
+        (effect,) = ga.effects
+        self.assertEqual(effect.fluent, f(em.Int(2)))
+        self.assertEqual(effect.value, em.Int(1))
+
+    def test_zero_parameter_action_conflicting_effects_are_detected(self):
+        # same shape as test_effect_target_arguments_are_simplified, but with zero
+        # parameters: the un-normalized target of the first effect must not let the
+        # conflict with the second effect's f(2) go undetected.
+        f = Fluent("f", IntType(), i=IntType(0, 3))
+        action = InstantaneousAction("act")
+        action.add_effect(f(Plus(Int(1), Int(1))), 1)
+        action.add_effect(f(Int(2)), 99)
+
+        problem = Problem("zero_param_conflict")
+        problem.add_fluent(f, default_initial_value=0)
+        problem.add_action(action)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(len(grounded_problem.actions), 0)
+
+    def test_zero_parameter_action_simulated_effect_survives_normalization(self):
+        # normalizing effects clears and rebuilds the action's bookkeeping, which also
+        # wipes any simulated effect; it must be restored afterwards.
+        f = Fluent("f", IntType())
+        x = Fluent("x", IntType())
+        action = InstantaneousAction("act")
+        action.add_effect(f(), 1)
+
+        def fun(problem, state, actual_params):
+            return [Int(0)]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            action.set_simulated_effect(SimulatedEffect([FluentExp(x)], fun))
+
+        problem = Problem("zero_param_simulated")
+        problem.add_fluent(f, default_initial_value=0)
+        problem.add_fluent(x, default_initial_value=1)
+        problem.add_action(action)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(len(grounded_problem.actions), 1)
+        ga = cast(InstantaneousAction, grounded_problem.action("act"))
+        self.assertIsNotNone(ga.simulated_effect)
+
+    def test_zero_parameter_durative_action_effect_target_is_normalized(self):
+        # durative-action variant of test_zero_parameter_action_effect_target_is_normalized:
+        # the target must be normalized at its own timing, and the duration left untouched.
+        f = Fluent("f", IntType(), i=IntType(0, 3))
+        action = DurativeAction("act")
+        action.set_fixed_duration(1)
+        action.add_effect(EndTiming(), f(Plus(Int(1), Int(1))), 1)
+
+        problem = Problem("zero_param_durative_arith_target")
+        problem.add_fluent(f, default_initial_value=0)
+        problem.add_action(action)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(len(grounded_problem.actions), 1)
+        ga = cast(DurativeAction, grounded_problem.action("act"))
+        self.assertEqual(ga.duration, action.duration)
+        em = problem.environment.expression_manager
+        (effect,) = ga.effects[EndTiming()]
+        self.assertEqual(effect.fluent, f(em.Int(2)))
+        self.assertEqual(effect.value, em.Int(1))
 
     @skipIfEngineNotAvailable("pyperplan")
     def test_pyperplan_grounder(self):

--- a/unified_planning/test/test_plan_validator.py
+++ b/unified_planning/test/test_plan_validator.py
@@ -407,6 +407,26 @@ class TestProblem(unittest_TestCase):
             validation_result = ttv.validate(problem, plan)
             self.assertEqual(validation_result.status, ValidationResultStatus.INVALID)
 
+    def test_time_triggered_effect_target_arguments_are_evaluated(self):
+        # an effect's target fluent arguments must be evaluated in the current state, exactly
+        # like its value: f(x + 1) applied with x := 1 must update f(2), matching what the goal
+        # f(2) == 5 reads, not the un-evaluated f((1 + 1))
+        f = Fluent("f", IntType(0, 5), i=IntType(0, 3))
+        action = DurativeAction("act", x=IntType(1, 1))
+        x = action.parameter("x")
+        action.set_fixed_duration(1)
+        action.add_effect(EndTiming(), f(Plus(x, 1)), 5)
+
+        problem = Problem("ttp_target")
+        problem.add_fluent(f, default_initial_value=0)
+        problem.add_action(action)
+        problem.add_goal(Equals(f(2), 5))
+
+        plan = up.plans.TimeTriggeredPlan([(Fraction(0), action(Int(1)), Fraction(1))])
+        ttv = TimeTriggeredPlanValidator(environment=get_environment())
+        validation_result = ttv.validate(problem, plan)
+        self.assertEqual(validation_result.status, ValidationResultStatus.VALID)
+
     def test_with_interpreted_functions_sequential(self):
         spv = SequentialPlanValidator(environment=get_environment())
 


### PR DESCRIPTION
## Issues found

1. **Effect targets were substituted but never simplified.**
   `create_effect_with_given_subs` (the grounder) rebuilt an effect's target
   fluent by substitution alone, unlike its value and condition. A grounded
   action could end up with a target like `f((1 + 1))` instead of `f(2)`,
   which matches no fluent instance in the problem and silently defeats the
   conflicting-effects check, since that check keys on the target
   expression. `TimeTriggeredPlanValidator._apply_effect` had the same
   asymmetry: it substituted the target but never evaluated its arguments
   against the state, so it could store an update under a key no read would
   ever match — losing the effect and missing conflicts, and potentially
   reporting a valid plan as INVALID.

2. **Zero-parameter actions skipped that fix entirely.**
   `GrounderHelper.ground_action` short-circuits actions with no parameters
   to a plain `action.clone()`, since there's nothing to substitute — but
   that also means it never reaches `create_effect_with_given_subs`. A
   zero-parameter action with a target like `f(1 + 1)` kept the unevaluated
   arithmetic after grounding, and a conflicting second effect on `f(2)`
   went undetected, while the identical action with an unused parameter
   added was grounded and conflict-checked correctly. Output differed
   purely by arity.

3. **Ks0Compiler and UPSequentialSimulator treated placeholder initial
   values as real.**
   Fixing 2. made zero-parameter actions go through the same simplification
   as parameterized ones — including `Grounder`'s default
   `prune_actions=True`, which folds any fluent that's never an effect
   target ("static") into its *declared* initial value wherever it's
   referenced. That's unsound whenever the declared value is only a
   placeholder:
   - `Ks0Compiler` grounds a template problem this way before encoding it
     for several externally supplied `possible_initial_states`; the
     template's own declared initial values are meaningless placeholders,
     so a conditional effect guarded by such a fluent could be folded away
     entirely.
   - `UPSequentialSimulator` built its internal `GrounderHelper` with the
     same default, so a fluent never written by any action was assumed to
     permanently equal its declared initial value, even when simulating
     from a caller-supplied `State` that deliberately assigns it something
     else (e.g. one of several hypothetical initial states). This already
     misbehaved for parameterized actions before this change — it just had
     no test exercising it until the zero-parameter path became reachable.

## Solution

- Simplify the target fluent's arguments in `create_effect_with_given_subs`,
  and evaluate them against the state in
  `TimeTriggeredPlanValidator._apply_effect`, mirroring what
  `UPSequentialSimulator` already did correctly.
- Add `normalize_ground_action_effects`, which rebuilds a zero-parameter
  action's effects (and restores its simulated effect) through the same
  normalization path and re-adds them via `_add_effect_instance` so
  conflicts are re-checked. `GrounderHelper` now runs the zero-parameter
  clone through it instead of using it verbatim.
- Construct `Ks0Compiler`'s and `UPSequentialSimulator`'s internal
  grounder with `prune_actions=False`, since neither can safely assume a
  fluent's declared initial value is the value that actually holds at
  runtime.