### PR TITLE
fix(kind): close blind spots where features silently miss Problem.kind

### DIFF
--- a/unified_planning/model/htn/hierarchical_problem.py
+++ b/unified_planning/model/htn/hierarchical_problem.py
@@ -119,7 +119,11 @@ class HierarchicalProblem(up.model.problem.Problem):
         for m in self.methods:
             remove_used_fluents(*m.preconditions)
             remove_used_fluents(*m.constraints)
+            for st in m.subtasks:
+                remove_used_fluents(*st.parameters)
         remove_used_fluents(*self.task_network.constraints)
+        for st in self.task_network.subtasks:
+            remove_used_fluents(*st.parameters)
 
         return unused_fluents
 
@@ -148,6 +152,8 @@ class HierarchicalProblem(up.model.problem.Problem):
             factory.kind.set_hierarchical("INITIAL_TASK_NETWORK_VARIABLES")
         if len(self.task_network.non_temporal_constraints()) > 0:
             factory.kind.set_hierarchical("TASK_NETWORK_CONSTRAINTS")
+            for tn_constraint in self.task_network.non_temporal_constraints():
+                factory.update_problem_kind_expression(tn_constraint)
 
         for method in self.methods:
             ordering_kind = max(ordering_kind, lvl(method))
@@ -156,6 +162,8 @@ class HierarchicalProblem(up.model.problem.Problem):
                 factory.update_problem_kind_expression(method_cond)
             if len(method.non_temporal_constraints()) > 0:
                 factory.kind.set_hierarchical("TASK_NETWORK_CONSTRAINTS")
