### PR TITLE
fix: don't crash on a Dot effect target's own fluent expression

### DIFF
--- a/unified_planning/model/effect.py
+++ b/unified_planning/model/effect.py
@@ -77,8 +77,11 @@ class Effect:
         forall: Iterable["up.model.variable.Variable"] = tuple(),
     ):
         fve = fluent.environment.free_vars_extractor
+        # A multi-agent target is a Dot node wrapping the modified fluent expression, so the
+        # extractor yields that inner expression rather than the Dot node itself.
+        target_fluent_exp = fluent.arg(0) if fluent.is_dot() else fluent
         fluents_in_fluent = set(fve.get(fluent))
-        fluents_in_fluent.remove(fluent)
+        fluents_in_fluent.discard(target_fluent_exp)
         if fluents_in_fluent:
             raise UPProblemDefinitionError(
                 f"The fluent: {fluent} contains other fluents in his arguments: {fluents_in_fluent}"

--- a/unified_planning/test/test_model.py
+++ b/unified_planning/test/test_model.py
@@ -26,6 +26,7 @@ from unified_planning.exceptions import (
 from unified_planning.test.examples import get_example_problems
 from unified_planning.test import unittest_TestCase, main
 from unified_planning.model.action import InstantaneousAction
+from unified_planning.model.multi_agent import Agent, MultiAgentProblem
 
 
 class TestModel(unittest_TestCase):
@@ -150,6 +151,35 @@ class TestModel(unittest_TestCase):
         b = InstantaneousAction("b")
         with self.assertRaises(UPProblemDefinitionError):
             b.add_effect(value(other), 9)
+
+    def test_effect_dot_target(self):
+        Location = UserType("Location")
+        l1 = Object("l1", Location)
+        at = Fluent("at", BoolType(), l=Location)
+        home = Fluent("home", Location)
+        counter = Fluent("counter", IntType())
+
+        ma = MultiAgentProblem("ma")
+        ma.add_object(l1)
+        ag = Agent("a1", ma)
+        ag.add_fluent(at, default_initial_value=False)
+        ag.add_fluent(home, default_initial_value=l1)
+        ag.add_fluent(counter, default_initial_value=0)
+        ma.add_agent(ag)
+
+        # a Dot target with no other fluents nested in its arguments is accepted...
+        c = InstantaneousAction("c")
+        c.add_effect(Dot(ag, at(l1)), True)
+        self.assertEqual(c.effects[0].fluent, Dot(ag, at(l1)))
+
+        d = InstantaneousAction("d")
+        d.add_increase_effect(Dot(ag, counter()), 1)
+        self.assertEqual(d.effects[0].fluent, Dot(ag, counter()))
+
+        # ...but a Dot target with another fluent nested in its arguments is still rejected.
+        e = InstantaneousAction("e")
+        with self.assertRaises(UPProblemDefinitionError):
+            e.add_effect(Dot(ag, at(home())), True)
 
     def test_interpreted_functions_in_numeric_assignments(self):
         i_type = IntType(0, 5)


### PR DESCRIPTION
## Summary
- `Effect.__init__` raised an uncaught `KeyError` instead of running its "no nested fluents in the target's arguments" check whenever the effect target was a multi-agent `Dot(agent, fluent_exp)` node, because the free-vars extractor returns the `Dot`'s inner fluent expression rather than the `Dot` node itself.
- Fix by discarding the `Dot`'s inner fluent expression (falling back to the target itself for a plain fluent target) instead of assuming the target is always present in the extractor's result.

## Test plan
- [x] Added `test_effect_dot_target` in `unified_planning/test/test_model.py`, verified it fails with the reported `KeyError` before the fix and passes after