### PR TITLE
fix: write ANML real bounds as decimals

### DIFF
--- a/unified_planning/io/anml_writer.py
+++ b/unified_planning/io/anml_writer.py
@@ -14,6 +14,7 @@
 #
 
 
+from decimal import Decimal, localcontext
 from fractions import Fraction
 import re
 import sys
@@ -30,6 +31,7 @@ from unified_planning.model import (
 from unified_planning.model.types import _UserType, _RealType, _IntType
 from typing import IO, Dict, List, Optional, cast, Union
 from io import StringIO
+from warnings import warn
 
 ANML_KEYWORDS = {
     "action",
@@ -452,6 +454,22 @@ class ANMLWriter:
             return f"{left_bracket} {self._convert_anml_timing(interval.lower)}, {self._convert_anml_timing(interval.upper)} {right_bracket}"
 
 
+ANML_DECIMAL_PRECISION = 10  # Number of decimal places used for real type bounds
+
+
+def _anml_decimal(frac: Fraction) -> str:
+    """Formats a Fraction as an ANML `real` literal (digits "." digits)."""
+    with localcontext() as ctx:
+        ctx.prec = ANML_DECIMAL_PRECISION
+        dec = frac.numerator / Decimal(frac.denominator, ctx)
+        if Fraction(dec) != frac:
+            warn(
+                f"The ANML printer cannot exactly represent the real constant '{frac}'"
+            )
+        res = format(dec, "f")  # never scientific notation
+    return res if "." in res else f"{res}.0"  # the grammar requires a fractional part
+
+
 def _is_valid_anml_name(name: str) -> bool:
     regex = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*")
     if (
@@ -526,18 +544,16 @@ def _get_anml_name(
             new_name = f"integer {left_bound}, {right_bound}"
         elif isinstance(item, up.model.Type) and item.is_real_type():
             num_real_type = cast(_RealType, item)
-            if num_real_type.lower_bound is None:
-                left_bound = "(-infinity"
-            elif num_real_type.lower_bound.denominator == 1:
-                left_bound = f"[{str(num_real_type.lower_bound)}.0"
-            else:
-                left_bound = f"[{str(num_real_type.lower_bound)}"
-            if num_real_type.upper_bound is None:
-                right_bound = "infinity)"
-            elif num_real_type.upper_bound.denominator == 1:
-                right_bound = f"{str(num_real_type.upper_bound)}.0]"
-            else:
-                right_bound = f"{str(num_real_type.upper_bound)}]"
+            left_bound = (
+                "(-infinity"
+                if num_real_type.lower_bound is None
+                else f"[{_anml_decimal(num_real_type.lower_bound)}"
+            )
+            right_bound = (
+                "infinity)"
+                if num_real_type.upper_bound is None
+                else f"{_anml_decimal(num_real_type.upper_bound)}]"
+            )
             new_name = f"float {left_bound}, {right_bound}"
         else:  # We mangle the name and get a fresh one
             new_name = _get_anml_valid_name(item)

--- a/unified_planning/test/test_anml_reader.py
+++ b/unified_planning/test/test_anml_reader.py
@@ -826,6 +826,7 @@ class TestANMLReader(unittest_TestCase):
         reader = ANMLReader()
         anml = """
         fluent float x := 0.1;
+        fluent float[0.1, 0.3] y := 0.2;
         action Dummy() {
             duration := 1.3;
         };
@@ -835,6 +836,10 @@ class TestANMLReader(unittest_TestCase):
 
         x = problem.fluent("x")
         self.assertEqual(problem.initial_value(x()), em.Real(Fraction(1, 10)))
+        self.assertEqual(
+            problem.fluent("y").type,
+            problem.environment.type_manager.RealType(Fraction(1, 10), Fraction(3, 10)),
+        )
         dummy = cast(DurativeAction, problem.action("Dummy"))
         self.assertEqual(dummy.duration, FixedDuration(em.Real(Fraction(13, 10))))
 
@@ -845,15 +850,3 @@ class TestANMLReader(unittest_TestCase):
                 problem_filename, problem.name
             )
         self.assertEqual(problem, reparsed_problem)
-
-        # Same precision requirement for a non-integer real-type bound.
-        bounded_anml = "fluent float[0.1, 0.3] y;"
-        bounded_problem = reader.parse_problem_string(
-            bounded_anml, "test_decimal_literal_precision_bounds"
-        )
-        self.assertEqual(
-            bounded_problem.fluent("y").type,
-            bounded_problem.environment.type_manager.RealType(
-                Fraction(1, 10), Fraction(3, 10)
-            ),
-        )

--- a/unified_planning/test/test_anml_writer.py
+++ b/unified_planning/test/test_anml_writer.py
@@ -16,7 +16,7 @@
 from unified_planning.shortcuts import *
 from unified_planning.test import unittest_TestCase
 from unified_planning.test.examples import get_example_problems
-from unified_planning.io import ANMLWriter, PDDLReader
+from unified_planning.io import ANMLReader, ANMLWriter, PDDLReader
 import os
 
 
@@ -257,6 +257,31 @@ instance when_ predicate_;
 [ start ] f_4ction := false;
 """
         self.assertEqual(anml_problem, expected_result)
+
+    def test_bounded_real_fluent(self):
+        # A non-integer real-type bound must be written as a plain decimal literal
+        # (e.g. "0.1"), not as "numerator/denominator", which the ANML grammar's
+        # `real` literal cannot parse.
+        tm = get_environment().type_manager
+        problem = Problem("bounded_types")
+        x = Fluent("x", tm.RealType(Fraction(1, 10), Fraction(3, 10)))
+        y = Fluent("y", tm.RealType(0, 100))
+        problem.add_fluent(x, default_initial_value=Fraction(1, 5))
+        problem.add_fluent(y, default_initial_value=50)
+        aw = ANMLWriter(problem)
+        anml_problem = aw.get_problem()
+        expected_result = """constant float [0.1, 0.3] x;
+constant float [0.0, 100.0] y;
+x := (1/5);
+y := 50;
+"""
+        self.assertEqual(anml_problem, expected_result)
+
+        reparsed_problem = ANMLReader().parse_problem_string(
+            anml_problem, "bounded_types"
+        )
+        self.assertEqual(reparsed_problem.fluent("x").type, x.type)
+        self.assertEqual(reparsed_problem.fluent("y").type, y.type)
 
     def test_forall_effects(self):
         FILE_PATH = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- `ANMLWriter` emitted non-integer real-type bounds as `numerator/denominator` (e.g. `float [1/10, 3/10]`), which the ANML grammar's `real` literal cannot parse — round-tripping any fluent with such a bound through the writer produced unreadable ANML.
- Format bounds as fixed-precision decimal strings instead, mirroring the existing `pddl_writer.py` approach for real constants.