### PR TITLE
fix: correct NegativeConditionsRemover kind reporting and cost handling

### DIFF
--- a/unified_planning/engines/compilers/negative_conditions_remover.py
+++ b/unified_planning/engines/compilers/negative_conditions_remover.py
@@ -249,8 +249,12 @@ class NegativeConditionsRemover(engines.engine.Engine, CompilerMixin):
         new_kind = problem_kind.clone()
         if new_kind.has_negative_conditions():
             new_kind.unset_conditions_kind("NEGATIVE_CONDITIONS")
-            if new_kind.has_equalities():
-                new_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
+            # Removing a negation rewrites the condition in NNF, which can turn a
+            # negated conjunction, equality or iff into a genuine disjunction, e.g.:
+            #   Not(And(a, b))     -> Or(not_a, not_b)
+            #   Not(Equals(x, y))  -> Or(GT(x, y), LT(x, y))
+            #   Not(Iff(a, b))     -> Or(And(a, b), And(not_a, not_b))
+            new_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
         return new_kind
 
     def _compile(

--- a/unified_planning/engines/compilers/negative_conditions_remover.py
+++ b/unified_planning/engines/compilers/negative_conditions_remover.py
@@ -340,11 +340,8 @@ class NegativeConditionsRemover(engines.engine.Engine, CompilerMixin):
 
         for qm in problem.quality_metrics:
             if qm.is_minimize_action_costs():
-                new_problem.add_quality_metric(
-                    updated_minimize_action_costs(
-                        qm, new_to_old, new_problem.environment
-                    )
-                )
+                # Handled below, once new_to_old is populated by the actions loop.
+                continue
             elif qm.is_oversubscription():
                 assert isinstance(qm, Oversubscription)
                 new_problem.add_quality_metric(
@@ -468,6 +465,14 @@ class NegativeConditionsRemover(engines.engine.Engine, CompilerMixin):
                             e.forall,
                         ),
                     )
