### PR TITLE
fix: three latent correctness bugs (compiler closure, shared dataclass default, total-cost metric)

### DIFF
--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -304,14 +304,16 @@ def create_action_with_given_subs(
             for f in old_se.fluents:
                 new_fluents.append(f.substitute(subs))
 
-            def fun(_problem, _state, _):
-                return old_se.function(_problem, _state, c_subs)
+            # _old_se bound as a default: the closure outlives the iteration, so capturing
+            # the loop variable would make every timing call the last one's function.
+            def durative_fun(_problem, _state, _, _old_se=old_se):
+                return _old_se.function(_problem, _state, c_subs)
 
             # this rebuilds a simulated effect the user already defined (and got
             # warned about), so the deprecation warning is silenced here
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-                new_simulated_effect = SimulatedEffect(new_fluents, fun)
+                new_simulated_effect = SimulatedEffect(new_fluents, durative_fun)
             # We try to add the new simulated effect, but a compiler might generate conflicting effects,
             # so the action is just considered invalid
             try:

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -304,10 +304,11 @@ def create_action_with_given_subs(
             for f in old_se.fluents:
                 new_fluents.append(f.substitute(subs))
 
-            # _old_se bound as a default: the closure outlives the iteration, so capturing
-            # the loop variable would make every timing call the last one's function.
-            def durative_fun(_problem, _state, _, _old_se=old_se):
-                return _old_se.function(_problem, _state, c_subs)
+            # _inner_simulated_effect bound as a default: the closure outlives the
+            # iteration, so capturing the loop variable would make every timing call
+            # the last one's function.
+            def durative_fun(_problem, _state, _, _inner_simulated_effect=old_se):
+                return _inner_simulated_effect.function(_problem, _state, c_subs)
 
             # this rebuilds a simulated effect the user already defined (and got
             # warned about), so the deprecation warning is silenced here

--- a/unified_planning/io/up_pddl_reader.py
+++ b/unified_planning/io/up_pddl_reader.py
@@ -2056,6 +2056,8 @@ class UPPDDLReader:
                         and metric_exp == self._totalcost
                     ):
                         costs: Dict[up.model.Action, up.model.Expression] = {}
+                        # cleared below unless every action costs exactly 1
+                        use_plan_length = True
                         problem._fluents.remove(self._totalcost.fluent())
                         if self._totalcost in problem._initial_value:
                             problem._initial_value.pop(self._totalcost)
@@ -2073,7 +2075,10 @@ class UPPDDLReader:
                                 if cost is not None:
                                     costs[a] = cost.value
                                     a._effects.remove(cost)
-                                    if cost.value != 1:
+                                    if not (
+                                        cost.value.is_int_constant()
+                                        and cost.value.constant_value() == 1
+                                    ):
                                         use_plan_length = False
                                 else:
                                     use_plan_length = False

--- a/unified_planning/plans/hierarchical_plan.py
+++ b/unified_planning/plans/hierarchical_plan.py
@@ -115,7 +115,7 @@ class MethodInstance:
 
     method: Method
     parameters: Tuple[FNode, ...]
-    decomposition: "Decomposition" = Decomposition()
+    decomposition: "Decomposition" = field(default_factory=Decomposition)
 
     def __repr__(self):
         return f"{self.method.name}{self.parameters}\n{self.decomposition}"

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -563,6 +563,59 @@ class TestGrounder(unittest_TestCase):
         ga = cast(InstantaneousAction, grounded_problem.action("act"))
         self.assertIsNotNone(ga.simulated_effect)
 
+    def test_durative_action_keeps_one_simulated_effect_per_timing(self):
+        # the rebuilt effects used to close over the loop variable, so every timing ended
+        # up calling the last timing's function.
+        x = Fluent("x", IntType(0, 100))
+        y = Fluent("y", IntType(0, 100))
+        Loc = UserType("Loc")
+        action = DurativeAction("act", l=Loc)
+        action.set_fixed_duration(1)
+
+        def at_start(problem, state, actual_params):
+            return [Int(7)]
+
+        def at_end(problem, state, actual_params):
+            return [Int(9)]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            action.set_simulated_effect(
+                StartTiming(), SimulatedEffect([FluentExp(x)], at_start)
+            )
+            action.set_simulated_effect(
+                EndTiming(), SimulatedEffect([FluentExp(y)], at_end)
+            )
+
+        problem = Problem("durative_two_simulated_effects")
+        problem.add_fluent(x, default_initial_value=0)
+        problem.add_fluent(y, default_initial_value=0)
+        problem.add_object(Object("o1", Loc))
+        problem.add_action(action)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(len(grounded_problem.actions), 1)
+        ga = cast(DurativeAction, grounded_problem.actions[0])
+        self.assertEqual(len(ga.simulated_effects), 2)
+
+        state = UPState({}, grounded_problem)
+        results = {
+            timing: [str(v) for v in se.function(grounded_problem, state, {})]
+            for timing, se in ga.simulated_effects.items()
+        }
+        self.assertEqual(results[StartTiming()], ["7"])
+        self.assertEqual(results[EndTiming()], ["9"])
+        # and each timing still updates its own fluent
+        self.assertEqual(
+            str(ga.simulated_effects[StartTiming()].fluents[0]), str(FluentExp(x))
+        )
+        self.assertEqual(
+            str(ga.simulated_effects[EndTiming()].fluents[0]), str(FluentExp(y))
+        )
+
     def test_zero_parameter_durative_action_effect_target_is_normalized(self):
         # durative-action variant of test_zero_parameter_action_effect_target_is_normalized:
         # the target must be normalized at its own timing, and the duration left untouched.

--- a/unified_planning/test/test_htn.py
+++ b/unified_planning/test/test_htn.py
@@ -160,6 +160,30 @@ class TestProblem(unittest_TestCase):
             tn.add_constraint(c)
             assert_temporal(tn)
 
+    def test_method_instances_do_not_share_a_decomposition(self):
+        # decomposition used to default to one shared Decomposition, so mutating one
+        # instance's subtasks leaked into every other default-constructed one.
+        from unified_planning.plans.hierarchical_plan import MethodInstance
+        from unified_planning.plans.plan import ActionInstance
+
+        top_task = Task("top-task")
+        m = up.model.htn.Method("m1")
+        m.set_task(top_task)
+
+        a = InstantaneousAction("a")
+
+        first = MethodInstance(m, ())
+        second = MethodInstance(m, ())
+
+        self.assertIsNot(first.decomposition, second.decomposition)
+        self.assertEqual(first.decomposition.subtasks, {})
+        self.assertEqual(second.decomposition.subtasks, {})
+
+        first.decomposition.subtasks["s1"] = ActionInstance(a)
+
+        self.assertEqual(list(first.decomposition.subtasks), ["s1"])
+        self.assertEqual(second.decomposition.subtasks, {})
+
     def test_hddl_parsing(self):
         """Tests that all HDDL benchmarks are successfully parsed."""
         hddl_dir = os.path.join(FILE_PATH, "hddl")

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -1096,6 +1096,74 @@ class TestPddlIO(unittest_TestCase):
             pddl_problem = self._normalized_pddl_str(writer.get_problem())
             self.assertIn(expected_goal, pddl_problem)
 
+    def test_total_cost_metric_with_no_actions(self):
+        # use_plan_length was never initialised, so this raised UnboundLocalError
+        domain = """(define (domain d)
+         (:requirements :strips :action-costs :fluents)
+         (:functions (total-cost))
+        )"""
+        problem_str = """(define (problem p)
+         (:domain d)
+         (:init (= (total-cost) 0))
+         (:goal (and))
+         (:metric minimize (total-cost))
+        )"""
+        problem = UPPDDLReader().parse_problem_string(domain, problem_str)
+        self.assertEqual(len(problem.quality_metrics), 1)
+        # with no action contributing a cost, total-cost and plan length coincide
+        self.assertIsInstance(problem.quality_metrics[0], MinimizeSequentialPlanLength)
+
+    def test_unit_action_costs_parse_as_plan_length(self):
+        # `cost.value != 1` compared an FNode to an int, so this metric was unreachable
+        domain_template = """(define (domain d)
+         (:requirements :strips :action-costs :fluents)
+         (:predicates (p))
+         (:functions (total-cost))
+         (:action a :parameters () :precondition (and)
+          :effect (and (p) (increase (total-cost) {cost})))
+        )"""
+        problem_str = """(define (problem p)
+         (:domain d)
+         (:init (= (total-cost) 0))
+         (:goal (and (p)))
+         (:metric minimize (total-cost))
+        )"""
+
+        unit = UPPDDLReader().parse_problem_string(
+            domain_template.format(cost="1"), problem_str
+        )
+        self.assertIsInstance(unit.quality_metrics[0], MinimizeSequentialPlanLength)
+        self.assertTrue(unit.kind.has_plan_length())
+
+        # any other cost keeps the action-costs metric
+        non_unit = UPPDDLReader().parse_problem_string(
+            domain_template.format(cost="3"), problem_str
+        )
+        self.assertIsInstance(
+            non_unit.quality_metrics[0],
+            unified_planning.model.metrics.MinimizeActionCosts,
+        )
+        self.assertTrue(non_unit.kind.has_actions_cost())
+
+    def test_plan_length_metric_pddl_round_trip(self):
+        # the writer emits unit increase effects, so reading back must give plan length again
+        p = Fluent("p")
+        a = InstantaneousAction("a")
+        a.add_effect(p, True)
+        problem = Problem("plan_length_round_trip")
+        problem.add_fluent(p, default_initial_value=False)
+        problem.add_action(a)
+        problem.add_goal(p)
+        problem.add_quality_metric(MinimizeSequentialPlanLength())
+
+        writer = PDDLWriter(problem)
+        # UPPDDLReader directly: PDDLReader would fall back to it anyway
+        parsed = UPPDDLReader().parse_problem_string(
+            writer.get_domain(), writer.get_problem()
+        )
+        self.assertEqual(len(parsed.quality_metrics), 1)
+        self.assertIsInstance(parsed.quality_metrics[0], MinimizeSequentialPlanLength)
+
     def test_grounding_tpp_metric(self):
         reader = UPPDDLReader()
 


### PR DESCRIPTION
## Problem

Three independent bugs, none of which any existing test catches. Each is fixed in its own commit with its own regression test, so they can be reviewed — or cherry-picked onto a patch release — separately.

**1. Rebuilt durative simulated effects all called the last one's function.**
`create_action_with_given_subs` rebuilds a `DurativeAction`'s simulated effects one timing at a time, and the closure it builds captured the loop variable rather than its value. That closure is stored in the `SimulatedEffect` and attached to the action, so it outlives the loop — by the time it runs, every timing invoked the last timing's function. The result is a silently wrong compiled problem on every path through this helper: grounder, quantifiers remover, disjunctive and conditional effects removers.

Two simulated effects at different timings are legal (`simulated_effects` is keyed by `Timing`, and `check_conflicting_simulated_effects` only compares within a single timing), but nothing in the suite used more than one. The only grounder test with simulated effects goes through the `InstantaneousAction` branch, which is safe because it is an `if` rather than a `for` — which is why two otherwise identical blocks behaved differently.

**2. All default-constructed `MethodInstance`s shared one `Decomposition`.**
`decomposition` defaulted to a single class-level `Decomposition()`, so every instance saw the same `subtasks` dict and mutating one leaked into all the others. Neither `MethodInstance` nor `Decomposition` had any test coverage.

**3. Three defects in `UPPDDLReader`'s total-cost handling.**
`use_plan_length` was assigned `False` in five places and read once, but never initialised — so a domain declaring `(:metric minimize (total-cost))` with no actions raised `UnboundLocalError` straight out of `parse_problem`. Separately, `cost.value` is an `FNode`, which leaves `__eq__` as identity, so `cost.value != 1` was never false: the flag was cleared for every action that had a cost at all, making `MinimizeSequentialPlanLength` unreachable. A domain whose actions all cost 1 parsed as `MinimizeActionCosts`.

## Fix

- `engines/compilers/utils.py`: bind `old_se` as a default argument. Renamed, since both closures share a scope and their signatures now differ (mypy `no-redef`).
- `plans/hierarchical_plan.py`: `field(default_factory=Decomposition)`.
- `io/up_pddl_reader.py`: initialise `use_plan_length = True`, and compare the constant via `is_int_constant()` / `constant_value()`.

With the reader fixed, a uniformly unit-cost domain now yields the plan-length metric, which is what the surrounding code was written to do. **No existing fixture changes behaviour**: `parking_action_cost` has no instantaneous actions, `citycar`'s costs are not all 1, and `tpp_metric`'s are expressions. It also makes the metric survive a PDDL round trip, since `PDDLWriter` already emits unit increase effects for it.

## Test plan

- [x] 5 new tests, each verified to **fail against the pre-fix sources** and pass after — checked by loading the parent commit's version of each file through an import hook, so they are genuine regression guards rather than tautologies
- [x] `just test` — 527 passed, 3 skipped (unchanged)
- [x] `just lint`
- [x] `just typecheck`
- [x] pre-commit hooks on each commit
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)