### PR TITLE
fix: copy _fluents_inc_dec in Problem.clone()

### DIFF
--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -268,6 +268,9 @@ class Problem(  # type: ignore[misc]
         new_p._fluents_assigned = {
             t: d.copy() for t, d in self._fluents_assigned.items()
         }
+        new_p._fluents_inc_dec = {
+            t: fs.copy() for t, fs in self._fluents_inc_dec.items()
+        }
 
         # last as it requires actions to be cloned already
         MetricsMixin._clone_to(self, new_p, new_actions=new_p)

--- a/unified_planning/test/test_model.py
+++ b/unified_planning/test/test_model.py
@@ -105,6 +105,29 @@ class TestModel(unittest_TestCase):
             self.assertNotEqual(problem_clone_2, problem)
             self.assertNotEqual(problem, problem_clone_2)
 
+    def test_clone_preserves_timed_effect_conflict_tracking(self):
+        x = Fluent("x", RealType())
+        y = Fluent("y", RealType())
+        problem = Problem("p")
+        problem.add_fluent(x, default_initial_value=0)
+        problem.add_fluent(y, default_initial_value=0)
+        t = GlobalStartTiming()
+        problem.add_increase_effect(t, x, 1)
+
+        # sanity: the original detects the conflict
+        with self.assertRaises(UPConflictingEffectsException):
+            problem.add_timed_effect(t, x, 2)
+
+        problem_clone = problem.clone()
+        self.assertEqual(problem_clone._fluents_inc_dec, problem._fluents_inc_dec)
+        # the clone must detect the very same conflict
+        with self.assertRaises(UPConflictingEffectsException):
+            problem_clone.add_timed_effect(t, x, 2)
+
+        # ... and the copy must be independent from the original
+        problem_clone.add_increase_effect(t, y, 1)
+        problem.add_timed_effect(t, y, 2)  # no conflict on the original
+
     def test_clone_action(self):
         Location = UserType("Location")
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Summary
- `Problem.clone()` copied `_fluents_assigned` but never copied the sibling `_fluents_inc_dec` set, so a clone started with empty increase/decrease conflict tracking.
- As a result, adding a timed effect to a cloned `Problem` that conflicts with a pre-existing increase/decrease effect at the same timing silently succeeded instead of raising `UPConflictingEffectsException`, even though the same call on the original problem correctly raised.
- Fixed by copying `_fluents_inc_dec` in `Problem.clone()`, mirroring how `TimedCondsEffs._clone_to` already handles this pair of fields.

## Test plan
- [x] Added `test_clone_preserves_timed_effect_conflict_tracking` to `unified_planning/test/test_model.py`, verified it fails before the fix and passes after.