### PR TITLE
fix(compilers): simplify and prune preconditions of zero-parameter actions during grounding

### DIFF
--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -34,7 +34,7 @@ from unified_planning.model.problem_kind_versioning import LATEST_PROBLEM_KIND_V
 from unified_planning.engines.compilers.utils import (
     lift_action_instance,
     create_action_with_given_subs,
-    normalize_ground_action_effects,
+    normalize_ground_action,
     split_all_ands,
 )
 from typing import Dict, List, Optional, Set, Tuple, Iterator, cast
@@ -141,7 +141,7 @@ class GrounderHelper:
                     self._grounding_actions_map is None
                     or self._grounding_actions_map.get(action, None) is not None
                 ):
-                    new_action = normalize_ground_action_effects(
+                    new_action = normalize_ground_action(
                         self._problem, action.clone(), self._simplifier
                     )
                 else:

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -34,7 +34,6 @@ from unified_planning.model.problem_kind_versioning import LATEST_PROBLEM_KIND_V
 from unified_planning.engines.compilers.utils import (
     lift_action_instance,
     create_action_with_given_subs,
-    normalize_ground_action,
     split_all_ands,
 )
 from typing import Dict, List, Optional, Set, Tuple, Iterator, cast
@@ -141,8 +140,8 @@ class GrounderHelper:
                     self._grounding_actions_map is None
                     or self._grounding_actions_map.get(action, None) is not None
                 ):