+
+        for qm in problem.quality_metrics:
+            if qm.is_minimize_action_costs():
+                new_problem.add_quality_metric(
+                    updated_minimize_action_costs(
+                        qm, new_to_old, new_problem.environment
+                    )
+                )
 
         return CompilerResult(
             new_problem, partial(replace_action, map=new_to_old), self.name

--- a/unified_planning/test/test_negative_conditions_remover.py
+++ b/unified_planning/test/test_negative_conditions_remover.py
@@ -457,3 +457,39 @@ class TestNegativeConditionsRemover(unittest_TestCase):
         comp_res = ncr.compile(problem, CompilationKind.NEGATIVE_CONDITIONS_REMOVING)
         assert isinstance(comp_res.problem, Problem)
         self.assertEqual(expected_action, comp_res.problem.action("test_action"))
+
+    def test_resulting_kind_negated_conjunction_is_disjunctive(self):
+        # Negating a conjunction (`Not(And(a, b))`) turns into `Or(not_a, not_b)` in
+        # NNF, even though the input problem has no equalities at all.
+        # `resulting_problem_kind` must claim `DISJUNCTIVE_CONDITIONS` here.
+        a = Fluent("a")
+        b = Fluent("b")
+        goal_f = Fluent("goal_f")
+        act = InstantaneousAction("act")
+        act.add_precondition(Not(And(a, b)))
+        act.add_effect(goal_f, True)
+        problem = Problem("test")
+        problem.add_fluent(a, default_initial_value=True)
+        problem.add_fluent(b, default_initial_value=False)
+        problem.add_fluent(goal_f, default_initial_value=False)
+        problem.add_action(act)
+        problem.add_goal(goal_f)
+
+        self.assertTrue(problem.kind.has_negative_conditions())
+        self.assertFalse(problem.kind.has_disjunctive_conditions())
+        self.assertFalse(problem.kind.has_equalities())
+
+        ncr = NegativeConditionsRemover()
+        resulting_kind = ncr.resulting_problem_kind(
+            problem.kind, CompilationKind.NEGATIVE_CONDITIONS_REMOVING
+        )
+        comp_res = ncr.compile(problem, CompilationKind.NEGATIVE_CONDITIONS_REMOVING)
+        assert isinstance(comp_res.problem, Problem)
+        compiled_kind = comp_res.problem.kind
+
+        # the compiled problem really has an Or in it...
+        self.assertTrue(compiled_kind.has_disjunctive_conditions())
+        # ...and the claimed resulting kind must not hide that.
+        self.assertFalse(resulting_kind.has_negative_conditions())
+        self.assertTrue(resulting_kind.has_disjunctive_conditions())
+        self.assertTrue(compiled_kind <= resulting_kind)

--- a/unified_planning/test/test_negative_conditions_remover.py
+++ b/unified_planning/test/test_negative_conditions_remover.py
@@ -29,6 +29,7 @@ from unified_planning.model.problem_kind import (
 )
 from unified_planning.engines.compilers import NegativeConditionsRemover
 from unified_planning.engines import CompilationKind
+from unified_planning.exceptions import UPExpressionDefinitionError
 
 
 class TestNegativeConditionsRemover(unittest_TestCase):
@@ -493,3 +494,63 @@ class TestNegativeConditionsRemover(unittest_TestCase):
         self.assertFalse(resulting_kind.has_negative_conditions())
         self.assertTrue(resulting_kind.has_disjunctive_conditions())
         self.assertTrue(compiled_kind <= resulting_kind)
+
+    def test_action_costs_are_preserved(self):
+        a = Fluent("a")
+        goal_f = Fluent("goal_f")
+        act = InstantaneousAction("act")
+        act.add_precondition(Not(a))
+        act.add_effect(goal_f, True)
+        problem = Problem("test")
+        problem.add_fluent(a, default_initial_value=True)
+        problem.add_fluent(goal_f, default_initial_value=False)
+        problem.add_action(act)
+        problem.add_goal(goal_f)
+        problem.add_quality_metric(MinimizeActionCosts({act: 5}))
+
+        ncr = NegativeConditionsRemover()
+        comp_res = ncr.compile(problem, CompilationKind.NEGATIVE_CONDITIONS_REMOVING)
+        assert isinstance(comp_res.problem, Problem)
+        new_problem = comp_res.problem
+
+        self.assertEqual(len(new_problem.quality_metrics), 1)
+        new_metric = new_problem.quality_metrics[0]
+        assert isinstance(new_metric, MinimizeActionCosts)
+        new_action = new_problem.action("act")
+        self.assertEqual(new_metric.get_action_cost(new_action), Int(5))
+
+    def test_all_problem_kind(self):
+        # for every shared example problem this compiler supports, the claimed
+        # resulting kind must cover the actually compiled problem's kind.
+        ncr = NegativeConditionsRemover()
+        checked = 0
+        for example in self.problems.values():
+            problem = example.problem
+            if not isinstance(problem, Problem):
+                continue
+            kind = problem.kind
+            if not NegativeConditionsRemover.supports(kind):
+                continue
+            if not kind.has_negative_conditions():
+                continue
+            try:
+                comp_res = ncr.compile(
+                    problem, CompilationKind.NEGATIVE_CONDITIONS_REMOVING
+                )
+            except UPExpressionDefinitionError:
+                # This compiler cannot remove negations from quantified expressions
+                # or from trajectory constraints (Nnf treats Always(...) as a leaf).
+                continue
+            assert isinstance(comp_res.problem, Problem)
+            compiled_kind = comp_res.problem.kind
+            resulting_kind = ncr.resulting_problem_kind(
+                kind, CompilationKind.NEGATIVE_CONDITIONS_REMOVING
+            )
+            self.assertTrue(
+                compiled_kind <= resulting_kind,
+                msg=f"{problem.name}: compiled kind has features "
+                f"{sorted(set(compiled_kind.features) - set(resulting_kind.features))} "
+                "that resulting_problem_kind does not claim",
+            )
+            checked += 1
+        self.assertGreater(checked, 0)


### PR DESCRIPTION
## Summary

### 1. `resulting_problem_kind` under-reported `DISJUNCTIVE_CONDITIONS`

`NegativeConditionsRemover._compile` rewrites negated conditions into NNF, which turns
`Not(And(a, b))` into `Or(not_a, not_b)`. But `resulting_problem_kind` only set
`DISJUNCTIVE_CONDITIONS` on the output kind when the *input* kind `has_equalities()`:

```python
if new_kind.has_negative_conditions():
    new_kind.unset_conditions_kind("NEGATIVE_CONDITIONS")
    if new_kind.has_equalities():
        new_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
```

For a problem whose only negative condition is `Not(And(a, b))` (no equalities at all), the
claimed kind said `DISJUNCTIVE_CONDITIONS: False` while the actually compiled problem contained
an `Or`. Any caller that trusts `resulting_problem_kind` to pick the next compilation stage or a
compatible engine without running the compiler first (`Factory._get_engine` does exactly this
when chaining a `CompilersPipeline`) could pick an engine that doesn't actually support the
compiled problem.

Fix: always set `DISJUNCTIVE_CONDITIONS` when `NEGATIVE_CONDITIONS` is removed.
`resulting_problem_kind` only receives a `ProblemKind`, not the actual expression tree, so it has
no way to distinguish a negated atom (no `Or` introduced) from a negated conjunction, equality,
or iff (a real `Or` introduced) - it must over-approximate rather than risk under-reporting.

### 2. `_compile` silently dropped `MinimizeActionCosts` costs

`_compile` rewrites the `MinimizeActionCosts` metric via `updated_minimize_action_costs(qm,
new_to_old, ...)`, where `new_to_old` maps each newly-created action back to the original one it
replaces. `new_to_old` is declared as an empty dict at the top of `_compile` and only populated
later, inside the loop that actually builds and adds the new actions to the problem - but the
cost-metric rewrite ran *before* that loop. It therefore always iterated an empty mapping and
returned a metric with no costs at all: every action's cost was silently lost, regardless of what
the original problem declared.

Reproduced on the shared example `locations_connected_cost_minimize`:
```
input metric:  minimize actions-cost: {'move': distance(l_from, l_to), 'default': None}
output metric: minimize actions-cost: {'default': None}
```

Fix: move the `MinimizeActionCosts` handling into a second pass over the quality metrics, placed
after the actions loop that populates `new_to_old`. `Oversubscription`/`TemporalOversubscription`
handling stays in the original pass, since it also discovers new fluent negations that later code
(building the compiled problem's fluents, initial values, and effects) relies on already knowing
about - moving it too would risk silently missing those.

## Test plan
- [x] Added `test_resulting_kind_negated_conjunction_is_disjunctive`, `test_action_costs_are_preserved`, and `test_all_problem_kind` in `test_negative_conditions_remover.py`