### PR TITLE
fix: forward MinimizeActionCosts default in compiler helper

### DIFF
--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -598,6 +598,12 @@ def updated_minimize_action_costs(
     updated equivalent metric for the new problem. This simply changes the costs keys
     and does not alter the cost expression, so it does not cover use-cases like grounding.
 
+    The original metric's `default` is carried over unchanged to the returned metric. Actions
+    with no original counterpart (mapped to `None` in `new_to_old`) always get cost `0`, not the
+    default: they are compiler-introduced bookkeeping actions (e.g. the fake actions
+    `DisjunctiveConditionsRemover` adds to encode a disjunctive goal) that every valid compiled
+    plan must apply, so giving them a non-zero cost would change the compiled problem's optimum.
+
     :param quality_metric: The `MinimizeActionCosts`metric to update.
     :param new_to_old: The action's mapping from the compiled problem to the original problem.
     :param environment: The environment of the new problem (therefore, also of the new actions).
@@ -611,7 +617,9 @@ def updated_minimize_action_costs(
                 new_costs[new_act] = new_cost
         else:
             new_costs[new_act] = environment.expression_manager.Int(0)
-    return MinimizeActionCosts(new_costs, environment=environment)
+    return MinimizeActionCosts(
+        new_costs, default=quality_metric.default, environment=environment
+    )
 
 
 def remove_fluents(problem: Problem, fluents: Set[Fluent]) -> None:

--- a/unified_planning/test/test_compilers_quality_metrics.py
+++ b/unified_planning/test/test_compilers_quality_metrics.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict, Optional
+
 from unified_planning.shortcuts import *
 from unified_planning.model.problem_kind import (
     basic_classical_kind,
@@ -23,6 +25,13 @@ from unified_planning.test import unittest_TestCase, main
 from unified_planning.test import skipIfNoOneshotPlannerForProblemKind
 from unified_planning.test.examples import get_example_problems
 from unified_planning.engines import CompilationKind
+from unified_planning.engines.compilers import (
+    NegativeConditionsRemover,
+    ConditionalEffectsRemover,
+    QuantifiersRemover,
+    DisjunctiveConditionsRemover,
+)
+from unified_planning.engines.compilers.utils import updated_minimize_action_costs
 
 
 class TestCompilersPipeline(unittest_TestCase):
@@ -75,3 +84,63 @@ class TestCompilersPipeline(unittest_TestCase):
             plan = planner.solve(new_problem).plan
             new_plan = plan.replace_action_instances(res.map_back_action_instance)
             self.assertEqual(new_plan, test_plan)
+
+
+class TestUpdatedMinimizeActionCosts(unittest_TestCase):
+    def _build_problem(self):
+        a = Fluent("a")
+        goal_f = Fluent("goal_f")
+        act = InstantaneousAction("act")
+        act.add_precondition(Not(a))
+        act.add_effect(goal_f, True)
+        problem = Problem("test")
+        problem.add_fluent(a, default_initial_value=True)
+        problem.add_fluent(goal_f, default_initial_value=False)
+        problem.add_action(act)
+        problem.add_goal(goal_f)
+        problem.add_quality_metric(MinimizeActionCosts({act: 5}, default=99))
+        return problem
+
+    def test_default_is_preserved_across_compilers(self):
+        compilers_and_kinds = [
+            (NegativeConditionsRemover, CompilationKind.NEGATIVE_CONDITIONS_REMOVING),
+            (ConditionalEffectsRemover, CompilationKind.CONDITIONAL_EFFECTS_REMOVING),
+            (QuantifiersRemover, CompilationKind.QUANTIFIERS_REMOVING),
+            (
+                DisjunctiveConditionsRemover,
+                CompilationKind.DISJUNCTIVE_CONDITIONS_REMOVING,
+            ),
+        ]
+        for compiler_class, compilation_kind in compilers_and_kinds:
+            with self.subTest(compiler=compiler_class.__name__):
+                problem = self._build_problem()
+                compiler = compiler_class()
+                comp_res = compiler.compile(problem, compilation_kind)
+                new_problem = comp_res.problem
+                assert isinstance(new_problem, Problem)
+
+                self.assertEqual(len(new_problem.quality_metrics), 1)
+                new_metric = new_problem.quality_metrics[0]
+                assert isinstance(new_metric, MinimizeActionCosts)
+                self.assertEqual(new_metric.default, Int(99))
+                new_action = new_problem.action("act")
+                self.assertEqual(new_metric.get_action_cost(new_action), Int(5))
+
+    def test_helper_preserves_default_and_zeroes_new_actions(self):
+        old_act = InstantaneousAction("old")
+        new_act = InstantaneousAction("new")
+        fake_act = InstantaneousAction("fake")
+        metric = MinimizeActionCosts({old_act: 5}, default=99)
+        new_to_old: Dict[Action, Optional[Action]] = {
+            new_act: old_act,
+            fake_act: None,
+        }
+        updated = updated_minimize_action_costs(metric, new_to_old, get_environment())
+        assert isinstance(updated, MinimizeActionCosts)
+        self.assertEqual(updated.default, Int(99))
+        self.assertEqual(updated.get_action_cost(new_act), Int(5))
+        # Actions with no original counterpart (e.g. DisjunctiveConditionsRemover's
+        # fake bookkeeping actions) must keep cost 0, not inherit the default: every
+        # valid compiled plan applies exactly one of them, so a non-zero cost would
+        # change the compiled problem's optimum relative to the original.
+        self.assertEqual(updated.get_action_cost(fake_act), Int(0))


### PR DESCRIPTION
## Summary

The shared helper `updated_minimize_action_costs` (used by all four conditions/effects-removing
compilers - `NegativeConditionsRemover`, `ConditionalEffectsRemover`, `QuantifiersRemover`, and
`DisjunctiveConditionsRemover`) carries over each action's individual cost via
`get_action_cost`, but never passed the original metric's `default` to the reconstructed
`MinimizeActionCosts` - it silently reverted to `None` regardless of what the input problem
declared.

Reproduced:
```
input default:  99
output default: None
```

Fix: pass `default=quality_metric.default` through, matching how `MetricsMixin._clone_to`
already handles `default` on `Problem.clone()`. Actions with no original counterpart (the
`<name>_fake_action` bookkeeping actions `DisjunctiveConditionsRemover` adds to encode a
disjunctive goal) keep cost `0`, not the default - every valid compiled plan applies exactly one
of them, so a non-zero default there would change the compiled problem's optimum.

## Test plan
- [x] Added `TestUpdatedMinimizeActionCosts` (`test_default_is_preserved_across_compilers`,
  `test_helper_preserves_default_and_zeroes_new_actions`) in `test_compilers_quality_metrics.py`,
  covering all four affected compilers plus the shared helper directly