-                    new_action = normalize_ground_action(
-                        self._problem, action.clone(), self._simplifier
+                    new_action = create_action_with_given_subs(
+                        self._problem, action, self._simplifier, {}
                     )
                 else:
                     new_action = None
@@ -332,7 +331,7 @@ class Grounder(engines.engine.Engine, CompilerMixin):
     grounder's simplifier evaluates it and replaces the call with its value; while any argument is not
     constant, the call is left unevaluated.
 
-    This `Compiler` supports only the the `GROUNDING` :class:`~unified_planning.engines.CompilationKind`.
+    This `Compiler` supports only the `GROUNDING` :class:`~unified_planning.engines.CompilationKind`.
     """
 
     def __init__(

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -160,102 +160,20 @@ def create_effect_with_given_subs(
         )
 
 
-def normalize_ground_action(
-    problem: Problem,
-    action: Action,
-    simplifier,
-) -> Optional[Action]:
-    """
-    Rebuilds the effects (and simulated effect(s)) of an already parameter-less
-    action (typically a clone of an action that had no parameters to begin with,
-    so it never goes through :func:`create_action_with_given_subs`) through
-    :func:`create_effect_with_given_subs` with an empty substitution, and
-    simplifies/prunes its preconditions or conditions the same way
-    :func:`create_action_with_given_subs` does.
-
-    This gives the action the same target/value/condition normalization and
-    precondition simplification applied to actions that do have parameters,
-    and re-runs the conflicting-effects check that a plain ``clone()``
-    bypasses, since it copies the conflict-checking bookkeeping verbatim
-    instead of re-adding each effect.
-
-    :param problem: The `Problem` the action belongs to.
-    :param action: The parameter-less action to normalize; it is mutated in place.
-    :param simplifier: The `Simplifier` used to normalize effect targets/values/conditions.
-    :return: The same `action`, mutated, or `None` if the normalized effects (or
-        simulated effect) conflict with each other, or if its preconditions or
-        conditions simplify to a contradiction.
-    """
-    empty_subs: Dict[Expression, Expression] = {}
-    if isinstance(action, InstantaneousAction):
-        old_effects = list(action.effects)
-        old_simulated_effect = action.simulated_effect
-        action.clear_effects()
-        for old_effect in old_effects:
-            new_effect = create_effect_with_given_subs(
-                problem, old_effect, simplifier, empty_subs
-            )
-            if new_effect is not None:
-                try:
-                    action._add_effect_instance(new_effect)
-                except UPConflictingEffectsException:
-                    return None
-        if old_simulated_effect is not None:
-            try:
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", DeprecationWarning)
-                    action.set_simulated_effect(old_simulated_effect)
-            except UPConflictingEffectsException:
-                return None
-        is_feasible, new_preconditions = check_and_simplify_preconditions(
-            problem, action, simplifier
-        )
-        if not is_feasible:
-            return None
-        action._set_preconditions(new_preconditions)
-        return action
-    elif isinstance(action, DurativeAction):
-        old_effects_by_timing = {t: list(el) for t, el in action.effects.items()}
-        old_simulated_effects = dict(action.simulated_effects)
-        action.clear_effects()
-        for timing, effects_list in old_effects_by_timing.items():
-            for old_effect in effects_list:
-                new_effect = create_effect_with_given_subs(
-                    problem, old_effect, simplifier, empty_subs
-                )
-                if new_effect is not None:
-                    try:
-                        action._add_effect_instance(timing, new_effect)
-                    except UPConflictingEffectsException:
-                        return None
-        for timing, old_simulated_effect in old_simulated_effects.items():
-            try:
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", DeprecationWarning)
-                    action.set_simulated_effect(timing, old_simulated_effect)
-            except UPConflictingEffectsException:
-                return None
-        is_feasible, new_conditions = check_and_simplify_conditions(
-            problem, action, simplifier
-        )
-        if not is_feasible:
-            return None
-        action.clear_conditions()
-        for interval, c in new_conditions:
-            action.add_condition(interval, c)
-        return action
-    else:
-        # Unknown/unsupported action type: leave it untouched
-        return action
-
-
 def create_action_with_given_subs(
     problem: Problem,
     old_action: Action,
     simplifier,
     subs: Dict[Expression, Expression],
 ) -> Optional[Action]:
-    """This method is used to instantiate the actions parameters to a constant."""
+    """
+    This method is used to instantiate the actions parameters to a constant.
+
+    When ``subs`` is empty (``old_action`` has no parameters), the action keeps its
+    original name instead of going through :func:`get_fresh_name`: since ``old_action``
+    is still registered in ``problem`` under that name, `get_fresh_name` would otherwise
+    treat it as colliding with itself and rename it needlessly.
+    """
     naming_list: List[str] = []
     for param, value in subs.items():
         assert isinstance(param, Parameter)
@@ -264,7 +182,9 @@ def create_action_with_given_subs(
     c_subs = cast(Dict[Parameter, FNode], subs)
     if isinstance(old_action, InstantaneousAction):
         new_action = InstantaneousAction(
-            get_fresh_name(problem, old_action.name, naming_list),
+            old_action.name
+            if not subs
+            else get_fresh_name(problem, old_action.name, naming_list),
             _env=old_action.environment,
         )
         for p in old_action.preconditions:
@@ -308,7 +228,9 @@ def create_action_with_given_subs(
         return new_action
     elif isinstance(old_action, DurativeAction):
         new_durative_action = DurativeAction(
-            get_fresh_name(problem, old_action.name, naming_list),
+            old_action.name
+            if not subs
+            else get_fresh_name(problem, old_action.name, naming_list),
             _env=old_action.environment,
         )
         old_duration = old_action.duration

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -160,7 +160,7 @@ def create_effect_with_given_subs(
         )
 
 
-def normalize_ground_action_effects(
+def normalize_ground_action(
     problem: Problem,
     action: Action,
     simplifier,
@@ -169,18 +169,22 @@ def normalize_ground_action_effects(
     Rebuilds the effects (and simulated effect(s)) of an already parameter-less
     action (typically a clone of an action that had no parameters to begin with,
     so it never goes through :func:`create_action_with_given_subs`) through
-    :func:`create_effect_with_given_subs` with an empty substitution.
+    :func:`create_effect_with_given_subs` with an empty substitution, and
+    simplifies/prunes its preconditions or conditions the same way
+    :func:`create_action_with_given_subs` does.
 
-    This gives the action the same target/value/condition normalization applied
-    to actions that do have parameters, and re-runs the conflicting-effects check
-    that a plain ``clone()`` bypasses, since it copies the conflict-checking
-    bookkeeping verbatim instead of re-adding each effect.
+    This gives the action the same target/value/condition normalization and
+    precondition simplification applied to actions that do have parameters,
+    and re-runs the conflicting-effects check that a plain ``clone()``
+    bypasses, since it copies the conflict-checking bookkeeping verbatim
+    instead of re-adding each effect.
 
     :param problem: The `Problem` the action belongs to.
     :param action: The parameter-less action to normalize; it is mutated in place.
     :param simplifier: The `Simplifier` used to normalize effect targets/values/conditions.
     :return: The same `action`, mutated, or `None` if the normalized effects (or
-        simulated effect) conflict with each other.
+        simulated effect) conflict with each other, or if its preconditions or
+        conditions simplify to a contradiction.
     """
     empty_subs: Dict[Expression, Expression] = {}
     if isinstance(action, InstantaneousAction):
@@ -203,6 +207,12 @@ def normalize_ground_action_effects(
                     action.set_simulated_effect(old_simulated_effect)
             except UPConflictingEffectsException:
                 return None
+        is_feasible, new_preconditions = check_and_simplify_preconditions(
+            problem, action, simplifier
+        )
+        if not is_feasible:
+            return None
+        action._set_preconditions(new_preconditions)
         return action
     elif isinstance(action, DurativeAction):
         old_effects_by_timing = {t: list(el) for t, el in action.effects.items()}
@@ -225,6 +235,14 @@ def normalize_ground_action_effects(
                     action.set_simulated_effect(timing, old_simulated_effect)
             except UPConflictingEffectsException:
                 return None
+        is_feasible, new_conditions = check_and_simplify_conditions(
+            problem, action, simplifier
+        )
+        if not is_feasible:
+            return None
+        action.clear_conditions()
+        for interval, c in new_conditions:
+            action.add_condition(interval, c)
         return action
     else:
         # Unknown/unsupported action type: leave it untouched

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -24,6 +24,7 @@ from unified_planning.exceptions import (
     UPUsageError,
 )
 from unified_planning.environment import Environment
+from unified_planning.model.contingent import SensingAction
 from unified_planning.model import (
     FNode,
     TimeInterval,
@@ -169,6 +170,11 @@ def create_action_with_given_subs(
     """
     This method is used to instantiate the actions parameters to a constant.
 
+    ``old_action`` is cloned first (preserving its exact subclass and any subclass-only
+    data, e.g. a :class:`~unified_planning.model.contingent.SensingAction`'s
+    ``observed_fluents``), then its preconditions/conditions, effects, and (for a `DurativeAction`)
+    duration and continuous effects are rebuilt on the clone through the given substitution.
+
     When ``subs`` is empty (``old_action`` has no parameters), the action keeps its
     original name instead of going through :func:`get_fresh_name`: since ``old_action``
     is still registered in ``problem`` under that name, `get_fresh_name` would otherwise
@@ -181,15 +187,26 @@ def create_action_with_given_subs(
         naming_list.append(str(value))
     c_subs = cast(Dict[Parameter, FNode], subs)
     if isinstance(old_action, InstantaneousAction):
-        new_action = InstantaneousAction(
+        new_action = cast(InstantaneousAction, old_action.clone())
+        new_action.name = (
             old_action.name
             if not subs
-            else get_fresh_name(problem, old_action.name, naming_list),
-            _env=old_action.environment,
+            else get_fresh_name(problem, old_action.name, naming_list)
         )
-        for p in old_action.preconditions:
-            new_action.add_precondition(p.substitute(subs))
-        for e in old_action.effects:
+        new_action._parameters = OrderedDict()
+        if isinstance(new_action, SensingAction):
+            # observed_fluents is SensingAction-only, so create_effect_with_given_subs
+            # (which only knows about preconditions/effects) can't substitute it; do it here.
+            new_action._observed_fluents = [
+                f.substitute(subs) for f in new_action.observed_fluents
+            ]
+        old_preconditions = new_action.preconditions
+        new_action._set_preconditions([p.substitute(subs) for p in old_preconditions])
+
+        old_effects = list(new_action.effects)
+        old_simulated_effect = new_action.simulated_effect
+        new_action.clear_effects()
+        for e in old_effects:
             new_effect = create_effect_with_given_subs(problem, e, simplifier, subs)
             if new_effect is not None:
                 # We try to add the new effect, but a compiler might generate conflicting effects,
@@ -198,15 +215,14 @@ def create_action_with_given_subs(
                     new_action._add_effect_instance(new_effect)
                 except UPConflictingEffectsException:
                     return None
-        se = old_action.simulated_effect
-        if se is not None:
+        if old_simulated_effect is not None:
             new_fluents = []
-            for f in se.fluents:
+            for f in old_simulated_effect.fluents:
                 new_fluents.append(f.substitute(subs))
 
             def fun(_problem, _state, _):
-                assert se is not None
-                return se.function(_problem, _state, c_subs)
+                assert old_simulated_effect is not None
+                return old_simulated_effect.function(_problem, _state, c_subs)
 
             # this rebuilds a simulated effect the user already defined (and got
             # warned about), so the deprecation warning is silenced here
@@ -227,13 +243,14 @@ def create_action_with_given_subs(
         new_action._set_preconditions(new_preconditions)
         return new_action
     elif isinstance(old_action, DurativeAction):
-        new_durative_action = DurativeAction(
+        new_durative_action = cast(DurativeAction, old_action.clone())
+        new_durative_action.name = (
             old_action.name
             if not subs
-            else get_fresh_name(problem, old_action.name, naming_list),
-            _env=old_action.environment,
+            else get_fresh_name(problem, old_action.name, naming_list)
         )
-        old_duration = old_action.duration
+        new_durative_action._parameters = OrderedDict()
+        old_duration = new_durative_action.duration
         new_duration = DurationInterval(
             simplifier.simplify(old_duration.lower.substitute(subs)),
             simplifier.simplify(old_duration.upper.substitute(subs)),
@@ -245,27 +262,50 @@ def create_action_with_given_subs(
         except UPProblemDefinitionError:
             # the simplified interval is empty, so this grounding can never be applied
             return None
-        for i, cl in old_action.conditions.items():
+
+        old_conditions = {
+            i: list(cl) for i, cl in new_durative_action.conditions.items()
+        }
+        new_durative_action.clear_conditions()
+        for i, cl in old_conditions.items():
             for c in cl:
                 new_durative_action.add_condition(i, c.substitute(subs))
-        for t, el in old_action.effects.items():
-            for e in el:
+
+        old_effects_by_timing = {
+            t: list(el) for t, el in new_durative_action.effects.items()
+        }
+        old_simulated_effects = dict(new_durative_action.simulated_effects)
+        old_continuous_effects = {
+            i: list(el) for i, el in new_durative_action.continuous_effects.items()
+        }
+        new_durative_action.clear_effects()
+        new_durative_action.clear_continuous_effects()
+        for t, effects_list in old_effects_by_timing.items():
+            for e in effects_list:
                 new_effect = create_effect_with_given_subs(problem, e, simplifier, subs)
                 if new_effect is not None:
-                    # We try to add the new simulated effect, but a compiler might generate conflicting effects,
+                    # We try to add the new effect, but a compiler might generate conflicting effects,
                     # so the action is just considered invalid
                     try:
                         new_durative_action._add_effect_instance(t, new_effect)
                     except UPConflictingEffectsException:
                         return None
-        for t, se in old_action.simulated_effects.items():
+        for i, ce_list in old_continuous_effects.items():
+            for ce in ce_list:
+                new_continuous_effect = create_effect_with_given_subs(
+                    problem, ce, simplifier, subs
+                )
+                if new_continuous_effect is not None:
+                    new_durative_action._add_continuous_effect_instance(
+                        i, new_continuous_effect
+                    )
+        for t, old_se in old_simulated_effects.items():
             new_fluents = []
-            for f in se.fluents:
+            for f in old_se.fluents:
                 new_fluents.append(f.substitute(subs))
 
             def fun(_problem, _state, _):
-                assert se is not None
-                return se.function(_problem, _state, c_subs)
+                return old_se.function(_problem, _state, c_subs)
 
             # this rebuilds a simulated effect the user already defined (and got
             # warned about), so the deprecation warning is silenced here

--- a/unified_planning/model/motion/action.py
+++ b/unified_planning/model/motion/action.py
@@ -128,6 +128,9 @@ class DurativeMotionAction(DurativeAction, MotionConstraintsSetMixin):
         )
         new_durative_motion_action._duration = self._duration
         TimedCondsEffs._clone_to(self, new_durative_motion_action)
+        new_durative_motion_action._continuous_effects = {
+            t: [e.clone() for e in el] for t, el in self._continuous_effects.items()
+        }
         new_durative_motion_action._motion_constraints = self._motion_constraints.copy()
         new_durative_motion_action._motion_constraints_set = (
             self._motion_constraints_set.copy()

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -35,6 +35,7 @@ from unified_planning.test import (
 from unified_planning.test.examples import get_example_problems
 from unified_planning.engines import CompilationKind
 from unified_planning.engines.compilers import Grounder
+from unified_planning.model.contingent import SensingAction
 
 
 class TestGrounder(unittest_TestCase):
@@ -585,6 +586,115 @@ class TestGrounder(unittest_TestCase):
         (effect,) = ga.effects[EndTiming()]
         self.assertEqual(effect.fluent, f(em.Int(2)))
         self.assertEqual(effect.value, em.Int(1))
+
+    def test_zero_parameter_action_preconditions_are_simplified(self):
+        # the same clone-shortcut that skipped effect normalization at zero
+        # parameters (fixed above) also skipped check_and_simplify_preconditions;
+        # a zero-parameter action's precondition must still be simplified/pruned
+        # exactly like it would be for a parameterized action: a contradiction
+        # drops the action, a top-level And is flattened, and a tautology is
+        # cleared.
+        cases = (
+            ("contradiction", lambda b, c: And(b, Not(b)), None),
+            ("conjunction", lambda b, c: And(b, c), "both"),
+            ("tautology", lambda b, c: Or(b, Not(b)), "none"),
+        )
+        for case_name, build_precondition, expected in cases:
+            with self.subTest(case=case_name):
+                b = Fluent(f"b_{case_name}")
+                c = Fluent(f"c_{case_name}")
+                f = Fluent(f"f_{case_name}")
+                action = InstantaneousAction("act")
+                action.add_precondition(build_precondition(FluentExp(b), FluentExp(c)))
+                action.add_effect(f, True)
+                writer = InstantaneousAction("writer")
+                writer.add_effect(b, True)
+                writer.add_effect(c, True)
+
+                problem = Problem(f"zero_param_{case_name}")
+                problem.add_fluent(b, default_initial_value=False)
+                problem.add_fluent(c, default_initial_value=False)
+                problem.add_fluent(f, default_initial_value=False)
+                problem.add_action(action)
+                problem.add_action(writer)
+
+                grounded_problem = (
+                    Grounder().compile(problem, CompilationKind.GROUNDING).problem
+                )
+                assert isinstance(grounded_problem, Problem)
+                if expected is None:
+                    self.assertEqual(
+                        {a.name for a in grounded_problem.actions}, {"writer"}
+                    )
+                else:
+                    ga = cast(InstantaneousAction, grounded_problem.action("act"))
+                    if expected == "both":
+                        self.assertEqual(
+                            set(ga.preconditions), {FluentExp(b), FluentExp(c)}
+                        )
+                    else:
+                        self.assertEqual(ga.preconditions, [])
+
+    def test_zero_parameter_durative_action_contradictory_condition_is_pruned(self):
+        # durative-action variant: a contradictory condition at a given timing
+        # must still drop the action at zero parameters.
+        b = Fluent("b")
+        f = Fluent("f")
+        action = DurativeAction("act")
+        action.set_fixed_duration(1)
+        action.add_condition(StartTiming(), And(FluentExp(b), Not(FluentExp(b))))
+        action.add_effect(EndTiming(), f, True)
+        writer = InstantaneousAction("writer")
+        writer.add_effect(b, True)
+
+        problem = Problem("zero_param_durative_contradictory_condition")
+        problem.add_fluent(b, default_initial_value=False)
+        problem.add_fluent(f, default_initial_value=False)
+        problem.add_action(action)
+        problem.add_action(writer)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(
+            {a.name for a in grounded_problem.actions},
+            {"writer"},
+        )
+
+    def test_zero_parameter_sensing_action_is_preserved_after_normalization(self):
+        # normalize_ground_action mutates the action in place; it must not
+        # downgrade a SensingAction to a plain InstantaneousAction, and its
+        # observed fluents and simplified precondition must survive.
+        b = Fluent("b")
+        f = Fluent("f")
+        hidden = Fluent("hidden")
+        action = SensingAction("sense")
+        action.add_precondition(And(FluentExp(b), FluentExp(b)))
+        action.add_effect(f, True)
+        action.add_observed_fluent(FluentExp(hidden))
+        writer = InstantaneousAction("writer")
+        writer.add_effect(b, True)
+
+        problem = Problem("zero_param_sensing")
+        problem.add_fluent(b, default_initial_value=False)
+        problem.add_fluent(f, default_initial_value=False)
+        problem.add_fluent(hidden, default_initial_value=False)
+        problem.add_action(action)
+        problem.add_action(writer)
+
+        # PARTIAL_OBSERVABILITY (SensingAction) is not part of Grounder.supported_kind;
+        # skip_checks bypasses that check, matching how Ks0Compiler grounds actions
+        # outside the kinds the grounder formally declares support for.
+        compiler = Grounder()
+        compiler.skip_checks = True
+        grounded_problem = compiler.compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded_problem, Problem)
+        ga = grounded_problem.action("sense")
+        self.assertIsInstance(ga, SensingAction)
+        assert isinstance(ga, SensingAction)
+        self.assertEqual(ga.observed_fluents, [FluentExp(hidden)])
+        self.assertEqual(ga.preconditions, [FluentExp(b)])
 
     @skipIfEngineNotAvailable("pyperplan")
     def test_pyperplan_grounder(self):

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -710,6 +710,110 @@ class TestGrounder(unittest_TestCase):
         assert isinstance(grounded_problem, Problem)
         self.assertEqual(len(grounded_problem.actions), 0)
 
+    def test_zero_parameter_sensing_action_is_preserved_after_grounding(self):
+        # create_action_with_given_subs clones the action instead of rebuilding a
+        # plain InstantaneousAction, so it must not downgrade a SensingAction; its
+        # observed fluents and simplified precondition must survive grounding.
+        b = Fluent("b")
+        f = Fluent("f")
+        hidden = Fluent("hidden")
+        action = SensingAction("sense")
+        action.add_precondition(And(FluentExp(b), FluentExp(b)))
+        action.add_effect(f, True)
+        action.add_observed_fluent(FluentExp(hidden))
+        writer = InstantaneousAction("writer")
+        writer.add_effect(b, True)
+
+        problem = Problem("zero_param_sensing")
+        problem.add_fluent(b, default_initial_value=False)
+        problem.add_fluent(f, default_initial_value=False)
+        problem.add_fluent(hidden, default_initial_value=False)
+        problem.add_action(action)
+        problem.add_action(writer)
+
+        # PARTIAL_OBSERVABILITY (SensingAction) is not part of Grounder.supported_kind;
+        # skip_checks bypasses that check, matching how Ks0Compiler grounds actions
+        # outside the kinds the grounder formally declares support for.
+        compiler = Grounder()
+        compiler.skip_checks = True
+        grounded_problem = compiler.compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded_problem, Problem)
+        ga = grounded_problem.action("sense")
+        self.assertIsInstance(ga, SensingAction)
+        assert isinstance(ga, SensingAction)
+        self.assertEqual(ga.observed_fluents, [FluentExp(hidden)])
+        self.assertEqual(ga.preconditions, [FluentExp(b)])
+
+    def test_parameterized_sensing_action_is_preserved_after_grounding(self):
+        # same as above, but with a parameter: the SensingAction's observed_fluents
+        # must survive AND be substituted, not just copied verbatim.
+        Loc = UserType("Loc")
+        l1 = Object("l1", Loc)
+        l2 = Object("l2", Loc)
+        hidden = Fluent("hidden", BoolType(), l=Loc)
+        f = Fluent("f")
+        action = SensingAction("sense", l=Loc)
+        l = action.parameter("l")
+        action.add_effect(f, True)
+        action.add_observed_fluent(hidden(l))
+
+        problem = Problem("parameterized_sensing")
+        problem.add_objects([l1, l2])
+        problem.add_fluent(hidden, default_initial_value=False)
+        problem.add_fluent(f, default_initial_value=False)
+        problem.add_action(action)
+
+        compiler = Grounder()
+        compiler.skip_checks = True
+        grounded_problem = compiler.compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded_problem, Problem)
+        ga = grounded_problem.action("sense_l1")
+        self.assertIsInstance(ga, SensingAction)
+        assert isinstance(ga, SensingAction)
+        self.assertEqual(len(ga.parameters), 0)
+        self.assertEqual(ga.observed_fluents, [hidden(l1)])
+
+    def test_durative_action_continuous_effects_preserved_and_substituted_after_grounding(
+        self,
+    ):
+        # create_action_with_given_subs used to silently drop a DurativeAction's
+        # continuous effects entirely; cloning the action must preserve them, and
+        # they must still be substituted like any other effect.
+        Loc = UserType("Loc")
+        l1 = Object("l1", Loc)
+        rate = Fluent("rate", RealType(), l=Loc)
+        x = Fluent("x", RealType())
+        action = DurativeAction("act", l=Loc)
+        l = action.parameter("l")
+        action.set_fixed_duration(1)
+        action.add_increase_continuous_effect(
+            ClosedTimeInterval(StartTiming(), EndTiming()), x, rate(l)
+        )
+        # keeps "rate" non-static, so its read in the continuous effect isn't folded to a
+        # constant: this test is about parameter substitution, not static-fluent folding.
+        writer = InstantaneousAction("writer")
+        writer.add_effect(rate(l1), 3.0)
+
+        problem = Problem("continuous_effect_substitution")
+        problem.add_objects([l1])
+        problem.add_fluent(rate, default_initial_value=2.0)
+        problem.add_fluent(x, default_initial_value=0.0)
+        problem.add_action(action)
+        problem.add_action(writer)
+
+        # INCREASE_CONTINUOUS_EFFECTS is not part of Grounder.supported_kind, same as
+        # PARTIAL_OBSERVABILITY for the SensingAction tests above.
+        compiler = Grounder()
+        compiler.skip_checks = True
+        grounded_problem = compiler.compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded_problem, Problem)
+        ga = cast(DurativeAction, grounded_problem.action("act_l1"))
+        self.assertEqual(len(ga.parameters), 0)
+        ((interval, effects),) = ga.continuous_effects.items()
+        (effect,) = effects
+        self.assertTrue(effect.is_continuous_increase())
+        self.assertEqual(effect.value, rate(l1))
+
     @skipIfEngineNotAvailable("pyperplan")
     def test_pyperplan_grounder(self):
         problem = self.problems["robot_no_negative_preconditions"].problem

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -492,9 +492,9 @@ class TestGrounder(unittest_TestCase):
             self.assertEqual(second_effect.value, em.Int(99))
 
     def test_zero_parameter_action_effect_target_is_normalized(self):
-        # a zero-parameter action is never routed through create_action_with_given_subs
-        # (there is nothing to substitute), so its effects must still be normalized
-        # explicitly; otherwise a hand-written f(1 + 1) target survives grounding unevaluated.
+        # create_action_with_given_subs is also used for zero-parameter actions
+        # (with an empty substitution), so their effects must still be normalized;
+        # otherwise a hand-written f(1 + 1) target survives grounding unevaluated.
         f = Fluent("f", IntType(), i=IntType(0, 3))
         action = InstantaneousAction("act")
         action.add_effect(f(Plus(Int(1), Int(1))), 1)
@@ -588,12 +588,9 @@ class TestGrounder(unittest_TestCase):
         self.assertEqual(effect.value, em.Int(1))
 
     def test_zero_parameter_action_preconditions_are_simplified(self):
-        # the same clone-shortcut that skipped effect normalization at zero
-        # parameters (fixed above) also skipped check_and_simplify_preconditions;
-        # a zero-parameter action's precondition must still be simplified/pruned
-        # exactly like it would be for a parameterized action: a contradiction
-        # drops the action, a top-level And is flattened, and a tautology is
-        # cleared.
+        # a zero-parameter action's precondition must be simplified/pruned exactly
+        # like it would be for a parameterized action: a contradiction drops the
+        # action, a top-level And is flattened, and a tautology is cleared.
         cases = (
             ("contradiction", lambda b, c: And(b, Not(b)), None),
             ("conjunction", lambda b, c: And(b, c), "both"),
@@ -662,39 +659,56 @@ class TestGrounder(unittest_TestCase):
             {"writer"},
         )
 
-    def test_zero_parameter_sensing_action_is_preserved_after_normalization(self):
-        # normalize_ground_action mutates the action in place; it must not
-        # downgrade a SensingAction to a plain InstantaneousAction, and its
-        # observed fluents and simplified precondition must survive.
-        b = Fluent("b")
-        f = Fluent("f")
-        hidden = Fluent("hidden")
-        action = SensingAction("sense")
-        action.add_precondition(And(FluentExp(b), FluentExp(b)))
-        action.add_effect(f, True)
-        action.add_observed_fluent(FluentExp(hidden))
-        writer = InstantaneousAction("writer")
-        writer.add_effect(b, True)
+    def test_zero_parameter_durative_action_duration_is_simplified(self):
+        # gap closed by the unified create_action_with_given_subs: a
+        # zero-parameter durative action's duration, if built from static
+        # fluents, must be folded to a constant just like a parameterized
+        # action's duration already is.
+        static_lower = Fluent("static_lower", IntType())
+        static_upper = Fluent("static_upper", IntType())
+        done = Fluent("done")
+        action = DurativeAction("act")
+        action.set_closed_duration_interval(static_lower(), static_upper())
+        action.add_effect(EndTiming(), done, True)
 
-        problem = Problem("zero_param_sensing")
-        problem.add_fluent(b, default_initial_value=False)
-        problem.add_fluent(f, default_initial_value=False)
-        problem.add_fluent(hidden, default_initial_value=False)
+        problem = Problem("zero_param_duration_folds")
+        problem.add_fluent(static_lower, default_initial_value=1)
+        problem.add_fluent(static_upper, default_initial_value=5)
+        problem.add_fluent(done, default_initial_value=False)
         problem.add_action(action)
-        problem.add_action(writer)
 
-        # PARTIAL_OBSERVABILITY (SensingAction) is not part of Grounder.supported_kind;
-        # skip_checks bypasses that check, matching how Ks0Compiler grounds actions
-        # outside the kinds the grounder formally declares support for.
-        compiler = Grounder()
-        compiler.skip_checks = True
-        grounded_problem = compiler.compile(problem, CompilationKind.GROUNDING).problem
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
         assert isinstance(grounded_problem, Problem)
-        ga = grounded_problem.action("sense")
-        self.assertIsInstance(ga, SensingAction)
-        assert isinstance(ga, SensingAction)
-        self.assertEqual(ga.observed_fluents, [FluentExp(hidden)])
-        self.assertEqual(ga.preconditions, [FluentExp(b)])
+        self.assertEqual(len(grounded_problem.actions), 1)
+        em = problem.environment.expression_manager
+        ga = cast(DurativeAction, grounded_problem.action("act"))
+        self.assertEqual(ga.duration.lower, em.Int(1))
+        self.assertEqual(ga.duration.upper, em.Int(5))
+
+    def test_zero_parameter_durative_action_empty_duration_drops_action(self):
+        # durative-action variant of test_empty_simplified_duration_drops_action,
+        # at zero parameters: the action must be dropped, not left with an
+        # un-simplified, empty duration interval.
+        static_lower = Fluent("static_lower", IntType())
+        static_upper = Fluent("static_upper", IntType())
+        done = Fluent("done")
+        action = DurativeAction("act")
+        action.set_closed_duration_interval(static_lower(), static_upper())
+        action.add_effect(EndTiming(), done, True)
+
+        problem = Problem("zero_param_duration_empty")
+        problem.add_fluent(static_lower, default_initial_value=5)
+        problem.add_fluent(static_upper, default_initial_value=1)
+        problem.add_fluent(done, default_initial_value=False)
+        problem.add_action(action)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(len(grounded_problem.actions), 0)
 
     @skipIfEngineNotAvailable("pyperplan")
     def test_pyperplan_grounder(self):


### PR DESCRIPTION
## Summary
- `GrounderHelper.ground_action`'s zero-parameter shortcut clones the
  action instead of routing it through `create_action_with_given_subs`,
  since there's nothing to substitute. That also skipped
  `check_and_simplify_preconditions` / `check_and_simplify_conditions`: a
  zero-parameter action with a contradictory precondition (`b and not b`)
  survived grounding un-pruned, while the identical action with an added
  (unused) parameter was correctly dropped. Un-simplified preconditions
  (unflattened `And`, uncleared tautologies) had the same gap.
- Extended `normalize_ground_action` (renamed from
  `normalize_ground_action_effects`) to also run
  `check_and_simplify_preconditions` / `check_and_simplify_conditions` on
  the cloned action, mirroring `create_action_with_given_subs` exactly.
  Verified a zero-parameter `SensingAction` still comes through as a
  `SensingAction` with its `observed_fluents` intact.