### PR TITLE
fix: don't drop fields when cloning HTN/contingent problems

### DIFF
--- a/unified_planning/model/contingent/contingent_problem.py
+++ b/unified_planning/model/contingent/contingent_problem.py
@@ -72,29 +72,7 @@ class ContingentProblem(Problem):
 
     def clone(self):
         new_p = ContingentProblem(self._name, self._env)
-        new_p._fluents = self._fluents[:]
-        new_p._actions = [a.clone() for a in self._actions]
-        new_p._user_types = self._user_types[:]
-        new_p._user_types_hierarchy = self._user_types_hierarchy.copy()
-        new_p._objects = self._objects[:]
-        new_p._initial_value = self._initial_value.copy()
-        new_p._timed_effects = {
-            t: [e.clone() for e in el] for t, el in self._timed_effects.items()
-        }
-        new_p._timed_goals = {i: [g for g in gl] for i, gl in self._timed_goals.items()}
-        new_p._goals = self._goals[:]
-        new_p._metrics = []
-        for m in self._metrics:
-            if m.is_minimize_action_costs():
-                assert isinstance(m, up.model.metrics.MinimizeActionCosts)
-                costs: Dict["up.model.Action", "up.model.Expression"] = {
-                    new_p.action(a.name): c for a, c in m.costs.items()
-                }
-                new_p._metrics.append(up.model.metrics.MinimizeActionCosts(costs))
-            else:
-                new_p._metrics.append(m)
-        new_p._initial_defaults = self._initial_defaults.copy()
-        new_p._fluents_defaults = self._fluents_defaults.copy()
+        Problem._clone_to(self, new_p)
         new_p._hidden_fluents = self._hidden_fluents.copy()
         new_p._or_initial_constraints = self._or_initial_constraints.copy()
         new_p._oneof_initial_constraints = self._oneof_initial_constraints.copy()

--- a/unified_planning/model/htn/hierarchical_problem.py
+++ b/unified_planning/model/htn/hierarchical_problem.py
@@ -76,29 +76,7 @@ class HierarchicalProblem(up.model.problem.Problem):
 
     def clone(self):
         new_p = HierarchicalProblem(self._name, self._env)
