### PR TITLE
fix: pin the Parallel engine to the fork start method on Linux

### DIFF
--- a/unified_planning/engines/parallel.py
+++ b/unified_planning/engines/parallel.py
@@ -14,6 +14,7 @@
 #
 
 
+import sys
 import warnings
 import unified_planning as up
 import unified_planning.engines as engines
@@ -27,8 +28,18 @@ from unified_planning.engines.results import (
     ValidationResult,
     PlanGenerationResult,
 )
-from typing import IO, Dict, List, Optional, Tuple, Callable, cast
-from multiprocessing import Process, Queue
+from typing import IO, Any, Dict, List, Optional, Tuple, Callable, cast
+from multiprocessing import Queue, get_all_start_methods, get_context
+
+
+# Keep forking where it was the default before Python 3.14: the `forkserver` method it
+# switched Linux to re-imports `__main__` in every child, which breaks callers that have no
+# `if __name__ == "__main__":` guard. Windows and macOS were already on `spawn`.
+_mp_context: Any
+if sys.platform != "darwin" and "fork" in get_all_start_methods():
+    _mp_context = get_context("fork")
+else:
+    _mp_context = get_context()
 
 
 class Parallel(
@@ -75,11 +86,11 @@ class Parallel(
         return True
 
     def _run_parallel(self, fname, *args) -> List[Result]:
-        signaling_queue: Queue = Queue()
+        signaling_queue: Queue = _mp_context.Queue()
         processes = []
         for idx, (engine_name, opts) in enumerate(self.engines):
             options = opts
-            _p = Process(
+            _p = _mp_context.Process(
                 name=str(idx),
                 target=_run,
                 args=(


### PR DESCRIPTION
## Problem

Python 3.14 changes the default `multiprocessing` start method on Linux from `fork` to `forkserver`. `forkserver` (like `spawn`) re-imports `__main__` in every child process, so any caller that builds and solves a problem at module level — without an `if __name__ == "__main__":` guard — has its own script re-executed in each worker of the `Parallel` engine.

## Fix

`unified_planning/engines/parallel.py` now selects an explicit multiprocessing context instead of relying on the platform default:

- Linux (and any platform other than macOS that offers `fork`): use the `fork` context, preserving the pre-3.14 behaviour.
- macOS and Windows: fall back to the platform default, which was already `spawn` — behaviour there is unchanged.

`Queue` and `Process` are created from that context.

## Test plan

- [x] pre-commit hooks (formatting, `just lint`) pass
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)