+                for method_constraint in method.non_temporal_constraints():
+                    factory.update_problem_kind_expression(method_constraint)
 
         if ordering_kind == TO:
             factory.kind.set_hierarchical("TASK_ORDER_TOTAL")

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -346,6 +346,7 @@ class Problem(  # type: ignore[misc]
                     for f in a.simulated_effect.fluents:
                         static_fluents.discard(f.fluent())
             elif isinstance(a, up.model.action.DurativeAction):
+                remove_used_fluents(a.duration.lower, a.duration.upper)
                 for cl in a.conditions.values():
                     remove_used_fluents(*cl)
                 for el in a.effects.values():
@@ -709,6 +710,13 @@ class Problem(  # type: ignore[misc]
             factory.kind.set_time("TIMED_EFFECTS")
         for process in self._processes:
             factory.update_problem_kind_process(process)
+        for event in self._events:
+            for param in event.parameters:
+                factory.update_action_parameter(param)
+            for precondition in event.preconditions:
+                factory.update_problem_kind_expression(precondition)
+            for effect in event.effects:
+                factory.update_problem_kind_effect(effect)
         for effect in chain(*self._timed_effects.values()):
             factory.update_problem_kind_effect(effect)
         if len(self._timed_goals) > 0:
@@ -719,6 +727,7 @@ class Problem(  # type: ignore[misc]
                 factory.kind.set_constraints_kind("STATE_INVARIANTS")
             else:
                 factory.kind.set_constraints_kind("TRAJECTORY_CONSTRAINTS")
+            factory.update_problem_kind_expression(tc)
         for goal in chain(*self._timed_goals.values(), self._goals):
             factory.update_problem_kind_expression(goal)
         factory.update_problem_kind_initial_state(self)
@@ -832,7 +841,6 @@ class _KindFactory:
         # We declare it as a Problem to avoid limitations of the python type system
         self.pb: up.model.Problem = pb
         self.static_fluents: Set[Fluent] = pb.get_static_fluents()
-        self.unused_fluents: Set[Fluent] = pb.get_unused_fluents()
 
         self.environment: up.Environment = environment
         self.kind: up.model.ProblemKind = up.model.ProblemKind(
@@ -896,6 +904,11 @@ class _KindFactory:
         value = e.value
         fluents_in_value = self.environment.free_vars_extractor.get(value)
         ops = self.operators_extractor.get(value)
+        for arg in e.fluent.args:
+            fluents_in_value = (
+                fluents_in_value | self.environment.free_vars_extractor.get(arg)
+            )
+            ops = ops | self.operators_extractor.get(arg)
         if e.is_conditional():
             self.update_problem_kind_expression(e.condition)
             self.kind.set_effects_kind("CONDITIONAL_EFFECTS")
@@ -904,6 +917,8 @@ class _KindFactory:
                 self.kind.unset_problem_type("SIMPLE_NUMERIC_PLANNING")
         if e.is_forall():
             self.kind.set_effects_kind("FORALL_EFFECTS")
+            for v in e.forall:
+                self.update_problem_kind_type(v.type)
         if e.is_increase():
             self.kind.set_effects_kind("INCREASE_EFFECTS")
             # If the value is a number (int or real) and it violates the constraint
@@ -922,6 +937,10 @@ class _KindFactory:
                     self.kind.unset_problem_type("SIMPLE_NUMERIC_PLANNING")
             else:
                 self.kind.unset_problem_type("SIMPLE_NUMERIC_PLANNING")
+                if OperatorKind.INTERPRETED_FUNCTION_EXP in ops:
+                    self.kind.set_effects_kind(
+                        "INTERPRETED_FUNCTIONS_IN_NUMERIC_ASSIGNMENTS"
+                    )
                 if any(f in self.static_fluents for f in fluents_in_value):
                     self.kind.set_effects_kind("STATIC_FLUENTS_IN_NUMERIC_ASSIGNMENTS")
                 if any(f not in self.static_fluents for f in fluents_in_value):
@@ -944,6 +963,10 @@ class _KindFactory:
                     self.kind.unset_problem_type("SIMPLE_NUMERIC_PLANNING")
             else:
                 self.kind.unset_problem_type("SIMPLE_NUMERIC_PLANNING")
+                if OperatorKind.INTERPRETED_FUNCTION_EXP in ops:
+                    self.kind.set_effects_kind(
+                        "INTERPRETED_FUNCTIONS_IN_NUMERIC_ASSIGNMENTS"
+                    )
                 if any(f in self.static_fluents for f in fluents_in_value):
                     self.kind.set_effects_kind("STATIC_FLUENTS_IN_NUMERIC_ASSIGNMENTS")
                 if any(f not in self.static_fluents for f in fluents_in_value):
@@ -1020,10 +1043,11 @@ class _KindFactory:
         fluent: "up.model.fluent.Fluent",
     ):
         type = fluent.type
-        if fluent not in self.unused_fluents or (
-            not type.is_int_type() and not type.is_real_type()
-        ):
-            self.update_problem_kind_type(type)
+        # A fluent contributes its declared type to kind regardless of whether it is ever
+        # referenced by any expression: an engine still needs to be able to represent it (and,
+        # for a compiled problem, still has to parse its still-declared initial value), even if
+        # nothing reads or writes it anymore.
+        self.update_problem_kind_type(type)
         if type.is_int_type() or type.is_real_type():
             numeric_type = type
             assert isinstance(
@@ -1034,12 +1058,11 @@ class _KindFactory:
                 or numeric_type.upper_bound is not None
             ):
                 self.kind.set_numbers("BOUNDED_TYPES")
-            if fluent not in self.unused_fluents:
-                if type.is_int_type():
-                    self.kind.set_fluents_type("INT_FLUENTS")
-                else:
-                    assert type.is_real_type()
-                    self.kind.set_fluents_type("REAL_FLUENTS")
+            if type.is_int_type():
+                self.kind.set_fluents_type("INT_FLUENTS")
+            else:
+                assert type.is_real_type()
+                self.kind.set_fluents_type("REAL_FLUENTS")
         elif type.is_user_type():
             self.kind.set_fluents_type("OBJECT_FLUENTS")
         for param in fluent.signature:
@@ -1269,6 +1292,7 @@ class _KindFactory:
                         raise UPProblemDefinitionError(
                             "The cost of an Action can't be None."
                         )
+                    self.update_problem_kind_expression(cost)
                     t = cost.type
                     if t.is_int_type():
                         self.kind.set_actions_cost_kind("INT_NUMBERS_IN_ACTIONS_COST")

--- a/unified_planning/test/test_htn.py
+++ b/unified_planning/test/test_htn.py
@@ -32,6 +32,18 @@ class TestProblem(unittest_TestCase):
         unittest_TestCase.setUp(self)
         self.problems = get_example_problems()
 
+    def test_subtask_argument_fluent_is_not_unused(self):
+        # a fluent used only as a subtask's argument (never in a method/task-network
+        # precondition or constraint) must not be reported as unused
+        htn = up.model.htn.HierarchicalProblem()
+        Location = UserType("Location")
+        l1 = htn.add_object("l1", Location)
+        loc = Fluent("loc", Location)
+        htn.add_fluent(loc, default_initial_value=l1)
+        check = htn.add_task("check", target=Location)
+        htn.task_network.add_subtask(check, loc())
+        self.assertNotIn(loc, htn.get_unused_fluents())
+
     def test_htn_problem_creation(self):
         problems = examples.hierarchical.get_example_problems()
         problem = problems["htn-go"].problem

--- a/unified_planning/test/test_problem.py
+++ b/unified_planning/test/test_problem.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+from collections import OrderedDict
+
 import unified_planning as up
 from unified_planning.shortcuts import *
 from unified_planning.test import unittest_TestCase, main, examples
@@ -534,6 +536,13 @@ class TestProblem(unittest_TestCase):
             "sched:optional_activities_effects",
             "1d_Movement",
             "boiling_water",
+            "robot_with_durative_action",
+            "robot_with_static_fluents_duration_timed_goals",
+            "logistic",
+            "robot_with_variable_duration",
+            "matchcellar_static_duration",
+            "locations_connected_cost_minimize",
+            "go_home_with_rain_and_interpreted_functions",
         ]
         for example in self.problems.values():
             problem = example.problem
@@ -546,6 +555,115 @@ class TestProblem(unittest_TestCase):
                 self.assertFalse(
                     problem.kind.has_simple_numeric_planning(), problem.name
                 )
+
+    def test_effect_target_interpreted_function_kind(self):
+        # value(choose()) := 9 : the interpreted function is in the effect's TARGET
+        # arguments, not its value; it must still be visible to kind computation.
+        Obj = UserType("Obj")
+        o1 = Object("o1", Obj)
+        choose = InterpretedFunction("choose", Obj, OrderedDict(), lambda: o1)
+        value = Fluent("value", IntType(), o=Obj)
+        a = InstantaneousAction("act")
+        a.add_effect(value(choose()), 9)
+        problem = Problem("effect_target_if")
+        problem.add_fluent(value, default_initial_value=0)
+        problem.add_object(o1)
+        problem.add_action(a)
+        self.assertTrue(problem.kind.has_interpreted_functions_in_numeric_assignments())
+
+    def test_increase_effect_interpreted_function_kind(self):
+        # the assignment branch already checked for interpreted functions in the value;
+        # increase/decrease effects did not.
+        sig = OrderedDict()
+        sig["x"] = IntType()
+        double_if = InterpretedFunction("double", IntType(), sig, lambda x: x * 2)
+        counter = Fluent("counter", IntType())
+        a = InstantaneousAction("inc")
+        a.add_increase_effect(counter, double_if(counter))
+        problem = Problem("increase_if")
+        problem.add_fluent(counter, default_initial_value=1)
+        problem.add_action(a)
+        self.assertTrue(problem.kind.has_interpreted_functions_in_numeric_assignments())
+
+    def test_declared_unreferenced_numeric_fluent_kind(self):
+        # a fluent that is declared but never appears in any effect/condition/goal/duration
+        # must still contribute its type to kind (the direct fix for issue #768)
+        unused = Fluent("unused", RealType())
+        problem = Problem("declared_unreferenced")
+        problem.add_fluent(unused, default_initial_value=1.5)
+        self.assertTrue(problem.kind.has_real_fluents())
+        self.assertIn(unused, problem.get_unused_fluents())
+
+    def test_duration_only_fluent_is_not_unused(self):
+        dur_fluent = Fluent("dur_fluent", RealType())
+        a = DurativeAction("act")
+        a.set_fixed_duration(dur_fluent())
+        problem = Problem("dur_unused")
+        problem.add_fluent(dur_fluent, default_initial_value=1.0)
+        problem.add_action(a)
+        self.assertNotIn(dur_fluent, problem.get_unused_fluents())
+
+    def test_action_cost_only_fluent_kind(self):
+        # documented behaviour: a fluent used only in the ActionCost quality metric is
+        # still reported as unused by get_unused_fluents() (see the docstring of
+        # _get_static_and_unused_fluents), but it must still contribute its type to kind
+        # unconditionally, so REAL_FLUENTS is correctly set regardless
+        cost_fluent = Fluent("cost_fluent", RealType())
+        done = Fluent("done", BoolType())
+        a = InstantaneousAction("act")
+        a.add_effect(done, True)
+        problem = Problem("cost_unused")
+        problem.add_fluent(cost_fluent, default_initial_value=1.0)
+        problem.add_fluent(done, default_initial_value=False)
+        problem.add_action(a)
+        problem.add_quality_metric(MinimizeActionCosts({a: cost_fluent}))
+        self.assertIn(cost_fluent, problem.get_unused_fluents())
+        self.assertTrue(problem.kind.has_real_fluents())
+
+    def test_action_cost_interpreted_function_kind(self):
+        one_if = InterpretedFunction("one", IntType(), OrderedDict(), lambda: 1)
+        done = Fluent("done", BoolType())
+        a = InstantaneousAction("act")
+        a.add_effect(done, True)
+        problem = Problem("cost_if")
+        problem.add_fluent(done, default_initial_value=False)
+        problem.add_action(a)
+        problem.add_quality_metric(MinimizeActionCosts({a: one_if()}))
+        self.assertTrue(problem.kind.has_interpreted_functions_in_conditions())
+
+    def test_event_contributes_to_kind(self):
+        # event preconditions/effects were never walked at all before this fix
+        x = Fluent("x", BoolType())
+        y = Fluent("y", BoolType())
+        evt = Event("evt")
+        evt.add_precondition(Or(x, y))
+        evt.add_effect(x, False)
+        problem = Problem("event_kind")
+        problem.add_fluent(x, default_initial_value=False)
+        problem.add_fluent(y, default_initial_value=False)
+        problem.add_event(evt)
+        self.assertTrue(problem.kind.has_disjunctive_conditions())
+
+    def test_trajectory_constraint_contributes_to_kind(self):
+        x = Fluent("x", BoolType())
+        y = Fluent("y", BoolType())
+        problem = Problem("tc_kind")
+        problem.add_fluent(x, default_initial_value=False)
+        problem.add_fluent(y, default_initial_value=False)
+        problem.add_trajectory_constraint(Sometime(Or(x, y)))
+        self.assertTrue(problem.kind.has_disjunctive_conditions())
+
+    def test_forall_effect_type_kind(self):
+        Base = UserType("Base")
+        Sub = UserType("Sub", father=Base)
+        visited = Fluent("visited", BoolType(), o=Base)
+        v = Variable("v", Sub)
+        a = InstantaneousAction("reset_all")
+        a.add_effect(visited(v), True, forall=[v])
+        problem = Problem("forall_kind")
+        problem.add_fluent(visited, default_initial_value=False)
+        problem.add_action(a)
+        self.assertTrue(problem.kind.has_hierarchical_typing())
 
     def test_simple_numeric_planning_ad_hoc_1(self):
         problem = Problem("ad_hoc_1")


### PR DESCRIPTION
## Summary
- `update_problem_kind_effect` now also inspects an effect's target-fluent arguments (not just
  its value), so an interpreted function or fluent nested in the target is no longer invisible
  to `.kind`.
- A declared numeric fluent now contributes `INT_FLUENTS`/`REAL_FLUENTS` unconditionally,
  matching how `OBJECT_FLUENTS` already worked, instead of only when `get_unused_fluents()`
  considers it used — closing the gap where a fluent used only in a duration silently dropped
  out of `.kind`, letting an unsuited engine get matched and then fail downstream.
- `Event`s, trajectory constraints, and `MinimizeActionCosts` cost expressions are now walked
  for condition-kind features; increase/decrease effects now detect interpreted functions; a
  `forall` effect's quantified variable type is now walked.
- `HierarchicalProblem`: subtask arguments are now scanned by `get_unused_fluents()`, and
  method/task-network constraint expressions are now walked for kind features instead of only
  being counted.
- Closes #773.

## Test plan
- [x] New regression tests in `test_problem.py`/`test_htn.py`, each verified to fail without
      the corresponding fix and pass with it
- [x] black / mypy
- [x] Full `bash run_tests.sh`