-        new_p._fluents = self._fluents[:]
-        new_p._actions = [a.clone() for a in self._actions]
-        new_p._user_types = self._user_types[:]
-        new_p._user_types_hierarchy = self._user_types_hierarchy.copy()
-        new_p._objects = self._objects[:]
-        new_p._initial_value = self._initial_value.copy()
-        new_p._timed_effects = {
-            t: [e.clone() for e in el] for t, el in self._timed_effects.items()
-        }
-        new_p._timed_goals = {i: [g for g in gl] for i, gl in self._timed_goals.items()}
-        new_p._goals = self._goals[:]
-        new_p._metrics = []
-        for m in self._metrics:
-            if m.is_minimize_action_costs():
-                assert isinstance(m, up.model.metrics.MinimizeActionCosts)
-                costs: Dict["up.model.Action", "up.model.Expression"] = {
-                    new_p.action(a.name): c for a, c in m.costs.items()
-                }
-                new_p._metrics.append(up.model.metrics.MinimizeActionCosts(costs))
-            else:
-                new_p._metrics.append(m)
-        new_p._initial_defaults = self._initial_defaults.copy()
-        new_p._fluents_defaults = self._fluents_defaults.copy()
+        up.model.problem.Problem._clone_to(self, new_p)
         new_p._initial_task_network = self._initial_task_network.clone()
         new_p._methods = self._methods.copy()
         new_p._abstract_tasks = self._abstract_tasks.copy()

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -250,6 +250,15 @@ class Problem(  # type: ignore[misc]
 
     def clone(self):
         new_p = Problem(self._name, self._env)
+        self._clone_to(new_p)
+        return new_p
+
+    def _clone_to(self, new_p: "Problem"):  # type: ignore[override]
+        """
+        Copies this `Problem`'s state onto `new_p`, which must already be a fresh instance of
+        `Problem` (or a subclass sharing the same fields). Used by `clone()` and by subclasses
+        (e.g. `HierarchicalProblem`, `ContingentProblem`) that add their own state around it.
+        """
         UserTypesSetMixin._clone_to(self, new_p)
         ObjectsSetMixin._clone_to(self, new_p)
         FluentsSetMixin._clone_to(self, new_p)
@@ -271,7 +280,6 @@ class Problem(  # type: ignore[misc]
 
         # last as it requires actions to be cloned already
         MetricsMixin._clone_to(self, new_p, new_actions=new_p)
-        return new_p
 
     def has_name(self, name: str) -> bool:
         """

--- a/unified_planning/test/test_contingent_problem.py
+++ b/unified_planning/test/test_contingent_problem.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 from unified_planning.test import unittest_TestCase
 
 from unified_planning.model.contingent import ContingentProblem
@@ -100,6 +102,63 @@ class TestContingentProblem(unittest_TestCase):
         p1, p2 = make(), make()
         self.assertEqual(p1, p2)
         self.assertEqual(hash(p1), hash(p2))
+
+    def test_contingent_problem_clone_preserves_fields(self):
+        BlockType = UserType("block")
+        clear = Fluent("clear", BoolType(), b=BlockType)
+        b1 = Object("b1", BlockType)
+        b2 = Object("b2", BlockType)
+        a = InstantaneousAction("a")
+        a.add_effect(clear(b1), True)
+
+        problem = ContingentProblem("p")
+        problem.add_fluent(clear, default_initial_value=False)
+        problem.add_object(b1)
+        problem.add_object(b2)
+        problem.add_action(a)
+
+        # TimeModelMixin state
+        problem.epsilon = Fraction(1, 100)
+        problem.discrete_time = True
+        problem.self_overlapping = True
+
+        # natural transitions
+        event = Event("ev")
+        event.add_effect(clear(b1), True)
+        problem.add_event(event)
+        process = Process("proc")
+        y = Fluent("y", RealType())
+        problem.add_fluent(y, default_initial_value=0)
+        process.add_increase_continuous_effect(y, 1)
+        problem.add_process(process)
+
+        # quality metric default
+        problem.add_quality_metric(MinimizeActionCosts({a: 5}, default=99))
+
+        # trajectory constraint
+        problem.add_trajectory_constraint(Always(clear(b1)))
+
+        # contingent-specific state
+        problem.add_oneof_initial_constraint([clear(b1), clear(b2)])
+        problem.add_or_initial_constraint([clear(b1), clear(b2)])
+        problem.add_goal(clear(b1))
+
+        clone = problem.clone()
+
+        self.assertEqual(problem.epsilon, clone.epsilon)
+        self.assertEqual(problem.discrete_time, clone.discrete_time)
+        self.assertEqual(problem.self_overlapping, clone.self_overlapping)
+        self.assertEqual(len(problem.events), len(clone.events))
+        self.assertEqual(len(problem.processes), len(clone.processes))
+        metric, clone_metric = problem.quality_metrics[0], clone.quality_metrics[0]
+        assert isinstance(metric, MinimizeActionCosts) and isinstance(
+            clone_metric, MinimizeActionCosts
+        )
+        self.assertEqual(metric.default, clone_metric.default)
+        self.assertEqual(problem.trajectory_constraints, clone.trajectory_constraints)
+        self.assertEqual(problem.hidden_fluents, clone.hidden_fluents)
+        self.assertEqual(problem, clone)
+        self.assertEqual(clone, problem)
 
     def test_contingent_problem_hash_equals_with_duplicate_constraints(self):
         BlockType = UserType("block")

--- a/unified_planning/test/test_htn.py
+++ b/unified_planning/test/test_htn.py
@@ -14,10 +14,11 @@
 
 import os
 import tempfile
+from fractions import Fraction
 
 import unified_planning as up
 from unified_planning.io import PDDLReader, PDDLWriter
-from unified_planning.model.htn import TaskNetwork, Task
+from unified_planning.model.htn import HierarchicalProblem, Method, TaskNetwork, Task
 from unified_planning.model.htn.ordering import PartialOrder, TotalOrder
 from unified_planning.shortcuts import *
 from unified_planning.test import unittest_TestCase, main, examples
@@ -61,6 +62,64 @@ class TestProblem(unittest_TestCase):
             "TASK_ORDER_TEMPORAL"
             in self.problems["htn-go-temporal"].problem.kind.features
         )
+
+    def test_hierarchical_problem_clone_preserves_fields(self):
+        x = Fluent("x", BoolType())
+        a = InstantaneousAction("a")
+        a.add_effect(x, True)
+
+        problem = HierarchicalProblem("p")
+        problem.add_fluent(x, default_initial_value=False)
+        problem.add_action(a)
+
+        # TimeModelMixin state
+        problem.epsilon = Fraction(1, 100)
+        problem.discrete_time = True
+        problem.self_overlapping = True
+
+        # natural transitions
+        event = Event("ev")
+        event.add_effect(x, True)
+        problem.add_event(event)
+        process = Process("proc")
+        y = Fluent("y", RealType())
+        problem.add_fluent(y, default_initial_value=0)
+        process.add_increase_continuous_effect(y, 1)
+        problem.add_process(process)
+
+        # quality metric default
+        problem.add_quality_metric(MinimizeActionCosts({a: 5}, default=99))
+
+        # trajectory constraint
+        problem.add_trajectory_constraint(Always(x))
+
+        # HTN-specific state
+        go = problem.add_task("go")
+        go_noop = Method("go-noop")
+        go_noop.set_task(go)
+        problem.add_method(go_noop)
+        problem.task_network.add_subtask(go, ident="go1")
+
+        clone = problem.clone()
+
+        self.assertEqual(problem.epsilon, clone.epsilon)
+        self.assertEqual(problem.discrete_time, clone.discrete_time)
+        self.assertEqual(problem.self_overlapping, clone.self_overlapping)
+        self.assertEqual(len(problem.events), len(clone.events))
+        self.assertEqual(len(problem.processes), len(clone.processes))
+        metric, clone_metric = problem.quality_metrics[0], clone.quality_metrics[0]
+        assert isinstance(metric, MinimizeActionCosts) and isinstance(
+            clone_metric, MinimizeActionCosts
+        )
+        self.assertEqual(metric.default, clone_metric.default)
+        self.assertEqual(problem.trajectory_constraints, clone.trajectory_constraints)
+        self.assertEqual(len(problem.tasks), len(clone.tasks))
+        self.assertEqual(len(problem.methods), len(clone.methods))
+        self.assertEqual(
+            len(problem.task_network.subtasks), len(clone.task_network.subtasks)
+        )
+        self.assertEqual(problem, clone)
+        self.assertEqual(clone, problem)
 
     def test_task_network_constraint_kind(self):
         Loc = UserType("Loc")


### PR DESCRIPTION
## Summary
- `HierarchicalProblem.clone()` and `ContingentProblem.clone()` each hand-rolled a field-by-field copy of their `Problem` base instead of delegating to it, so time-model settings (`epsilon`, `discrete_time`, `self_overlapping`), `processes`/`events`, `MinimizeActionCosts.default`, and trajectory constraints were all silently dropped on clone.
- Extracted `Problem.clone()`'s body into `Problem._clone_to`, the same delegation pattern the mixins (`TimeModelMixin._clone_to`, `MetricsMixin._clone_to`, ...) already use, and had both subclasses call it before layering their own subclass-specific state (methods/tasks/task network; hidden fluents/oneof/or constraints) on top.

## Test plan
- [x] Added `test_hierarchical_problem_clone_preserves_fields` (`test_htn.py`) and `test_contingent_problem_clone_preserves_fields` (`test_contingent_problem.py`), covering every field that was previously lost; verified both fail against the pre-fix code and pass after.