### PR TITLE
ci: test the interpreter edges on PRs and stop the uv cache save race

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,6 +14,15 @@ inputs:
       would then miss on everything it needs.
     required: false
     default: "true"
+  save-cache:
+    description: >
+      Whether setup-uv should write the cache back at the end of the job. The key is
+      keyed on the lock, the OS and the Python version but not on the job, so every
+      concurrent job in a matrix leg computes the same one; on a cold cache they race
+      to reserve it and the losers warn. Set this to "false" on every job but the one
+      designated to populate the cache. Restoring is unaffected.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -23,6 +32,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: ${{ inputs.enable-cache }}
+        save-cache: ${{ inputs.save-cache }}
         cache-dependency-glob: "uv.lock"
 
     - name: Install just

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,12 +12,18 @@ concurrency:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.14"
+
     uses: ./.github/workflows/test.yml
 
-    # Pull requests deliberately run a single interpreter to keep CI cheap; the
-    # full 3.10-3.14 matrix runs post-merge from release.yml.
     with:
-      python-version: "3.12"
+      python-version: ${{ matrix.python-version }}
 
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   test:
     strategy:
+      fail-fast: false
+
       matrix:
         python-version:
           - "3.10"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
         run: just test unified_planning xml
 
       - name: Upload coverage to Codecov
-        if: ${{ github.repository == 'aiplan4eu/unified-planning' && inputs.python-version == '3.10' }}
+        if: ${{ github.repository == 'aiplan4eu/unified-planning' && github.ref == 'refs/heads/master' && inputs.python-version == '3.12' }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,9 @@ jobs:
         uses: ./.github/actions/setup
         with:
           python-version: ${{ inputs.python-version }}
+          # Starts at the same time as basic-check and computes the same cache key, so on
+          # a cold cache the two would race to reserve it. basic-check writes; this reads.
+          save-cache: "false"
 
       - name: Re-generate the protobuf bindings
         run: just gen-protobuf


### PR DESCRIPTION
## Problem

Two unrelated CI issues, one commit each.

**1. Every master run warned five times about the uv cache.**

```
Failed to save: Unable to reserve cache with key
setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-<py>-pruned-<lock-hash>,
another job may be creating this cache.
```

`setup-uv` keys its cache on the lock, the OS and the Python version — but not on the job. `basic-check` and `check-protobuf` start together with no dependency between them, so they compute the same key and race to reserve it when they finish. `check-protobuf` is the faster of the two (~15s vs ~50s), so it always won and `basic-check` always warned. The key contains the hash of `uv.lock`, so every dependency bump makes the cache cold again — with the current dependabot cadence this landed on nearly every run. The second wave of jobs was never involved: it starts once both of these have finished, gets a hit on the primary key and skips saving.

**2. Pull requests tested the one interpreter least likely to reveal anything.**

PRs ran 3.12, the middle of the supported range. Version-specific breakage clusters at the *ends*: reaching for something added after 3.10 fails only at the floor, while removals and behaviour changes fail only at the top. The most recent master breakage (run for #766) is exactly this — it failed in `test (3.14) / run-tests-ubuntu` and `test (3.14) / run-colab-notebooks` and nowhere else, and the fix was #783, 3.14 switching Linux `multiprocessing` to `forkserver`. A gate pinned to 3.12 was structurally incapable of catching it.

## Fix

**`ci: make basic-check the sole writer of the shared uv cache`**

Plumbs `setup-uv`'s `save-cache` input through `.github/actions/setup` and turns it off for `check-protobuf`. `basic-check` is the better writer of the two: `just check-imports` syncs the `plot` and `tarski` extras, so what it caches is a superset of what `check-protobuf` would have saved — and every downstream job already waits on it, so writing from the slower job costs no wall-clock. Restoring is unaffected.

**`ci: run the interpreter edges on pull requests`**

- PRs now run a `["3.10", "3.14"]` matrix; 3.11–3.13 keep running post-merge from `release.yml`. The two legs run concurrently and 14 jobs sits under the 20-concurrent cap for public repos, so this costs runner minutes rather than feedback latency.
- `fail-fast: false` on both matrices, so a break at one end no longer cancels the other and hides half of what went wrong.
- Coverage upload moves to 3.12 **and** master. Pinning it to a version PRs no longer run would have been enough on its own, but the branch check is what actually keeps the token out of PRs: a fork gets no secrets, and `github.repository` still resolves to the base repository there, so the existing guard cannot tell a fork apart — with `fail_ci_if_error: true` that would have meant a red check for external contributors the moment 3.10 landed on PRs.

## Notes for review

- This PR exercises its own change: `pull_request` runs use the workflow from the merge ref, so CI here should show the 3.10 and 3.14 legs rather than 3.12.
- Coverage will not be uploaded from this PR, by design. The next master push reports it from the 3.12 leg. Codecov's trend may show a one-time discontinuity from the 3.10 → 3.12 move; absolute numbers shouldn't shift.
- Not addressed here: the saved caches are only ~90 KB because `prune-cache` runs `uv cache prune --ci`, and no downstream job ever writes, so the extras `run-tests-ubuntu` and `run-colab-notebooks` install are re-downloaded every run. Worth a separate look if the caching is meant to pay for itself.

## Test plan

- [x] pre-commit hooks (`check yaml`, `just lint`) pass on both commits
- [x] all four workflow files parse and resolve to the intended settings
- [x] CI: PR legs are 3.10 and 3.14, and no `Failed to save` annotation appears
- [ ] first master run after merge: no cache warning, coverage uploads from the 3.12 leg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
