### PR TITLE
perf: speed up grounding, name lookups, and expression promotion

### DIFF
--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -36,7 +36,7 @@ from unified_planning.engines.compilers.utils import (
     create_action_with_given_subs,
     split_all_ands,
 )
-from typing import Dict, List, Optional, Set, Tuple, Iterator, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, Iterator, cast
 from itertools import product
 from functools import partial
 
@@ -73,7 +73,17 @@ class GrounderHelper:
             * `b (o3)`
             * `b (o4)`
             If this map is `None`, the `unified_planning` grounding algorithm is applied.
-        :param prune_actions: If true, the grounder prunes actions exploiting the simplification of static fluents.
+        :param prune_actions: If `True` (the default), actions are pruned exploiting the simplification of
+            static fluents: the action's eligible static fluents are hash-joined together (correctly
+            handling hierarchical typing), so a static predicate that jointly constrains several of the
+            action's parameters together (e.g. a lookup table relating them) is pruned down to the handful
+            of parameter tuples actually consistent with it, rather than enumerating (and then rejecting)
+            their full cross product. If the join isn't applicable/safe for a given action -- an unbounded
+            parameter type, a candidate count above an internal safety cap, or any unexpected condition --
+            that one action falls back to the weaker (but always sound) per-parameter-independent pruning:
+            each parameter is narrowed, independently of the others, to the objects that appear at a
+            matching argument position of some true static fluent in the action's precondition. If
+            `False`, no pruning at all is done.
         """
         assert isinstance(problem, Problem)
         self._problem = problem
@@ -90,13 +100,23 @@ class GrounderHelper:
         # When the grounded instance of the Action is None, it means that the resulting grounding
         # of that action is a meaningless Action.
         # An Action is meaningless when:
-        # - it has no effects
         # - his conditions create a contradiction
         # - the action has conflicting effects
         # - for a DurativeAction, its duration interval simplifies to an empty interval
+        # Note: an action with no effects is NOT rejected; it is grounded as-is.
         self._grounded_actions: Dict[
             Tuple[str, Tuple[FNode, ...]], Optional[Action]
         ] = {}
+        # Caches reused across every lifted action grounded by this instance. The problem is
+        # documented as immutable for the lifetime of this class (grounding relies on it, same
+        # as Simplifier's own "problem must not be modified" contract below), so these are safe
+        # to compute once instead of once per action / per (parameter, static-fluent) pair.
+        self._static_fluents_cache: Optional[Set["up.model.fluent.Fluent"]] = None
+        self._true_arg_tuples_cache: Dict[
+            "up.model.fluent.Fluent", List[Tuple[FNode, ...]]
+        ] = {}
+        self._domain_items_cache: Dict[Type, List[FNode]] = {}
+        self._valid_params_cache: Dict[Tuple[FNode, int], Set[FNode]] = {}
         env = problem.environment
         if prune_actions:
             self._simplifier = Simplifier(env, problem)
@@ -167,7 +187,8 @@ class GrounderHelper:
         * The ``grounded_action`` is the `Action` created by grounding the ``original_action`` with the given ``parameters``;
             the ``grounded_action`` can be ``None`` if the grounding of the ``original_action`` with the given parameters
             creates an invalid or meaningless `Action` (invalid if it has conflicting `Effects`,
-            meaningless if it has no `effects` or contradicting `conditions`).
+            meaningless if its conditions create a contradiction, or, for a `DurativeAction`,
+            if its duration interval simplifies to an empty interval).
         """
         for old_action in self._problem.actions:
             for grounded_params in self.get_possible_parameters(old_action):
@@ -205,52 +226,22 @@ class GrounderHelper:
                 # objects_list = [[r1, r2], [l1, l2]]
                 # the product of *objects_list will be:
                 # [(r1, l1), (r1, l2), (r2, l1), (r2,l2)]
-                ground_size = 1
-                domain_sizes = []
-                for t in type_list:
-                    ds = domain_size(self._problem, t)
-                    domain_sizes.append(ds)
-                    ground_size *= ds
-                items_list: List[List[FNode]] = []
-                for size, type in zip(domain_sizes, type_list):
-                    items_list.append(
-                        [domain_item(self._problem, type, j) for j in range(size)]
-                    )
+                if self._prune_actions:
+                    joined = self._compute_join_pruned_parameters(action, type_list)
+                    if joined is not None:
+                        return iter(joined)
+                    # else: the join wasn't applicable/safe for this action -- fall through
+                    # to the per-parameter-independent cross-product path below, for this
+                    # action only.
 
-                problem_static_fluents = self._problem.get_static_fluents()
-                if self._prune_actions and isinstance(
-                    action, up.model.action.InstantaneousAction
+                items_list: List[List[FNode]] = [
+                    self._get_domain_items(t) for t in type_list
+                ]
+                if self._prune_actions and (
+                    isinstance(action, up.model.action.InstantaneousAction)
+                    or isinstance(action, up.model.action.DurativeAction)
                 ):
-                    no_and_list = split_all_ands(action.preconditions)
-                    bool_conditions = []
-                    for c in no_and_list:
-                        if (
-                            c.is_fluent_exp()
-                            and c.fluent().type.is_bool_type()
-                            and c.fluent() in problem_static_fluents
-                        ):
-                            bool_conditions.append(c)
-                    items_list = self._purge_items_list(
-                        items_list=items_list,
-                        params=action.parameters,
-                        conds=bool_conditions,
-                    )
-                elif self._prune_actions and isinstance(
-                    action, up.model.action.DurativeAction
-                ):
-                    condlist = []
-                    for _, cl in action.conditions.items():
-                        condlist.extend(cl)
-
-                    no_and_list = split_all_ands(condlist)
-                    bool_conditions = []
-                    for c in no_and_list:
-                        if (
-                            c.is_fluent_exp()
-                            and c.fluent().type.is_bool_type()
-                            and c.fluent() in problem_static_fluents
-                        ):
-                            bool_conditions.append(c)
+                    bool_conditions = self._static_bool_fluents(action) or []
                     items_list = self._purge_items_list(
                         items_list=items_list,
                         params=action.parameters,
@@ -261,6 +252,392 @@ class GrounderHelper:
                 # The grounding_actions_map is not None, therefore it must be used to ground
                 res = iter(self._grounding_actions_map.get(action, []))
         return res
+
+    # Safety valve for the join: bail out to the per-parameter cross-product fallback for
+    # one action if its running candidate count exceeds this. The reference dataset this
+    # algorithm was validated against never got close to it (largest was ~52k).
+    _JOIN_MAX_CANDIDATES = 1_000_000
+
+    def _compute_join_pruned_parameters(
+        self, action: Action, type_list: List[Type]
+    ) -> Optional[List[Tuple[FNode, ...]]]:
+        """Hash-joins `action`'s eligible static fluents (`_static_bool_fluents`) against their
+        true argument tuples (`_fluent_true_arg_tuples`), incrementally building only the
+        parameter tuples consistent with every joined fluent -- instead of pruning each
+        parameter independently, which cannot see a static predicate
+        that correlates several of the action's parameters together and so ends up enumerating
+        their full cross product.
+
+        Returns `None` if the join isn't applicable/safe for this action, including when the
+        action type is unrecognized, the parameter type is unbounded or unenumerable, the
+        candidate count exceeds _JOIN_MAX_CANDIDATES, or an unexpected exception occurs.
+        """
+        try:
+            return self._compute_join_pruned_parameters_unsafe(action, type_list)
+        except Exception:
+            return None
+
+    def _compute_join_pruned_parameters_unsafe(
+        self, action: Action, type_list: List[Type]
+    ) -> Optional[List[Tuple[FNode, ...]]]:
+        """Given one action and the type domains of its parameters, return the exact
+        list of parameter tuples that satisfy all of the action's static-boolean-fluent
+        conditions -- computed via a relational hash-join instead of `_purge_items_list`'s
+        per-parameter (independent) pruning. Returns `None` when it can't safely do this
+        (unrecognized action, unbounded type, candidate blow-up, or any exception).
+
+        High-level shape: it's a classic database join -- each static fluent in
+        `static_fluents` is a "table" of rows (the argument tuples for which that fluent is
+        true), and the algorithm joins these tables together on the action-parameter columns
+        they share, incrementally narrowing a running result set (`bindings`). Any parameter
+        columns never touched by a joinable fluent are left free and cross-producted in at
+        the end.
+
+        Step-by-step:
+
+        1. Trivial cases: get `action.parameters` into `params`; if `num_params` is 0,
+            return `[()]`. Fetch the action's eligible static fluents via
+            `_static_bool_fluents`; if `None` (action type not recognized), bail out.
+        2. Set up per-parameter domains:
+            - `param_domains`: each action parameter's candidate objects (via
+              `_get_domain_items`).
+            - `domain_sets`: same, as sets, for fast membership checks.
+            - `domain_position`: object -> index within its own domain, needed later for
+              canonical ordering.
+            - `param_expr_to_column`: maps each parameter's `ParameterExp` to its column
+              index -- this is how a fluent's argument is recognized as "this is action
+              parameter #i" versus a constant or a nested/object-fluent expression.
+        3. Fold loop over static fluents -- this is the core. State carried across
+            iterations:
+            - `bindings`: `None` until the first fluent folds in, then a list of partial
+              bindings (`Dict[column_index, FNode]`), one per surviving candidate row.
+            - `bound_columns`: which parameter columns have been constrained so far.
+
+            For each fluent:
+            - Classify each argument as `("p", col)` if it's an action parameter,
+              `("c", value)` if it's a constant, or `("*", None)` (wildcard) if it's anything
+              else (nested/object-fluent arg -- same blind spot `_purge_items_list`'s
+              per-parameter pruning has).
+            - Skip fluents that touch no parameter column -- nothing to join on.
+            - Materialize this fluent's rows: pull its true argument-tuples via
+              `_fluent_true_arg_tuples`, and for each tuple build a `binding` dict from
+              parameter-columns to values, rejecting the tuple if a constant position
+              doesn't match, if a parameter-column value falls outside that parameter's own
+              domain (the hierarchical-typing guard), or if the fluent binds the same column
+              twice inconsistently (handles `sym(?x, ?x)`-style repeated parameters within
+              one fluent).
+            - Merge into `bindings`:
+              - First fluent: `bindings` just becomes `rows`.
+              - Later fluents: find `shared_columns` already bound vs. this fluent's
+                columns. If there's overlap, do an actual indexed hash-join on those shared
+                columns (`rows_by_shared_key`, built once, then probed once per existing
+                binding into `joined_rows`). If no overlap, it's a cross-product merge
+                (`{**left, **right}` for every pair) -- still correct, just not a filtering
+                join.
+            - Early exits: if `bindings` became empty, stop early (nothing will ever match).
+              If it exceeds `_JOIN_MAX_CANDIDATES`, give up and return `None` (safety valve
+              back to per-parameter pruning for this action).
+        4. Handle free (never-bound) columns: any parameter column no fluent constrained is
+            a `free_column`; its full domain (`free_domains`) must be cross-producted in.
+            Compute the prospective final size (`len(bindings) * free_size`) and bail to
+            `None` if it would exceed the candidate cap.
+        5. Expand into full parameter tuples: for each surviving binding, cross the free
+            columns' domains in (via `product`) and assemble one full
+            `(param_0_value, ..., param_n_value)` tuple per combination into `tuples`. If
+            there are no free columns, just read the binding straight through.
+        6. Canonical sort: sort `tuples` by each parameter's index within its own domain
+            (`domain_position`) -- this matches the enumeration order
+            `itertools.product(*param_domains)` would produce, so the join doesn't silently
+            reorder/rename ground actions relative to the per-parameter fallback.
+        7. Return the final `tuples` list -- the exact, jointly-consistent set of parameter
+            tuples for this action.
+
+        Example: action `deliver(?r: Robot, ?l: Location, ?p: Package)` -- columns 0=r,
+        1=l, 2=p -- with domains `Robot={r1,r2}`, `Location={l1,l2}`, `Package={p1,p2}` (8
+        combinations, unpruned) and static conditions `robot_can_carry(?r,?p)` true for
+        `(r1,p1), (r1,p2), (r2,p1)`, and `package_at(?p,?l)` true for `(p1,l1), (p2,l2)`.
+        Per-parameter pruning can't shrink anything here: `r1`, `r2`, `l1`, `l2`, `p1`, `p2`
+        each appear in at least one true tuple, so all 8 combinations -- including invalid
+        ones like `(r2, l2, p2)`, since r2 never carries p2 -- would still be
+        cross-producted. The join instead folds in `robot_can_carry` first, producing
+        partial bindings `{0:r1,2:p1}, {0:r1,2:p2}, {0:r2,2:p1}`; then folds in
+        `package_at`, joining on their shared column 2 (`p`): `shared_columns = [2]`, and
+        `p1` only pairs with `l1`, `p2` only with `l2`, leaving
+        `bindings = [{0:r1,2:p1,1:l1}, {0:r1,2:p2,1:l2}, {0:r2,2:p1,1:l1}]`. Both columns 0
+        and 1 are already bound here, so there are no free columns left to cross in, and
+        step 5 just reads each binding straight through into
+        `tuples = [(r1,l1,p1), (r1,l2,p2), (r2,l1,p1)]` -- the 3 combinations that are
+        jointly consistent with both conditions.
+
+        The essential idea: rather than pruning each parameter's candidate list independently,
+        this builds up joint bindings fluent-by-fluent, joining on whatever columns two fluents
+        happen to share, and only falls back to a full cross product for the columns nothing
+        constrains.
+        """
+        params = list(action.parameters)
+        num_params = len(params)
+        if num_params == 0:
+            return [tuple()]
+        static_fluents = self._static_bool_fluents(action)
+        if static_fluents is None:
+            # Not an InstantaneousAction/DurativeAction -- an action type this file doesn't
+            # know how to read preconditions/conditions from.
+            return None
+
+        em = self._problem.environment.expression_manager
+        # Every parameter's full type domain
+        param_domains = [self._get_domain_items(t) for t in type_list]
+        domain_sets = [set(d) for d in param_domains]
+        # Each object's position within its own type's domain -- used only at the very end,
+        # to sort the finished tuples back into the same order the caller's plain
+        # `itertools.product` over `param_domains` would have produced them in.
+        domain_position = [{obj: j for j, obj in enumerate(d)} for d in param_domains]
+        # Lets an atom argument that's a bare action parameter (as opposed to a constant or a
+        # nested expression) be recognized and traced back to its column index below.
+        param_expr_to_column = {em.ParameterExp(p): i for i, p in enumerate(params)}
+
+        # `bindings` is the running join result: each element maps a column index to the
+        # object bound there by every static fluent folded in so far. `None` means "no fluent
+        # folded in yet", i.e. fully unconstrained -- distinct from "folded in one and it left
+        # zero rows", which ends the loop early via the `if not bindings: break` below.
+        bindings: Optional[List[Dict[int, FNode]]] = None
+        bound_columns: Set[int] = set()
+
+        # Fold in one static fluent at a time, narrowing `bindings` after each one.
+        for static_fluent in static_fluents:
+            # Classify each argument of this one fluent: a bound action parameter (record its
+            # column), a literal constant, or -- falling through -- an unconstrained wildcard.
+            pattern: List[Tuple[str, Any]] = []
+            for arg in static_fluent.args:
+                if arg in param_expr_to_column:
+                    pattern.append(("p", param_expr_to_column[arg]))
+                elif arg.is_constant():
+                    pattern.append(("c", arg))
+                else:
+                    # nested/object-fluent argument: a wildcard, unconstrained -- same as
+                    # the per-parameter fallback pruning, which can't handle these either.
+                    pattern.append(("*", None))
+
+            fluent_columns: Set[int] = {i for kind, i in pattern if kind == "p"}
+            if not fluent_columns:
+                # Every argument was a constant/wildcard: this fluent doesn't mention any
+                # action parameter, so it has nothing to prune -- skip it (same blind spot
+                # the per-parameter fallback pruning already has).
+                continue
+
+            # Check every argument tuple this fluent is actually true for against the
+            # pattern; each one that's consistent becomes one candidate binding *for this
+            # fluent alone* (not yet folded together with any other fluent's bindings).
+            rows: List[Dict[int, FNode]] = []
+            for true_args in self._fluent_true_arg_tuples(static_fluent.fluent()):
+                binding: Dict[int, FNode] = {}
+                is_consistent = True
+                for (kind, payload), arg_value in zip(pattern, true_args):
+                    if kind == "c":
+                        if arg_value != payload:
+                            # TODO: can we enter here?
+                            is_consistent = False
+                            break
+                    elif kind == "p":
+                        col: int = payload
+                        if arg_value not in domain_sets[col]:
+                            # Hierarchical-typing guard: an object matched via a static fluent's argument
+                            # position must be a member of the ACTION PARAMETER's own type domain, not just the
+                            # static fluent's declared parameter type -- the fluent's declared type may be a
+                            # supertype of the action parameter it's being matched against.
+                            # Omitting this intersection would bind an object that's ill-typed for the action
+                            # parameter.
+                            is_consistent = False
+                            break
+                        # The same parameter appearing at more than one position of this one
+                        # fluent (e.g. `sym(?x, ?x)`) must agree with itself at every
+                        # occurrence, not just be individually well-typed at each one.
+                        if col in binding and binding[col] != arg_value:
+                            # TODO: can we enter here?
+                            is_consistent = False
+                            break
+                        binding[col] = arg_value
+                if is_consistent:
+                    rows.append(binding)
+
+            if bindings is None:
+                # First fluent processed: nothing to join against yet, so its own rows become
+                # the running result outright.
+                bindings, bound_columns = rows, set(fluent_columns)
+            else:
+                # Columns already bound by an earlier fluent that this fluent constrains too
+                # -- the actual join key. Two fluents that don't share any column have no key
+                # to join on at all (handled in the `else` branch below).
+                shared_columns = sorted(bound_columns & fluent_columns)
+                if shared_columns:
+                    # A real hash join: index this fluent's rows by their shared-column
+                    # values once, then probe that index once per existing binding, instead
+                    # of comparing every (existing binding, new row) pair against each other.
+                    rows_by_shared_key: Dict[
+                        Tuple[FNode, ...], List[Dict[int, FNode]]
+                    ] = {}
+                    for row in rows:
+                        key = tuple(row[i] for i in shared_columns)
+                        rows_by_shared_key.setdefault(key, []).append(row)
+                    joined_rows = []
+                    for left in bindings:
+                        key = tuple(left[i] for i in shared_columns)
+                        for right in rows_by_shared_key.get(key, ()):
+                            merged = dict(left)
+                            merged.update(right)
+                            joined_rows.append(merged)
+                    bindings = joined_rows
+                else:
+                    # No shared column: this fluent constrains entirely different
+                    # parameters than anything folded in so far, so there is nothing to join
+                    # on -- cross every existing binding with every one of this fluent's rows.
+                    bindings = [
+                        {**left, **right} for left in bindings for right in rows
+                    ]
+                bound_columns |= fluent_columns
+
+            if not bindings:
+                # Zero rows survived: no combination can ever satisfy every fluent folded in
+                # so far, so no later fluent can matter either -- stop early.
+                break
+            if len(bindings) > self._JOIN_MAX_CANDIDATES:
+                # Safety valve: give up on the join for this action and let the caller fall
+                # back to the (always bounded, if weaker) per-parameter pruning instead.
+                return None
+
+        # Any parameter no static fluent ever constrained keeps its entire type domain --
+        # this reproduces the per-parameter fallback's own behavior exactly for a column
+        # that can't be pruned at all.
+        free_columns = [i for i in range(num_params) if i not in bound_columns]
+        free_domains = [param_domains[i] for i in free_columns]
+        if bindings is None:
+            # No fluent was ever eligible to fold in (e.g. every one hit the `continue`
+            # above): one empty binding, to be crossed with the full free-column domains
+            # below exactly like a plain, unpruned cross product would be.
+            bindings = [{}]
+        free_size = 1
+        for domain in free_domains:
+            free_size *= len(domain)
+        if len(bindings) * free_size > self._JOIN_MAX_CANDIDATES:
+            # Second safety check: even when the constrained part of `bindings` stayed
+            # small, cross-joining in every free column could still blow the budget.
+            return None
+
+        # Expand every surviving (possibly partial) binding with every combination of the
+        # still-free columns' domains, turning each into a full length-`num_params` tuple.
+        tuples: List[Tuple[FNode, ...]] = []
+        for binding in bindings:
+            if free_columns:
+                for combo in product(*free_domains):
+                    full_binding = dict(binding)
+                    full_binding.update(zip(free_columns, combo))
+                    tuples.append(tuple(full_binding[i] for i in range(num_params)))
+            else:
+                tuples.append(tuple(binding[i] for i in range(num_params)))
+
+        # Canonical order -- must match itertools.product(*items_list)'s own enumeration
+        # order (lexicographic by each parameter's index within its own type's domain) so
+        # actions the join doesn't improve on stay order-identical to the fallback pruning:
+        # ground action naming/ordering must not silently change for a domain that doesn't
+        # even benefit from the join.
+        tuples.sort(
+            key=lambda ground_tuple: tuple(
+                domain_position[i][ground_tuple[i]] for i in range(num_params)
+            )
+        )
+        return tuples
+
+    def _static_bool_fluents(self, action: Action) -> Optional[List[FNode]]:
+        """Returns the top-level-AND positive boolean static-fluent expressions in `action`'s
+        preconditions (`InstantaneousAction`) or conditions (`DurativeAction`) -- the same
+        static-fluent selection the per-parameter fallback pruning (`_purge_items_list`'s
+        caller, below) has always used, factored out so the join (below) agrees on exactly
+        which static fluents are eligible and differs only in how it uses them. Returns
+        `None` for an action type this file doesn't recognize.
+
+        Negative literals, non-boolean static fluents, and static-fluent expressions nested
+        inside `Or`/`Exists`/`Forall`/`Not` are deliberately excluded here, matching the
+        fallback pruning's existing blind spots (`split_all_ands` only flattens top-level
+        `And`; a static fluent that doesn't have to hold for the *whole* action to be
+        applicable can't be used to filter parameters the way a top-level conjunct can).
+        """
+        if isinstance(action, up.model.action.InstantaneousAction):
+            conds = list(action.preconditions)
+        elif isinstance(action, up.model.action.DurativeAction):
+            conds = []
+            for _, cl in action.conditions.items():
+                conds.extend(cl)
+        else:
+            return None
+        problem_static_fluents = self._get_static_fluents()
+        return [
+            c
+            for c in split_all_ands(conds)
+            if c.is_fluent_exp()
+            and c.fluent().type.is_bool_type()
+            and c.fluent() in problem_static_fluents
+        ]
+
+    def _get_static_fluents(self) -> Set["up.model.fluent.Fluent"]:
+        """Cached version of ``self._problem.get_static_fluents()``: that method rescans
+        every action/effect/condition/metric in the problem on every call, but the set cannot
+        change across a single grounding (the problem must not be modified after this class is
+        constructed, same assumption `Simplifier` already makes)."""
+        if self._static_fluents_cache is None:
+            self._static_fluents_cache = self._problem.get_static_fluents()
+        return self._static_fluents_cache
+
+    def _get_domain_items(self, type: Type) -> List[FNode]:
+        """Cached version of ``[domain_item(problem, type, j) for j in range(domain_size(...))]``:
+        ``domain_item`` re-materializes ``list(objects_set.objects(typename))`` on every single
+        call, so building one parameter's domain list this way is quadratic in its size."""
+        cached = self._domain_items_cache.get(type)
+        if cached is None:
+            cached = [
+                domain_item(self._problem, type, j)
+                for j in range(domain_size(self._problem, type))
+            ]
+            self._domain_items_cache[type] = cached
+        return cached
+
+    def _fluent_true_arg_tuples(
+        self, fluent: "up.model.fluent.Fluent"
+    ) -> List[Tuple[FNode, ...]]:
+        """Returns the argument tuples for which the given static boolean fluent is true,
+        without materializing ``Problem.initial_values`` (which enumerates every grounding of
+        every fluent in the problem, and is documented as expensive to call). Reproduces the
+        same true/false-default semantics ``_bool_static_fluent_valid_parameters`` needs:
+        - default True: every grounding is true except the explicitly-set non-True ones (the
+          only case that needs to enumerate all groundings, via ``get_all_fluent_exp``).
+        - default False, or no default at all: only the explicitly-set-True groundings are
+          true; both cases are answered by ``explicit_initial_values`` alone, since a grounding
+          with no explicit value and no default evaluates to `None` (absent), exactly like one
+          with an explicit or defaulted False value.
+        """
+        cached = self._true_arg_tuples_cache.get(fluent)
+        if cached is not None:
+            return cached
+        default_value = self._problem.fluents_defaults.get(fluent, None)
+        result: List[Tuple[FNode, ...]]
+        if default_value is not None and default_value.is_true():
+            excluded = {
+                tuple(key.args)
+                for key, value in self._problem.explicit_initial_values.items()
+                if key.fluent() == fluent and not value.is_true()
+            }
+            result = [
+                tuple(exp.args)
+                for exp in up.model.fluent.get_all_fluent_exp(self._problem, fluent)
+                if tuple(exp.args) not in excluded
+            ]
+        else:
+            result = [
+                tuple(key.args)
+                for key, value in self._problem.explicit_initial_values.items()
+                if key.fluent() == fluent and value.is_true()
+            ]
+        self._true_arg_tuples_cache[fluent] = result
+        return result
 
     def _purge_items_list(
         self, items_list: List[List[FNode]], params: List[Parameter], conds: List[FNode]
@@ -274,39 +651,34 @@ class GrounderHelper:
         :param conds: The List of FNodes that represent the conditions we want to verify the validity of the parameters for.
         :return: the items_list input pruned off of the objects that would generate always invalid actions.
         """
+        # NOTE: if a static fluent mentions the same parameter at more than one argument
+        # position (e.g. a symmetric predicate applied as `sym(?x, ?x)`), every matching
+        # position is intersected in, not just the first one found -- each is independently
+        # sound, and using all of them is strictly stronger pruning than using only one.
+        em = self._problem.environment.expression_manager
         return_list = []
         for param, object_list in zip(params, items_list):
             temp_list = list(object_list)
-            for cond in conds:
-                static_fluent = cond
-                sig_pos = -1
+            param_exp = em.ParameterExp(param)
+            for static_fluent in conds:
                 for i, fp in enumerate(static_fluent.args):
-                    if fp == self._problem.environment.expression_manager.ParameterExp(
-                        param
-                    ):
-                        sig_pos = i
-                        break
-                if sig_pos != -1:
-                    valid_obj = self._bool_static_fluent_valid_parameters(
-                        static_fluent, sig_pos
-                    )
-                    temp_list = [obj for obj in temp_list if obj in valid_obj]
+                    if fp == param_exp:
+                        valid_obj = self._bool_static_fluent_valid_parameters(
+                            static_fluent, i
+                        )
+                        temp_list = [obj for obj in temp_list if obj in valid_obj]
             return_list.append(temp_list)
         return return_list
 
     def _bool_static_fluent_valid_parameters(self, sf: FNode, sp: int) -> Set[FNode]:
-        assert sf.fluent() in self._problem.get_static_fluents()
-        ret_val = set()
-        default_value = self._problem.fluents_defaults.get(sf.fluent(), None)
-        if default_value is not None and default_value.is_false():
-            # if default is false, check only explicit instead of all values
-            for key, value in self._problem.explicit_initial_values.items():
-                if key.fluent() == sf.fluent() and value.is_true():
-                    ret_val.add(key.args[sp])
-        else:
-            for key, value in self._problem.initial_values.items():
-                if key.fluent() == sf.fluent() and value.is_true():
-                    ret_val.add(key.args[sp])
+        cache_key = (sf, sp)
+        cached = self._valid_params_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        fluent = sf.fluent()
+        assert fluent in self._get_static_fluents()
+        ret_val = {tup[sp] for tup in self._fluent_true_arg_tuples(fluent)}
+        self._valid_params_cache[cache_key] = ret_val
         return ret_val
 
 
@@ -316,14 +688,17 @@ class Grounder(engines.engine.Engine, CompilerMixin):
     have :func:`Parameters <unified_planning.model.Action.parameters>` (meaning the `Actions` are lifted) and, through the :func:`~unified_planning.engines.mixins.CompilerMixin.compile`
     method, returns a `Problem` where every `Action` does not have `Parameters` (meaning the `Actions` are grounded).
 
-    When an `Action` grounding creates an `Action` without :func:`Effects <unified_planning.model.InstantaneousAction.effects>`, or an `Action` with impossible
+    When an `Action` grounding creates an `Action` with conflicting :func:`Effects <unified_planning.model.InstantaneousAction.effects>`, or an `Action` with impossible
     :func:`conditions <unified_planning.model.InstantaneousAction.preconditions>`, the `Action` is discarded and not added to the final `Problem`.
+    An `Action` grounding with no `Effects` at all is *not* discarded; it is added to the final `Problem` as-is.
 
     At construction time, the Grounder class can optionally take a map from `Action` to `List[Tuple[FNode, ...]]`. If this map is not None,
     it will be used for grounding instead of the implemented algorithm; the use of this parameter is mainly created to easily support
     the integration of external grounders inside the library. To see a practical example, checkout the :class:`~unified_planning.engines.compilers.TarskiGrounder` `_compile`
     implementation.
-    The Grounder class can also optionally take a flag prune_actions to enable/disable the pruning of actions exploiting the simplification of static fluents.
+    The Grounder class can also optionally take a `prune_actions` flag to enable/disable the pruning of
+    actions exploiting the simplification of static fluents -- see
+    :func:`GrounderHelper.__init__ <unified_planning.engines.compilers.GrounderHelper>` for details.
 
     Interpreted functions are treated as ordinary sub-expressions: calls appearing in conditions, effect
     values and duration bounds have their arguments rewritten by the parameter substitution, exactly like

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -123,11 +123,11 @@ class GrounderHelper:
         # to compute once instead of once per action / per (parameter, static-fluent) pair.
         self._static_fluents_cache: Optional[Set["up.model.fluent.Fluent"]] = None
         self._true_arg_tuples_cache: Dict[
-            "up.model.fluent.Fluent", List[Tuple[FNode, ...]]
+            "up.model.fluent.Fluent", Optional[List[Tuple[FNode, ...]]]
         ] = {}
         self._domain_items_cache: Dict[Type, List[FNode]] = {}
         self._valid_params_cache: Dict[
-            Tuple["up.model.fluent.Fluent", int], Set[FNode]
+            Tuple["up.model.fluent.Fluent", int], Optional[Set[FNode]]
         ] = {}
         env = problem.environment
         if prune_actions:
@@ -300,104 +300,27 @@ class GrounderHelper:
         per-parameter (independent) pruning. Returns `None` when it can't safely do this
         (unrecognized action, unbounded type, candidate blow-up, or any exception).
 
-        High-level shape: it's a classic database join -- each static fluent in
-        `static_fluents` is a "table" of rows (the argument tuples for which that fluent is
-        true), and the algorithm joins these tables together on the action-parameter columns
-        they share, incrementally narrowing a running result set (`bindings`). Any parameter
-        columns never touched by a joinable fluent are left free and cross-producted in at
-        the end.
+        It's a classic database join: each static fluent is a "table" of rows (the argument
+        tuples it is true for), and they are folded in one at a time, joining on the
+        action-parameter columns two fluents share and narrowing a running result set
+        (`bindings`, a partial column -> object map per surviving row). Parameter columns no
+        fluent ever constrains stay free and are cross-producted in at the end. Every step
+        is bounded by `self._join_max_candidates`, which sends the whole action back to the
+        per-parameter fallback rather than let an intermediate result blow up.
 
-        Step-by-step:
+        Example -- `deliver(?r: Robot, ?l: Location, ?p: Package)`, columns 0=r, 1=l, 2=p,
+        domains `Robot={r1,r2}`, `Location={l1,l2}`, `Package={p1,p2}`, static conditions
+        `robot_can_carry(?r,?p)` true for `(r1,p1), (r1,p2), (r2,p1)` and `package_at(?p,?l)`
+        true for `(p1,l1), (p2,l2)`. Per-parameter pruning shrinks nothing here, because each
+        of the six objects does appear in some true tuple, so all 8 combinations survive --
+        including `(r2, l2, p2)`, even though r2 never carries p2. The join folds in
+        `robot_can_carry` to `{0:r1,2:p1}, {0:r1,2:p2}, {0:r2,2:p1}`, then joins `package_at`
+        on their shared column 2, where `p1` only pairs with `l1` and `p2` only with `l2`,
+        leaving the 3 jointly-consistent tuples `(r1,l1,p1), (r1,l2,p2), (r2,l1,p1)`.
 
-        1. Trivial cases: get `action.parameters` into `params`; if `num_params` is 0,
-            return `[()]`. Fetch the action's eligible static fluents via
-            `_static_bool_fluents`; if `None` (action type not recognized), bail out.
-        2. Set up per-parameter domains:
-            - `param_domains`: each action parameter's candidate objects (via
-              `_get_domain_items`).
-            - `domain_sets`: same, as sets, for fast membership checks.
-            - `domain_position`: object -> index within its own domain, needed later for
-              canonical ordering.
-            - `param_expr_to_column`: maps each parameter's `ParameterExp` to its column
-              index -- this is how a fluent's argument is recognized as "this is action
-              parameter #i" versus a constant or a nested/object-fluent expression.
-        3. Fold loop over static fluents -- this is the core. State carried across
-            iterations:
-            - `bindings`: `None` until the first fluent folds in, then a list of partial
-              bindings (`Dict[column_index, FNode]`), one per surviving candidate row.
-            - `bound_columns`: which parameter columns have been constrained so far.
-
-            For each fluent:
-            - Classify each argument as `("p", col)` if it's an action parameter,
-              `("c", value)` if it's a constant, or `("*", None)` (wildcard) if it's anything
-              else (nested/object-fluent arg -- same blind spot `_purge_items_list`'s
-              per-parameter pruning has).
-            - Skip fluents that touch no parameter column -- nothing to join on.
-            - Materialize this fluent's rows: pull its true argument-tuples via
-              `_fluent_true_arg_tuples`, and for each tuple build a `binding` dict from
-              parameter-columns to values, rejecting the tuple if a constant position
-              doesn't match, if a parameter-column value falls outside that parameter's own
-              domain (the hierarchical-typing guard), or if the fluent binds the same column
-              twice inconsistently (handles `sym(?x, ?x)`-style repeated parameters within
-              one fluent). A wildcard position is not projected into the binding, so two
-              true tuples differing only there collapse onto the same row: when the pattern
-              has one, rows are deduplicated as they are built, or the same parameter tuple
-              would be emitted more than once. Bail out to `None` here if `rows` alone
-              already exceeds
-              `self._join_max_candidates` -- a fluent with a `True` default over N objects
-              materializes N**arity rows on its own, before anything is merged.
-            - Merge into `bindings`:
-              - First fluent: `bindings` just becomes `rows`.
-              - Later fluents: find `shared_columns` already bound vs. this fluent's
-                columns. If there's overlap, do an actual indexed hash-join on those shared
-                columns (`rows_by_shared_key`, built once, then probed once per existing
-                binding into `joined_rows`, bailing out to `None` as soon as `joined_rows`
-                itself exceeds the cap, rather than after the merge finishes). If no
-                overlap, it's a cross-product merge (`{**left, **right}` for every pair) --
-                still correct, just not a filtering join; its exact size
-                (`len(bindings) * len(rows)`) is known upfront, so it is cap-checked before
-                being built rather than after.
-            - Early exits: if `bindings` became empty, stop early (nothing will ever match).
-              If it still exceeds `self._join_max_candidates` after the merge (the two
-              per-merge checks above only bound the merge's own two shapes, so this is a
-              cheap backstop, not the primary guard), give up and return `None` (safety
-              valve back to per-parameter pruning for this action).
-        4. Handle free (never-bound) columns: any parameter column no fluent constrained is
-            a `free_column`; its full domain (`free_domains`) must be cross-producted in.
-            Compute the prospective final size (`len(bindings) * free_size`) and bail to
-            `None` if it would exceed the candidate cap.
-        5. Expand into full parameter tuples: for each surviving binding, cross the free
-            columns' domains in (via `product`) and assemble one full
-            `(param_0_value, ..., param_n_value)` tuple per combination into `tuples`. If
-            there are no free columns, just read the binding straight through.
-        6. Canonical sort: sort `tuples` by each parameter's index within its own domain
-            (`domain_position`) -- this matches the enumeration order
-            `itertools.product(*param_domains)` would produce, so the join doesn't silently
-            reorder/rename ground actions relative to the per-parameter fallback.
-        7. Return the final `tuples` list -- the exact, jointly-consistent set of parameter
-            tuples for this action.
-
-        Example: action `deliver(?r: Robot, ?l: Location, ?p: Package)` -- columns 0=r,
-        1=l, 2=p -- with domains `Robot={r1,r2}`, `Location={l1,l2}`, `Package={p1,p2}` (8
-        combinations, unpruned) and static conditions `robot_can_carry(?r,?p)` true for
-        `(r1,p1), (r1,p2), (r2,p1)`, and `package_at(?p,?l)` true for `(p1,l1), (p2,l2)`.
-        Per-parameter pruning can't shrink anything here: `r1`, `r2`, `l1`, `l2`, `p1`, `p2`
-        each appear in at least one true tuple, so all 8 combinations -- including invalid
-        ones like `(r2, l2, p2)`, since r2 never carries p2 -- would still be
-        cross-producted. The join instead folds in `robot_can_carry` first, producing
-        partial bindings `{0:r1,2:p1}, {0:r1,2:p2}, {0:r2,2:p1}`; then folds in
-        `package_at`, joining on their shared column 2 (`p`): `shared_columns = [2]`, and
-        `p1` only pairs with `l1`, `p2` only with `l2`, leaving
-        `bindings = [{0:r1,2:p1,1:l1}, {0:r1,2:p2,1:l2}, {0:r2,2:p1,1:l1}]`. Both columns 0
-        and 1 are already bound here, so there are no free columns left to cross in, and
-        step 5 just reads each binding straight through into
-        `tuples = [(r1,l1,p1), (r1,l2,p2), (r2,l1,p1)]` -- the 3 combinations that are
-        jointly consistent with both conditions.
-
-        The essential idea: rather than pruning each parameter's candidate list independently,
-        this builds up joint bindings fluent-by-fluent, joining on whatever columns two fluents
-        happen to share, and only falls back to a full cross product for the columns nothing
-        constrains.
+        The finished tuples are sorted back into `itertools.product(*param_domains)` order, so
+        an action the join doesn't improve on keeps exactly the ground-action naming and
+        ordering the fallback would have given it.
         """
         params = list(action.parameters)
         num_params = len(params)
@@ -450,6 +373,13 @@ class GrounderHelper:
                 # the per-parameter fallback pruning already has).
                 continue
 
+            true_arg_tuples = self._fluent_true_arg_tuples(static_fluent.fluent())
+            if true_arg_tuples is None:
+                # Over budget to enumerate. Skipping one conjunct only ever weakens the
+                # pruning, never makes it unsound, and it keeps the join's benefit for this
+                # action's other fluents -- bailing out to `None` would throw that away too.
+                continue
+
             # A binding only records the parameter columns, so a wildcard position is
             # projected away: two true tuples that differ only there produce the very same
             # row. Left in, that row is duplicated through every later merge and the same
@@ -465,7 +395,7 @@ class GrounderHelper:
             # pattern; each one that's consistent becomes one candidate binding *for this
             # fluent alone* (not yet folded together with any other fluent's bindings).
             rows: List[Dict[int, FNode]] = []
-            for true_args in self._fluent_true_arg_tuples(static_fluent.fluent()):
+            for true_args in true_arg_tuples:
                 binding: Dict[int, FNode] = {}
                 is_consistent = True
                 for (kind, payload), arg_value in zip(pattern, true_args):
@@ -658,34 +588,58 @@ class GrounderHelper:
 
     def _fluent_true_arg_tuples(
         self, fluent: "up.model.fluent.Fluent"
-    ) -> List[Tuple[FNode, ...]]:
-        """Returns the argument tuples for which the given static boolean fluent is true,
-        without materializing ``Problem.initial_values`` (which enumerates every grounding of
-        every fluent in the problem, and is documented as expensive to call). Reproduces the
+    ) -> Optional[List[Tuple[FNode, ...]]]:
+        """Returns the argument tuples for which the given static boolean fluent is true, or
+        `None` when building that list would cost more than `_join_max_candidates` rows -- in
+        which case the caller must prune nothing with this fluent rather than pay for it.
+
+        Avoids materializing ``Problem.initial_values`` (which enumerates every grounding of
+        every fluent in the problem, and is documented as expensive to call), reproducing the
         same true/false-default semantics ``_bool_static_fluent_valid_parameters`` needs:
-        - default True: every grounding is true except the explicitly-set non-True ones (the
-          only case that needs to enumerate all groundings, via ``get_all_fluent_exp``).
+        - default True: every grounding is true except the explicitly-set non-True ones. This
+          is the only case that has to enumerate all groundings (via ``get_all_fluent_exp``),
+          hence the only one that needs the budget check -- its size is the product of the
+          argument types' domain sizes, N**arity for N objects, which is cheap to compute up
+          front and is checked before anything is built. A type with no enumerable domain
+          (``domain_size`` raises) can't be materialized at all and counts as over budget.
         - default False, or no default at all: only the explicitly-set-True groundings are
-          true; both cases are answered by ``explicit_initial_values`` alone, since a grounding
-          with no explicit value and no default evaluates to `None` (absent), exactly like one
-          with an explicit or defaulted False value.
+          true; both cases are answered by ``explicit_initial_values`` alone (which the
+          problem already holds, so there is nothing to bound), since a grounding with no
+          explicit value and no default evaluates to `None` (absent), exactly like one with
+          an explicit or defaulted False value.
         """
-        cached = self._true_arg_tuples_cache.get(fluent)
-        if cached is not None:
-            return cached
+        if fluent in self._true_arg_tuples_cache:  # `None` is a real cached answer here
+            return self._true_arg_tuples_cache[fluent]
+        result: Optional[List[Tuple[FNode, ...]]]
         default_value = self._problem.fluents_defaults.get(fluent, None)
-        result: List[Tuple[FNode, ...]]
         if default_value is not None and default_value.is_true():
-            excluded = {
-                tuple(key.args)
-                for key, value in self._problem.explicit_initial_values.items()
-                if key.fluent() == fluent and not value.is_true()
-            }
-            result = [
-                tuple(exp.args)
-                for exp in up.model.fluent.get_all_fluent_exp(self._problem, fluent)
-                if tuple(exp.args) not in excluded
-            ]
+            budget = (
+                self._join_max_candidates
+                if self._join_max_candidates > 0
+                else self.DEFAULT_JOIN_MAX_CANDIDATES
+            )
+            result = []
+            size = 1
+            for param in fluent.signature:
+                try:
+                    size *= domain_size(self._problem, param.type)
+                except UPProblemDefinitionError:
+                    result = None
+                    break
+                if size > budget:
+                    result = None
+                    break
+            if result is not None:
+                excluded = {
+                    tuple(key.args)
+                    for key, value in self._problem.explicit_initial_values.items()
+                    if key.fluent() == fluent and not value.is_true()
+                }
+                result = [
+                    tuple(exp.args)
+                    for exp in up.model.fluent.get_all_fluent_exp(self._problem, fluent)
+                    if tuple(exp.args) not in excluded
+                ]
         else:
             result = [
                 tuple(key.args)
@@ -722,21 +676,31 @@ class GrounderHelper:
                         valid_obj = self._bool_static_fluent_valid_parameters(
                             static_fluent, i
                         )
-                        temp_list = [obj for obj in temp_list if obj in valid_obj]
+                        if valid_obj is not None:
+                            temp_list = [obj for obj in temp_list if obj in valid_obj]
             return_list.append(temp_list)
         return return_list
 
-    def _bool_static_fluent_valid_parameters(self, sf: FNode, sp: int) -> Set[FNode]:
+    def _bool_static_fluent_valid_parameters(
+        self, sf: FNode, sp: int
+    ) -> Optional[Set[FNode]]:
+        """The objects that may appear at argument position `sp` of the static boolean fluent
+        expression `sf`, or `None` when that cannot be answered within
+        `_fluent_true_arg_tuples`'s budget -- in which case the caller must prune nothing
+        for this position rather than enumerate the relation.
+        """
         # Keyed on (fluent, sp) rather than (sf, sp): the body below only ever depends on
         # sf.fluent() and sp, never on sf's actual arguments, so keying on the whole atom
         # missed cache hits across different atoms over the same fluent (and across actions).
         fluent = sf.fluent()
         cache_key = (fluent, sp)
-        cached = self._valid_params_cache.get(cache_key)
-        if cached is not None:
-            return cached
+        if cache_key in self._valid_params_cache:
+            return self._valid_params_cache[cache_key]
         assert fluent in self._get_static_fluents()
-        ret_val = {tup[sp] for tup in self._fluent_true_arg_tuples(fluent)}
+        true_arg_tuples = self._fluent_true_arg_tuples(fluent)
+        ret_val: Optional[Set[FNode]] = (
+            None if true_arg_tuples is None else {tup[sp] for tup in true_arg_tuples}
+        )
         self._valid_params_cache[cache_key] = ret_val
         return ret_val
 

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -871,13 +871,15 @@ class Grounder(engines.engine.Engine, CompilerMixin):
         trace_back_map: Dict[Action, Tuple[Action, List[FNode]]] = {}
 
         if type(problem) is Problem:
-            # _clone_without_actions() skips deep-cloning every lifted action.
+            # _clone_without_actions_and_metrics() skips deep-cloning every lifted action
+            # (and drops quality metrics, rebuilt below via ground_minimize_action_costs_metric).
             # Restricted to the exact Problem class: Problem subclasses
             # like HierarchicalProblem/ContingentProblem hand-roll their own clone() that
-            # _clone_without_actions() knows nothing about, and calling the inherited
-            # Problem._clone_without_actions() on one of them would silently construct a
-            # plain Problem, downgrading it and dropping its subclass-only state.
-            new_problem = problem._clone_without_actions()
+            # _clone_without_actions_and_metrics() knows nothing about, and calling the
+            # inherited Problem._clone_without_actions_and_metrics() on one of them would
+            # silently construct a plain Problem, downgrading it and dropping its
+            # subclass-only state.
+            new_problem = problem._clone_without_actions_and_metrics()
         else:
             new_problem = problem.clone()
             new_problem.clear_actions()

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -871,15 +871,14 @@ class Grounder(engines.engine.Engine, CompilerMixin):
         trace_back_map: Dict[Action, Tuple[Action, List[FNode]]] = {}
 
         if type(problem) is Problem:
-            # _clone_without_actions_and_metrics() skips deep-cloning every lifted action
+            # _clone_to_without_actions_and_metrics() skips deep-cloning every lifted action
             # (and drops quality metrics, rebuilt below via ground_minimize_action_costs_metric).
             # Restricted to the exact Problem class: Problem subclasses
             # like HierarchicalProblem/ContingentProblem hand-roll their own clone() that
-            # _clone_without_actions_and_metrics() knows nothing about, and calling the
-            # inherited Problem._clone_without_actions_and_metrics() on one of them would
-            # silently construct a plain Problem, downgrading it and dropping its
-            # subclass-only state.
-            new_problem = problem._clone_without_actions_and_metrics()
+            # _clone_to_without_actions_and_metrics() knows nothing about, and calling it
+            # on one of them would silently drop its subclass-only state.
+            new_problem = Problem(problem.name, problem.environment)
+            problem._clone_to_without_actions_and_metrics(new_problem)
         else:
             new_problem = problem.clone()
             new_problem.clear_actions()

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -54,11 +54,14 @@ class GrounderHelper:
     with the same parameters will return the same object!
     """
 
+    DEFAULT_JOIN_MAX_CANDIDATES = 1_000_000
+
     def __init__(
         self,
         problem: Problem,
         grounding_actions_map: Optional[Dict[Action, List[Tuple[FNode, ...]]]] = None,
         prune_actions: bool = True,
+        join_max_candidates: int = DEFAULT_JOIN_MAX_CANDIDATES,
     ):
         """
         Creates an instance of the GrounderHelper.
@@ -79,16 +82,22 @@ class GrounderHelper:
             action's parameters together (e.g. a lookup table relating them) is pruned down to the handful
             of parameter tuples actually consistent with it, rather than enumerating (and then rejecting)
             their full cross product. If the join isn't applicable/safe for a given action -- an unbounded
-            parameter type, a candidate count above an internal safety cap, or any unexpected condition --
+            parameter type, a candidate count above `join_max_candidates`, or any unexpected condition --
             that one action falls back to the weaker (but always sound) per-parameter-independent pruning:
             each parameter is narrowed, independently of the others, to the objects that appear at a
             matching argument position of some true static fluent in the action's precondition. If
             `False`, no pruning at all is done.
+        :param join_max_candidates: Safety valve for the join part of `prune_actions`: for one
+            action, once its running candidate count exceeds this, the join gives up and that
+            action falls back to the per-parameter-independent pruning instead. A value `<= 0`
+            disables the join outright (every action uses the fallback), which is mainly useful
+            to test the fallback path itself in isolation.
         """
         assert isinstance(problem, Problem)
         self._problem = problem
         self._grounding_actions_map = grounding_actions_map
         self._prune_actions = prune_actions
+        self._join_max_candidates = join_max_candidates
         if grounding_actions_map is not None:
             for action, params_list in grounding_actions_map.items():
                 for params in params_list:
@@ -253,11 +262,6 @@ class GrounderHelper:
                 res = iter(self._grounding_actions_map.get(action, []))
         return res
 
-    # Safety valve for the join: bail out to the per-parameter cross-product fallback for
-    # one action if its running candidate count exceeds this. The reference dataset this
-    # algorithm was validated against never got close to it (largest was ~52k).
-    _JOIN_MAX_CANDIDATES = 1_000_000
-
     def _compute_join_pruned_parameters(
         self, action: Action, type_list: List[Type]
     ) -> Optional[List[Tuple[FNode, ...]]]:
@@ -269,9 +273,12 @@ class GrounderHelper:
         their full cross product.
 
         Returns `None` if the join isn't applicable/safe for this action, including when the
-        action type is unrecognized, the parameter type is unbounded or unenumerable, the
-        candidate count exceeds _JOIN_MAX_CANDIDATES, or an unexpected exception occurs.
+        join is disabled (`self._join_max_candidates <= 0`), the action type is unrecognized,
+        the parameter type is unbounded or unenumerable, the candidate count exceeds
+        `self._join_max_candidates`, or an unexpected exception occurs.
         """
+        if self._join_max_candidates <= 0:
+            return None
         try:
             return self._compute_join_pruned_parameters_unsafe(action, type_list)
         except Exception:
@@ -335,8 +342,8 @@ class GrounderHelper:
                 (`{**left, **right}` for every pair) -- still correct, just not a filtering
                 join.
             - Early exits: if `bindings` became empty, stop early (nothing will ever match).
-              If it exceeds `_JOIN_MAX_CANDIDATES`, give up and return `None` (safety valve
-              back to per-parameter pruning for this action).
+              If it exceeds `self._join_max_candidates`, give up and return `None` (safety
+              valve back to per-parameter pruning for this action).
         4. Handle free (never-bound) columns: any parameter column no fluent constrained is
             a `free_column`; its full domain (`free_domains`) must be cross-producted in.
             Compute the prospective final size (`len(bindings) * free_size`) and bail to
@@ -500,7 +507,7 @@ class GrounderHelper:
                 # Zero rows survived: no combination can ever satisfy every fluent folded in
                 # so far, so no later fluent can matter either -- stop early.
                 break
-            if len(bindings) > self._JOIN_MAX_CANDIDATES:
+            if len(bindings) > self._join_max_candidates:
                 # Safety valve: give up on the join for this action and let the caller fall
                 # back to the (always bounded, if weaker) per-parameter pruning instead.
                 return None
@@ -518,7 +525,7 @@ class GrounderHelper:
         free_size = 1
         for domain in free_domains:
             free_size *= len(domain)
-        if len(bindings) * free_size > self._JOIN_MAX_CANDIDATES:
+        if len(bindings) * free_size > self._join_max_candidates:
             # Second safety check: even when the constrained part of `bindings` stayed
             # small, cross-joining in every free column could still blow the budget.
             return None
@@ -697,7 +704,8 @@ class Grounder(engines.engine.Engine, CompilerMixin):
     the integration of external grounders inside the library. To see a practical example, checkout the :class:`~unified_planning.engines.compilers.TarskiGrounder` `_compile`
     implementation.
     The Grounder class can also optionally take a `prune_actions` flag to enable/disable the pruning of
-    actions exploiting the simplification of static fluents -- see
+    actions exploiting the simplification of static fluents, and a `join_max_candidates` safety-valve
+    threshold for that pruning's join -- see
     :func:`GrounderHelper.__init__ <unified_planning.engines.compilers.GrounderHelper>` for details.
 
     Interpreted functions are treated as ordinary sub-expressions: calls appearing in conditions, effect
@@ -713,11 +721,13 @@ class Grounder(engines.engine.Engine, CompilerMixin):
         self,
         grounding_actions_map: Optional[Dict[Action, List[Tuple[FNode, ...]]]] = None,
         prune_actions: bool = True,
+        join_max_candidates: int = GrounderHelper.DEFAULT_JOIN_MAX_CANDIDATES,
     ):
         engines.engine.Engine.__init__(self)
         CompilerMixin.__init__(self, CompilationKind.GROUNDING)
         self._grounding_actions_map = grounding_actions_map
         self._prune_actions = prune_actions
+        self._join_max_candidates = join_max_candidates
 
     @property
     def name(self):
@@ -822,7 +832,10 @@ class Grounder(engines.engine.Engine, CompilerMixin):
             "The given problem is not a class supported by the Grounder"
         )
         grounder_helper = GrounderHelper(
-            problem, self._grounding_actions_map, self._prune_actions
+            problem,
+            self._grounding_actions_map,
+            self._prune_actions,
+            self._join_max_candidates,
         )
         trace_back_map: Dict[Action, Tuple[Action, List[FNode]]] = {}
 

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -449,7 +449,6 @@ class GrounderHelper:
                 for (kind, payload), arg_value in zip(pattern, true_args):
                     if kind == "c":
                         if arg_value != payload:
-                            # TODO: can we enter here?
                             is_consistent = False
                             break
                     elif kind == "p":
@@ -467,7 +466,6 @@ class GrounderHelper:
                         # fluent (e.g. `sym(?x, ?x)`) must agree with itself at every
                         # occurrence, not just be individually well-typed at each one.
                         if col in binding and binding[col] != arg_value:
-                            # TODO: can we enter here?
                             is_consistent = False
                             break
                         binding[col] = arg_value

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -826,9 +826,18 @@ class Grounder(engines.engine.Engine, CompilerMixin):
         )
         trace_back_map: Dict[Action, Tuple[Action, List[FNode]]] = {}
 
-        new_problem = problem.clone()
+        if type(problem) is Problem:
+            # _clone_without_actions() skips deep-cloning every lifted action.
+            # Restricted to the exact Problem class: Problem subclasses
+            # like HierarchicalProblem/ContingentProblem hand-roll their own clone() that
+            # _clone_without_actions() knows nothing about, and calling the inherited
+            # Problem._clone_without_actions() on one of them would silently construct a
+            # plain Problem, downgrading it and dropping its subclass-only state.
+            new_problem = problem._clone_without_actions()
+        else:
+            new_problem = problem.clone()
+            new_problem.clear_actions()
         new_problem.name = f"{self.name}_{problem.name}"
-        new_problem.clear_actions()
         for (
             old_action,
             parameters,

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -37,9 +37,44 @@ from unified_planning.engines.compilers.utils import (
     create_action_with_given_subs,
     split_all_ands,
 )
-from typing import Any, Dict, List, Optional, Set, Tuple, Iterator, cast
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Iterator, cast
 from itertools import product
 from functools import partial
+
+
+class _AtomPattern(NamedTuple):
+    """How one static-fluent atom's argument positions map onto an action's parameters.
+
+    `param_positions` and `const_positions` list only the positions that constrain anything;
+    an argument that is neither a bare parameter nor a constant (a nested expression, an
+    object-fluent call) appears in neither and only sets `has_wildcard` -- the same blind spot
+    the per-parameter fallback pruning has.
+    """
+
+    param_positions: List[Tuple[int, int]]  # (argument index, action-parameter column)
+    const_positions: List[Tuple[int, FNode]]  # (argument index, value it must equal)
+    columns: Set[int]  # the action-parameter columns this atom constrains
+    has_wildcard: bool
+
+
+def _classify_atom(atom: FNode, param_expr_to_column: Dict[FNode, int]) -> _AtomPattern:
+    param_positions: List[Tuple[int, int]] = []
+    const_positions: List[Tuple[int, FNode]] = []
+    has_wildcard = False
+    for i, arg in enumerate(atom.args):
+        column = param_expr_to_column.get(arg)
+        if column is not None:
+            param_positions.append((i, column))
+        elif arg.is_constant():
+            const_positions.append((i, arg))
+        else:
+            has_wildcard = True
+    return _AtomPattern(
+        param_positions,
+        const_positions,
+        {column for _, column in param_positions},
+        has_wildcard,
+    )
 
 
 class GrounderHelper:
@@ -333,184 +368,55 @@ class GrounderHelper:
             return None
 
         em = self._problem.environment.expression_manager
-        # Every parameter's full type domain
         param_domains = [self._get_domain_items(t) for t in type_list]
         domain_sets = [set(d) for d in param_domains]
-        # Each object's position within its own type's domain -- used only at the very end,
-        # to sort the finished tuples back into the same order the caller's plain
-        # `itertools.product` over `param_domains` would have produced them in.
-        domain_position = [{obj: j for j, obj in enumerate(d)} for d in param_domains]
-        # Lets an atom argument that's a bare action parameter (as opposed to a constant or a
-        # nested expression) be recognized and traced back to its column index below.
         param_expr_to_column = {em.ParameterExp(p): i for i, p in enumerate(params)}
 
-        # `bindings` is the running join result: each element maps a column index to the
-        # object bound there by every static fluent folded in so far. `None` means "no fluent
-        # folded in yet", i.e. fully unconstrained -- distinct from "folded in one and it left
-        # zero rows", which ends the loop early via the `if not bindings: break` below.
-        bindings: Optional[List[Dict[int, FNode]]] = None
+        # The running join result: each element maps a column index to the object bound there
+        # by every atom folded in so far. The lone empty binding stands for "nothing
+        # constrained yet", and folds into the first atom's rows as the identity.
+        bindings: List[Dict[int, FNode]] = [{}]
         bound_columns: Set[int] = set()
 
-        # Fold in one static fluent at a time, narrowing `bindings` after each one.
         for static_fluent in static_fluents:
-            # Classify each argument of this one fluent: a bound action parameter (record its
-            # column), a literal constant, or -- falling through -- an unconstrained wildcard.
-            pattern: List[Tuple[str, Any]] = []
-            for arg in static_fluent.args:
-                if arg in param_expr_to_column:
-                    pattern.append(("p", param_expr_to_column[arg]))
-                elif arg.is_constant():
-                    pattern.append(("c", arg))
-                else:
-                    # nested/object-fluent argument: a wildcard, unconstrained -- same as
-                    # the per-parameter fallback pruning, which can't handle these either.
-                    pattern.append(("*", None))
-
-            fluent_columns: Set[int] = {i for kind, i in pattern if kind == "p"}
-            if not fluent_columns:
-                # Every argument was a constant/wildcard: this fluent doesn't mention any
-                # action parameter, so it has nothing to prune -- skip it (same blind spot
-                # the per-parameter fallback pruning already has).
+            pattern = _classify_atom(static_fluent, param_expr_to_column)
+            if not pattern.columns:
+                # Mentions no action parameter, so it can prune nothing.
                 continue
 
             true_arg_tuples = self._fluent_true_arg_tuples(static_fluent.fluent())
             if true_arg_tuples is None:
                 # Over budget to enumerate. Skipping one conjunct only ever weakens the
                 # pruning, never makes it unsound, and it keeps the join's benefit for this
-                # action's other fluents -- bailing out to `None` would throw that away too.
+                # action's other atoms -- bailing out to `None` would throw that away too.
                 continue
 
-            # A binding only records the parameter columns, so a wildcard position is
-            # projected away: two true tuples that differ only there produce the very same
-            # row. Left in, that row is duplicated through every later merge and the same
-            # parameter tuple is grounded twice, which `Problem.add_action` rejects as a
-            # duplicate action name. Deduplicate as the rows are built (so the cap below
-            # sees the real count too); with no wildcard the projection is injective and
-            # the bookkeeping is skipped.
-            has_wildcard = any(kind == "*" for kind, _ in pattern)
-            row_columns = sorted(fluent_columns)
-            seen_rows: Set[Tuple[FNode, ...]] = set()
-
-            # Check every argument tuple this fluent is actually true for against the
-            # pattern; each one that's consistent becomes one candidate binding *for this
-            # fluent alone* (not yet folded together with any other fluent's bindings).
-            rows: List[Dict[int, FNode]] = []
-            for true_args in true_arg_tuples:
-                binding: Dict[int, FNode] = {}
-                is_consistent = True
-                for (kind, payload), arg_value in zip(pattern, true_args):
-                    if kind == "c":
-                        if arg_value != payload:
-                            is_consistent = False
-                            break
-                    elif kind == "p":
-                        col: int = payload
-                        if arg_value not in domain_sets[col]:
-                            # Hierarchical-typing guard: an object matched via a static fluent's argument
-                            # position must be a member of the ACTION PARAMETER's own type domain, not just the
-                            # static fluent's declared parameter type -- the fluent's declared type may be a
-                            # supertype of the action parameter it's being matched against.
-                            # Omitting this intersection would bind an object that's ill-typed for the action
-                            # parameter.
-                            is_consistent = False
-                            break
-                        # The same parameter appearing at more than one position of this one
-                        # fluent (e.g. `sym(?x, ?x)`) must agree with itself at every
-                        # occurrence, not just be individually well-typed at each one.
-                        if col in binding and binding[col] != arg_value:
-                            is_consistent = False
-                            break
-                        binding[col] = arg_value
-                if not is_consistent:
-                    continue
-                if has_wildcard:
-                    row_key = tuple(binding[c] for c in row_columns)
-                    if row_key in seen_rows:
-                        continue
-                    seen_rows.add(row_key)
-                rows.append(binding)
-
-            if len(rows) > self._join_max_candidates:
-                # Safety valve, checked before this fluent's rows are merged into anything:
-                # a fluent with a `True` default over N objects materializes this list as
-                # N**arity rows on its own, regardless of how small `bindings` still is.
+            rows = self._atom_rows(pattern, true_arg_tuples, domain_sets)
+            if rows is None:
                 return None
-
-            if bindings is None:
-                # First fluent processed: nothing to join against yet, so its own rows become
-                # the running result outright.
-                bindings, bound_columns = rows, set(fluent_columns)
-            else:
-                # Columns already bound by an earlier fluent that this fluent constrains too
-                # -- the actual join key. Two fluents that don't share any column have no key
-                # to join on at all (handled in the `else` branch below).
-                shared_columns = sorted(bound_columns & fluent_columns)
-                if shared_columns:
-                    # A real hash join: index this fluent's rows by their shared-column
-                    # values once, then probe that index once per existing binding, instead
-                    # of comparing every (existing binding, new row) pair against each other.
-                    rows_by_shared_key: Dict[
-                        Tuple[FNode, ...], List[Dict[int, FNode]]
-                    ] = {}
-                    for row in rows:
-                        key = tuple(row[i] for i in shared_columns)
-                        rows_by_shared_key.setdefault(key, []).append(row)
-                    joined_rows = []
-                    for left in bindings:
-                        key = tuple(left[i] for i in shared_columns)
-                        for right in rows_by_shared_key.get(key, ()):
-                            merged = dict(left)
-                            merged.update(right)
-                            joined_rows.append(merged)
-                            if len(joined_rows) > self._join_max_candidates:
-                                # Safety valve, checked as the join result is accumulated
-                                # rather than after: a join of two large tables can blow the
-                                # cap well before either operand's own size would suggest.
-                                return None
-                    bindings = joined_rows
-                else:
-                    # No shared column: this fluent constrains entirely different
-                    # parameters than anything folded in so far, so there is nothing to join
-                    # on -- cross every existing binding with every one of this fluent's rows.
-                    if len(bindings) * len(rows) > self._join_max_candidates:
-                        # Safety valve, checked before the cross product is built rather
-                        # than after: with no shared column to filter on, its size is
-                        # exactly len(bindings) * len(rows), known upfront.
-                        return None
-                    bindings = [
-                        {**left, **right} for left in bindings for right in rows
-                    ]
-                bound_columns |= fluent_columns
-
+            merged = self._merge_bindings(
+                bindings, bound_columns, rows, pattern.columns
+            )
+            if merged is None:
+                return None
+            bindings = merged
+            bound_columns |= pattern.columns
             if not bindings:
-                # Zero rows survived: no combination can ever satisfy every fluent folded in
-                # so far, so no later fluent can matter either -- stop early.
+                # Nothing can satisfy every atom folded in so far, so no later one matters.
                 break
-            if len(bindings) > self._join_max_candidates:
-                # Safety valve: give up on the join for this action and let the caller fall
-                # back to the (always bounded, if weaker) per-parameter pruning instead.
-                return None
 
-        # Any parameter no static fluent ever constrained keeps its entire type domain --
-        # this reproduces the per-parameter fallback's own behavior exactly for a column
-        # that can't be pruned at all.
+        # A column no atom constrained keeps its whole domain, exactly as the per-parameter
+        # fallback leaves a column it cannot prune.
         free_columns = [i for i in range(num_params) if i not in bound_columns]
         free_domains = [param_domains[i] for i in free_columns]
-        if bindings is None:
-            # No fluent was ever eligible to fold in (e.g. every one hit the `continue`
-            # above): one empty binding, to be crossed with the full free-column domains
-            # below exactly like a plain, unpruned cross product would be.
-            bindings = [{}]
         free_size = 1
         for domain in free_domains:
             free_size *= len(domain)
         if len(bindings) * free_size > self._join_max_candidates:
-            # Second safety check: even when the constrained part of `bindings` stayed
-            # small, cross-joining in every free column could still blow the budget.
+            # Even a small constrained part can blow the budget once every free column is
+            # crossed in.
             return None
 
-        # Expand every surviving (possibly partial) binding with every combination of the
-        # still-free columns' domains, turning each into a full length-`num_params` tuple.
         tuples: List[Tuple[FNode, ...]] = []
         for binding in bindings:
             if free_columns:
@@ -521,17 +427,102 @@ class GrounderHelper:
             else:
                 tuples.append(tuple(binding[i] for i in range(num_params)))
 
-        # Canonical order -- must match itertools.product(*items_list)'s own enumeration
-        # order (lexicographic by each parameter's index within its own type's domain) so
-        # actions the join doesn't improve on stay order-identical to the fallback pruning:
-        # ground action naming/ordering must not silently change for a domain that doesn't
-        # even benefit from the join.
+        # Must match `itertools.product(*param_domains)`'s own order (lexicographic by each
+        # parameter's index within its own type's domain), so ground-action naming and
+        # ordering don't silently change for an action the join doesn't improve on.
+        domain_position = [{obj: j for j, obj in enumerate(d)} for d in param_domains]
         tuples.sort(
             key=lambda ground_tuple: tuple(
                 domain_position[i][ground_tuple[i]] for i in range(num_params)
             )
         )
         return tuples
+
+    def _atom_rows(
+        self,
+        pattern: _AtomPattern,
+        true_arg_tuples: List[Tuple[FNode, ...]],
+        domain_sets: List[Set[FNode]],
+    ) -> Optional[List[Dict[int, FNode]]]:
+        """One atom's contribution to the join: the distinct column -> object bindings its
+        true tuples allow, or `None` if there are more than `_join_max_candidates` of them.
+
+        A `True`-default fluent over N objects has N**arity true tuples, so this is checked
+        as the rows accumulate rather than after, and independently of how small `bindings`
+        still is.
+        """
+        rows: List[Dict[int, FNode]] = []
+        seen: Set[Tuple[FNode, ...]] = set()
+        row_columns = sorted(pattern.columns)
+        for true_args in true_arg_tuples:
+            if any(true_args[i] != wanted for i, wanted in pattern.const_positions):
+                continue
+            binding: Dict[int, FNode] = {}
+            for i, column in pattern.param_positions:
+                value = true_args[i]
+                # An object reached through this atom must belong to the ACTION PARAMETER's
+                # own domain, not merely to the fluent's declared parameter type, which may
+                # be a supertype of it; skipping this binds an ill-typed object.
+                if value not in domain_sets[column]:
+                    break
+                # A parameter at more than one position of the same atom (`sym(?x, ?x)`) has
+                # to agree with itself, not just be well-typed at each occurrence.
+                if binding.setdefault(column, value) != value:
+                    break
+            else:
+                if pattern.has_wildcard:
+                    # A wildcard position is never projected into the binding, so two true
+                    # tuples differing only there collapse onto one row. Left in, that row
+                    # survives every later merge and the same parameter tuple gets grounded
+                    # twice, which `Problem.add_action` rejects as a duplicate name. With no
+                    # wildcard the projection is injective and there is nothing to catch.
+                    key = tuple(binding[c] for c in row_columns)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                rows.append(binding)
+                if len(rows) > self._join_max_candidates:
+                    return None
+        return rows
+
+    def _merge_bindings(
+        self,
+        bindings: List[Dict[int, FNode]],
+        bound_columns: Set[int],
+        rows: List[Dict[int, FNode]],
+        atom_columns: Set[int],
+    ) -> Optional[List[Dict[int, FNode]]]:
+        """Folds one atom's `rows` into the running `bindings`, or `None` if the result would
+        exceed `_join_max_candidates`.
+
+        Joins on the columns both sides constrain; with no column in common there is no join
+        key and the two are crossed instead -- still correct, just not filtering.
+        """
+        shared_columns = sorted(bound_columns & atom_columns)
+        if not shared_columns:
+            # The size is exactly len(bindings) * len(rows), so check it before building.
+            if len(bindings) * len(rows) > self._join_max_candidates:
+                return None
+            return [{**left, **right} for left in bindings for right in rows]
+
+        # Index `rows` by their shared-column values once, then probe once per existing
+        # binding, instead of testing every (binding, row) pair.
+        rows_by_shared_key: Dict[Tuple[FNode, ...], List[Dict[int, FNode]]] = {}
+        for row in rows:
+            rows_by_shared_key.setdefault(
+                tuple(row[i] for i in shared_columns), []
+            ).append(row)
+        joined_rows: List[Dict[int, FNode]] = []
+        for left in bindings:
+            for right in rows_by_shared_key.get(
+                tuple(left[i] for i in shared_columns), ()
+            ):
+                joined_rows.append({**left, **right})
+                # Checked as the result accumulates: a join of two large tables can blow the
+                # budget well before either operand's own size would suggest.
+                if len(joined_rows) > self._join_max_candidates:
+                    return None
+        return joined_rows
 
     def _static_bool_fluents(self, action: Action) -> Optional[List[FNode]]:
         """Returns the top-level-AND positive boolean static-fluent expressions in `action`'s

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -339,7 +339,11 @@ class GrounderHelper:
               doesn't match, if a parameter-column value falls outside that parameter's own
               domain (the hierarchical-typing guard), or if the fluent binds the same column
               twice inconsistently (handles `sym(?x, ?x)`-style repeated parameters within
-              one fluent). Bail out to `None` here if `rows` alone already exceeds
+              one fluent). A wildcard position is not projected into the binding, so two
+              true tuples differing only there collapse onto the same row: when the pattern
+              has one, rows are deduplicated as they are built, or the same parameter tuple
+              would be emitted more than once. Bail out to `None` here if `rows` alone
+              already exceeds
               `self._join_max_candidates` -- a fluent with a `True` default over N objects
               materializes N**arity rows on its own, before anything is merged.
             - Merge into `bindings`:
@@ -446,6 +450,17 @@ class GrounderHelper:
                 # the per-parameter fallback pruning already has).
                 continue
 
+            # A binding only records the parameter columns, so a wildcard position is
+            # projected away: two true tuples that differ only there produce the very same
+            # row. Left in, that row is duplicated through every later merge and the same
+            # parameter tuple is grounded twice, which `Problem.add_action` rejects as a
+            # duplicate action name. Deduplicate as the rows are built (so the cap below
+            # sees the real count too); with no wildcard the projection is injective and
+            # the bookkeeping is skipped.
+            has_wildcard = any(kind == "*" for kind, _ in pattern)
+            row_columns = sorted(fluent_columns)
+            seen_rows: Set[Tuple[FNode, ...]] = set()
+
             # Check every argument tuple this fluent is actually true for against the
             # pattern; each one that's consistent becomes one candidate binding *for this
             # fluent alone* (not yet folded together with any other fluent's bindings).
@@ -476,8 +491,14 @@ class GrounderHelper:
                             is_consistent = False
                             break
                         binding[col] = arg_value
-                if is_consistent:
-                    rows.append(binding)
+                if not is_consistent:
+                    continue
+                if has_wildcard:
+                    row_key = tuple(binding[c] for c in row_columns)
+                    if row_key in seen_rows:
+                        continue
+                    seen_rows.add(row_key)
+                rows.append(binding)
 
             if len(rows) > self._join_max_candidates:
                 # Safety valve, checked before this fluent's rows are merged into anything:

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -597,11 +597,20 @@ class GrounderHelper:
         every fluent in the problem, and is documented as expensive to call), reproducing the
         same true/false-default semantics ``_bool_static_fluent_valid_parameters`` needs:
         - default True: every grounding is true except the explicitly-set non-True ones. This
-          is the only case that has to enumerate all groundings (via ``get_all_fluent_exp``),
-          hence the only one that needs the budget check -- its size is the product of the
-          argument types' domain sizes, N**arity for N objects, which is cheap to compute up
-          front and is checked before anything is built. A type with no enumerable domain
-          (``domain_size`` raises) can't be materialized at all and counts as over budget.
+          is the only case that has to enumerate all groundings, hence the only one that needs
+          the budget check -- its size is the product of the argument types' domain sizes,
+          N**arity for N objects, which is cheap to compute up front and is checked before
+          anything is built. A type with no enumerable domain (``domain_size`` raises) can't
+          be materialized at all and counts as over budget. Within budget, the enumeration
+          itself is a product over each argument type's own cached domain-item list
+          (``_get_domain_items``) rather than ``get_all_fluent_exp``, which would call
+          ``fluent(*args)`` once per grounding and intern a fresh ``FNode`` for each into the
+          `Environment`'s own memo (unbounded, and it outlives this `GrounderHelper` --
+          usually forever, since most callers use the global environment) even though the
+          budget check already bounds how many groundings that could be. Only the iteration
+          order differs from ``get_all_fluent_exp``, which no caller observes: the join sorts
+          its output canonically, and `_bool_static_fluent_valid_parameters` folds the result
+          into a set.
         - default False, or no default at all: only the explicitly-set-True groundings are
           true; both cases are answered by ``explicit_initial_values`` alone (which the
           problem already holds, so there is nothing to bound), since a grounding with no
@@ -635,11 +644,8 @@ class GrounderHelper:
                     for key, value in self._problem.explicit_initial_values.items()
                     if key.fluent() == fluent and not value.is_true()
                 }
-                result = [
-                    tuple(exp.args)
-                    for exp in up.model.fluent.get_all_fluent_exp(self._problem, fluent)
-                    if tuple(exp.args) not in excluded
-                ]
+                domains = [self._get_domain_items(p.type) for p in fluent.signature]
+                result = [args for args in product(*domains) if args not in excluded]
         else:
             result = [
                 tuple(key.args)

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -18,6 +18,7 @@ import unified_planning as up
 import unified_planning.engines as engines
 from unified_planning.engines.mixins.compiler import CompilationKind, CompilerMixin
 from unified_planning.engines.results import CompilerResult
+from unified_planning.exceptions import UPProblemDefinitionError
 from unified_planning.model import (
     Problem,
     ProblemKind,
@@ -272,16 +273,20 @@ class GrounderHelper:
         that correlates several of the action's parameters together and so ends up enumerating
         their full cross product.
 
-        Returns `None` if the join isn't applicable/safe for this action, including when the
-        join is disabled (`self._join_max_candidates <= 0`), the action type is unrecognized,
-        the parameter type is unbounded or unenumerable, the candidate count exceeds
-        `self._join_max_candidates`, or an unexpected exception occurs.
+        Returns `None` if the join isn't applicable/safe for this action. Every documented
+        bail-out stays silent: the join is disabled (`self._join_max_candidates <= 0`), the
+        action type is unrecognized (a plain `return None`, not an exception), the candidate
+        count exceeds `self._join_max_candidates`, or a parameter type is unbounded/
+        unenumerable (`domain_size`/`domain_item` raise `UPProblemDefinitionError` for those --
+        see `unified_planning/model/types.py`). Any other exception is treated as an internal
+        bug rather than an expected bail-out and is left to propagate to the caller, instead
+        of being swallowed into the same silent `None` as the documented bail-outs above.
         """
         if self._join_max_candidates <= 0:
             return None
         try:
             return self._compute_join_pruned_parameters_unsafe(action, type_list)
-        except Exception:
+        except UPProblemDefinitionError:
             return None
 
     def _compute_join_pruned_parameters_unsafe(

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -126,7 +126,9 @@ class GrounderHelper:
             "up.model.fluent.Fluent", List[Tuple[FNode, ...]]
         ] = {}
         self._domain_items_cache: Dict[Type, List[FNode]] = {}
-        self._valid_params_cache: Dict[Tuple[FNode, int], Set[FNode]] = {}
+        self._valid_params_cache: Dict[
+            Tuple["up.model.fluent.Fluent", int], Set[FNode]
+        ] = {}
         env = problem.environment
         if prune_actions:
             self._simplifier = Simplifier(env, problem)
@@ -704,11 +706,14 @@ class GrounderHelper:
         return return_list
 
     def _bool_static_fluent_valid_parameters(self, sf: FNode, sp: int) -> Set[FNode]:
-        cache_key = (sf, sp)
+        # Keyed on (fluent, sp) rather than (sf, sp): the body below only ever depends on
+        # sf.fluent() and sp, never on sf's actual arguments, so keying on the whole atom
+        # missed cache hits across different atoms over the same fluent (and across actions).
+        fluent = sf.fluent()
+        cache_key = (fluent, sp)
         cached = self._valid_params_cache.get(cache_key)
         if cached is not None:
             return cached
-        fluent = sf.fluent()
         assert fluent in self._get_static_fluents()
         ret_val = {tup[sp] for tup in self._fluent_true_arg_tuples(fluent)}
         self._valid_params_cache[cache_key] = ret_val

--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -332,17 +332,24 @@ class GrounderHelper:
               doesn't match, if a parameter-column value falls outside that parameter's own
               domain (the hierarchical-typing guard), or if the fluent binds the same column
               twice inconsistently (handles `sym(?x, ?x)`-style repeated parameters within
-              one fluent).
+              one fluent). Bail out to `None` here if `rows` alone already exceeds
+              `self._join_max_candidates` -- a fluent with a `True` default over N objects
+              materializes N**arity rows on its own, before anything is merged.
             - Merge into `bindings`:
               - First fluent: `bindings` just becomes `rows`.
               - Later fluents: find `shared_columns` already bound vs. this fluent's
                 columns. If there's overlap, do an actual indexed hash-join on those shared
                 columns (`rows_by_shared_key`, built once, then probed once per existing
-                binding into `joined_rows`). If no overlap, it's a cross-product merge
-                (`{**left, **right}` for every pair) -- still correct, just not a filtering
-                join.
+                binding into `joined_rows`, bailing out to `None` as soon as `joined_rows`
+                itself exceeds the cap, rather than after the merge finishes). If no
+                overlap, it's a cross-product merge (`{**left, **right}` for every pair) --
+                still correct, just not a filtering join; its exact size
+                (`len(bindings) * len(rows)`) is known upfront, so it is cap-checked before
+                being built rather than after.
             - Early exits: if `bindings` became empty, stop early (nothing will ever match).
-              If it exceeds `self._join_max_candidates`, give up and return `None` (safety
+              If it still exceeds `self._join_max_candidates` after the merge (the two
+              per-merge checks above only bound the merge's own two shapes, so this is a
+              cheap backstop, not the primary guard), give up and return `None` (safety
               valve back to per-parameter pruning for this action).
         4. Handle free (never-bound) columns: any parameter column no fluent constrained is
             a `free_column`; its full domain (`free_domains`) must be cross-producted in.
@@ -467,6 +474,12 @@ class GrounderHelper:
                 if is_consistent:
                     rows.append(binding)
 
+            if len(rows) > self._join_max_candidates:
+                # Safety valve, checked before this fluent's rows are merged into anything:
+                # a fluent with a `True` default over N objects materializes this list as
+                # N**arity rows on its own, regardless of how small `bindings` still is.
+                return None
+
             if bindings is None:
                 # First fluent processed: nothing to join against yet, so its own rows become
                 # the running result outright.
@@ -493,11 +506,21 @@ class GrounderHelper:
                             merged = dict(left)
                             merged.update(right)
                             joined_rows.append(merged)
+                            if len(joined_rows) > self._join_max_candidates:
+                                # Safety valve, checked as the join result is accumulated
+                                # rather than after: a join of two large tables can blow the
+                                # cap well before either operand's own size would suggest.
+                                return None
                     bindings = joined_rows
                 else:
                     # No shared column: this fluent constrains entirely different
                     # parameters than anything folded in so far, so there is nothing to join
                     # on -- cross every existing binding with every one of this fluent's rows.
+                    if len(bindings) * len(rows) > self._join_max_candidates:
+                        # Safety valve, checked before the cross product is built rather
+                        # than after: with no shared column to filter on, its size is
+                        # exactly len(bindings) * len(rows), known upfront.
+                        return None
                     bindings = [
                         {**left, **right} for left in bindings for right in rows
                     ]

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -138,6 +138,46 @@ def check_and_simplify_preconditions(
     return (True, nap)
 
 
+def _naming_list(subs: Dict[Expression, Expression]) -> List[str]:
+    """Builds the fresh-name suffix for a grounded action from its substitution map. Kept as
+    a separate call (instead of at the very top of `create_action_with_given_subs`) so it, and
+    the `FNode.__repr__` call `str(value)` triggers, are only paid for an accepted candidate,
+    not for one rejected by the early feasibility check below."""
+    naming_list = []
+    for param, value in subs.items():
+        assert isinstance(param, Parameter)
+        assert isinstance(value, FNode)
+        naming_list.append(str(value))
+    return naming_list
+
+
+def _substitute_and_simplify_preconditions(
+    preconditions: List[FNode],
+    subs: Dict[Expression, Expression],
+    simplifier,
+    em,
+) -> Optional[List[FNode]]:
+    """Substitutes `subs` into `preconditions` and simplifies their conjunction, returning
+    the resulting precondition list, or `None` if the conjunction simplifies to a
+    contradiction (the grounding is infeasible).
+
+    Used by `create_action_with_given_subs` to test feasibility *before* cloning the action,
+    building its name or rebuilding its effects -- all of which are wasted work for a
+    candidate that gets rejected here anyway -- and, on the accepted path, to compute the
+    action's final preconditions directly instead of substituting them once (raw) and then
+    simplifying them a second time via `check_and_simplify_preconditions`.
+    """
+    if not preconditions:
+        return []
+    substituted = [p.substitute(subs) for p in preconditions]
+    ps = simplifier.simplify(em.And(substituted))
+    if ps.is_bool_constant():
+        return [] if ps.bool_constant_value() else None
+    if ps.is_and():
+        return list(ps.args)
+    return [ps]
+
+
 def create_effect_with_given_subs(
     problem: Problem,
     old_effect: Effect,
@@ -179,15 +219,37 @@ def create_action_with_given_subs(
     original name instead of going through :func:`get_fresh_name`: since ``old_action``
     is still registered in ``problem`` under that name, `get_fresh_name` would otherwise
     treat it as colliding with itself and rename it needlessly.
+
+    For an `InstantaneousAction`, feasibility is checked *before* any of the above: its
+    preconditions are substituted and simplified first, and if that simplifies to a
+    contradiction, `None` is returned immediately without cloning the action, computing its
+    name, or rebuilding its effects -- all of which would otherwise be wasted work for a
+    candidate that gets rejected anyway. (This does not extend to `DurativeAction` yet: its
+    conditions are de-duplicated per timing interval by `add_condition` on the way in, so an
+    early check over the raw substituted list is not guaranteed to see the same argument
+    multiset as the current post-clone path when substitution collapses two distinct lifted
+    conditions into one.)
     """
-    naming_list: List[str] = []
-    for param, value in subs.items():
-        assert isinstance(param, Parameter)
-        assert isinstance(value, FNode)
-        naming_list.append(str(value))
+    em = problem.environment.expression_manager
     c_subs = cast(Dict[Parameter, FNode], subs)
     if isinstance(old_action, InstantaneousAction):
-        new_action = cast(InstantaneousAction, old_action.clone())
+        new_preconditions = _substitute_and_simplify_preconditions(
+            old_action.preconditions, subs, simplifier, em
+        )
+        if new_preconditions is None:
+            return None
+        naming_list = _naming_list(subs)
+        new_action: InstantaneousAction
+        if type(old_action) is InstantaneousAction:
+            # Cloned without effects: they would only be immediately discarded and rebuilt
+            # below from old_action's (not new_action's) effects, so cloning them first via
+            # the generic clone() would be pure waste -- see _clone_without_effects's docstring.
+            new_action = old_action._clone_without_effects()
+        else:
+            # Any InstantaneousAction *subclass* (SensingAction, InstantaneousMotionAction,
+            # or any future one) falls back to a full clone() + clear_effects() instead.
+            new_action = cast(InstantaneousAction, old_action.clone())
+            new_action.clear_effects()
         new_action.name = (
             old_action.name
             if not subs
@@ -200,12 +262,10 @@ def create_action_with_given_subs(
             new_action._observed_fluents = [
                 f.substitute(subs) for f in new_action.observed_fluents
             ]
-        old_preconditions = new_action.preconditions
-        new_action._set_preconditions([p.substitute(subs) for p in old_preconditions])
+        new_action._set_preconditions(new_preconditions)
 
-        old_effects = list(new_action.effects)
-        old_simulated_effect = new_action.simulated_effect
-        new_action.clear_effects()
+        old_effects = old_action.effects
+        old_simulated_effect = old_action.simulated_effect
         for e in old_effects:
             new_effect = create_effect_with_given_subs(problem, e, simplifier, subs)
             if new_effect is not None:
@@ -235,14 +295,9 @@ def create_action_with_given_subs(
                 new_action.set_simulated_effect(new_simulated_effect)
             except UPConflictingEffectsException:
                 return None
-        is_feasible, new_preconditions = check_and_simplify_preconditions(
-            problem, new_action, simplifier
-        )
-        if not is_feasible:
-            return None
-        new_action._set_preconditions(new_preconditions)
         return new_action
     elif isinstance(old_action, DurativeAction):
+        naming_list = _naming_list(subs)
         new_durative_action = cast(DurativeAction, old_action.clone())
         new_durative_action.name = (
             old_action.name

--- a/unified_planning/engines/compilers/utils.py
+++ b/unified_planning/engines/compilers/utils.py
@@ -692,7 +692,7 @@ def remove_fluents(problem: Problem, fluents: Set[Fluent]) -> None:
     :param fluents: The `fluents` to remove; must all belong to the given `problem`.
     """
     for fluent in fluents:
-        problem._fluents.remove(fluent)
+        problem._remove_fluent(fluent)
         problem._fluents_defaults.pop(fluent, None)
     problem._initial_value = {
         fluent_exp: value

--- a/unified_planning/io/up_pddl_reader.py
+++ b/unified_planning/io/up_pddl_reader.py
@@ -2058,7 +2058,7 @@ class UPPDDLReader:
                         costs: Dict[up.model.Action, up.model.Expression] = {}
                         # cleared below unless every action costs exactly 1
                         use_plan_length = True
-                        problem._fluents.remove(self._totalcost.fluent())
+                        problem._remove_fluent(self._totalcost.fluent())
                         if self._totalcost in problem._initial_value:
                             problem._initial_value.pop(self._totalcost)
                         start_timing, end_timing = (

--- a/unified_planning/model/action.py
+++ b/unified_planning/model/action.py
@@ -123,6 +123,22 @@ class InstantaneousAction(UntimedEffectMixin, Action, PreconditionMixin):
         return res
 
     def clone(self):
+        new_instantaneous_action = self._clone_without_effects()
+        new_instantaneous_action._effects = [e.clone() for e in self._effects]
+        new_instantaneous_action._fluents_assigned = self._fluents_assigned.copy()
+        new_instantaneous_action._fluents_inc_dec = self._fluents_inc_dec.copy()
+        new_instantaneous_action._simulated_effect = self._simulated_effect
+        return new_instantaneous_action
+
+    def _clone_without_effects(self) -> "InstantaneousAction":
+        """Same as :func:`clone`, but leaves the clone with no effects (an empty
+        effects list, no assigned/inc-dec fluents, no simulated effect) instead of deep-cloning
+        the current ones. For a caller that is about to discard and rebuild every effect
+        anyway (as the grounder's ``create_action_with_given_subs`` does), cloning them first
+        is wasted work: each :class:`~unified_planning.model.Effect` clone re-runs
+        :func:`~unified_planning.model.Effect.__init__`'s free-variables/interpreted-function
+        extraction, on top of being immediately discarded.
+        """
         new_params = OrderedDict(
             (param_name, param.type) for param_name, param in self._parameters.items()
         )
@@ -130,10 +146,6 @@ class InstantaneousAction(UntimedEffectMixin, Action, PreconditionMixin):
             self._name, new_params, self._environment
         )
         new_instantaneous_action._preconditions = self._preconditions[:]
-        new_instantaneous_action._effects = [e.clone() for e in self._effects]
-        new_instantaneous_action._fluents_assigned = self._fluents_assigned.copy()
-        new_instantaneous_action._fluents_inc_dec = self._fluents_inc_dec.copy()
-        new_instantaneous_action._simulated_effect = self._simulated_effect
         return new_instantaneous_action
 
 

--- a/unified_planning/model/expression.py
+++ b/unified_planning/model/expression.py
@@ -28,6 +28,7 @@ from unified_planning.exceptions import (
     UPValueError,
 )
 from fractions import Fraction
+from collections.abc import Iterable as ABCIterable
 from typing import Optional, Iterable, List, Union, Dict, Tuple, Iterator, Sequence
 
 BoolExpression = Union[
@@ -102,7 +103,12 @@ class ExpressionManager(object):
         are both valid, and they are converted into (a,b,c)
         """
         for a in args:
-            if isinstance(a, Iterable) and not isinstance(a, str):
+            # FNode has no __iter__, so this check also
+            # serves as a fast path that skips the Iterable ABC machinery for
+            # the overwhelmingly common case of an already-promoted expression.
+            if isinstance(a, up.model.fnode.FNode):
+                yield a
+            elif isinstance(a, ABCIterable) and not isinstance(a, str):
                 for p in a:
                     yield p
             else:
@@ -120,7 +126,12 @@ class ExpressionManager(object):
         """
         res = []
         for e in self._polymorph_args_to_iterator(*args):
-            if isinstance(e, up.model.fluent.Fluent):
+            if isinstance(e, up.model.fnode.FNode):
+                assert e.environment == self.environment, (
+                    "Expression has a different environment of the expression manager"
+                )
+                res.append(e)
+            elif isinstance(e, up.model.fluent.Fluent):
                 assert e.environment == self.environment, (
                     "Fluent has a different environment of the expression manager"
                 )
@@ -166,10 +177,10 @@ class ExpressionManager(object):
                     assert isinstance(number, Fraction)
                     res.append(self.Real(number))
             else:
-                assert e.environment == self.environment, (
-                    "Expression has a different environment of the expression manager"
+                raise UPTypeError(
+                    f"{e!r} of type {type(e)} cannot be promoted to an FNode: it does "
+                    "not match any of the types accepted by the ExpressionManager."
                 )
-                res.append(e)
         return res
 
     def create_node(

--- a/unified_planning/model/fnode.py
+++ b/unified_planning/model/fnode.py
@@ -60,73 +60,11 @@ class FNode(object):
         return f"({op.join(str(arg) for arg in args)})"
 
     def __repr__(self) -> str:
-        repr_map = {
-            OperatorKind.BOOL_CONSTANT: lambda: (
-                "true" if self._content.payload else "false"
-            ),
-            OperatorKind.INT_CONSTANT: lambda: str(self._content.payload),
-            OperatorKind.REAL_CONSTANT: lambda: str(self._content.payload),
-            OperatorKind.FLUENT_EXP: lambda: (
-                self._content.payload.name
-                + self.get_nary_expression_string(", ", self.args)
-            ),
-            OperatorKind.INTERPRETED_FUNCTION_EXP: lambda: (
-                self._content.payload.name
-                + self.get_nary_expression_string(", ", self.args)
-            ),
-            OperatorKind.DOT: lambda: f"{self._content.payload}.{self.arg(0)}",
-            OperatorKind.PARAM_EXP: lambda: self._content.payload.name,
-            OperatorKind.VARIABLE_EXP: lambda: self._content.payload.name,
-            OperatorKind.OBJECT_EXP: lambda: self._content.payload.name,
-            OperatorKind.TIMING_EXP: lambda: str(self._content.payload),
-            OperatorKind.PRESENT_EXP: lambda: str(self._content.payload),
-            OperatorKind.AND: lambda: self.get_nary_expression_string(
-                " and ", self.args
-            ),
-            OperatorKind.OR: lambda: self.get_nary_expression_string(" or ", self.args),
-            OperatorKind.NOT: lambda: f"(not {self.arg(0)})",
-            OperatorKind.IMPLIES: lambda: self.get_nary_expression_string(
-                " implies ", self.args
-            ),
-            OperatorKind.IFF: lambda: self.get_nary_expression_string(
-                " iff ", self.args
-            ),
-            OperatorKind.EXISTS: lambda: (
-                f"Exists {self.get_nary_expression_string(', ', self._content.payload)} {self.arg(0)}"
-            ),
-            OperatorKind.FORALL: lambda: (
-                f"Forall {self.get_nary_expression_string(', ', self._content.payload)} {self.arg(0)}"
-            ),
-            OperatorKind.ALWAYS: lambda: f"Always({self.arg(0)})",
-            OperatorKind.SOMETIME: lambda: f"Sometime({self.arg(0)})",
-            OperatorKind.SOMETIME_BEFORE: lambda: (
-                f"Sometime-Before{self.get_nary_expression_string(', ', self.args)}"
-            ),
-            OperatorKind.SOMETIME_AFTER: lambda: (
-                f"Sometime-After{self.get_nary_expression_string(', ', self.args)}"
-            ),
-            OperatorKind.AT_MOST_ONCE: lambda: f"At-Most-Once({self.arg(0)})",
-            OperatorKind.PLUS: lambda: self.get_nary_expression_string(
-                " + ", self.args
-            ),
-            OperatorKind.MINUS: lambda: self.get_nary_expression_string(
-                " - ", self.args
-            ),
-            OperatorKind.TIMES: lambda: self.get_nary_expression_string(
-                " * ", self.args
-            ),
-            OperatorKind.DIV: lambda: self.get_nary_expression_string(" / ", self.args),
-            OperatorKind.LE: lambda: self.get_nary_expression_string(" <= ", self.args),
-            OperatorKind.LT: lambda: self.get_nary_expression_string(" < ", self.args),
-            OperatorKind.EQUALS: lambda: self.get_nary_expression_string(
-                " == ", self.args
-            ),
-        }
-
-        if self.node_type not in repr_map:
+        try:
+            repr_fn = _REPR_DISPATCH[self.node_type]
+        except KeyError:
             raise ValueError("Unknown FNode type found")
-
-        return repr_map[self.node_type]()
+        return repr_fn(self)
 
     @property
     def node_id(self) -> int:
@@ -493,3 +431,51 @@ class FNode(object):
 
     def Iff(self, right):
         return self._env.expression_manager.Iff(self, right)
+
+
+# Module-level __repr__ dispatch table: each function takes the FNode as its only
+# argument.
+_REPR_DISPATCH = {
+    OperatorKind.BOOL_CONSTANT: lambda n: "true" if n._content.payload else "false",
+    OperatorKind.INT_CONSTANT: lambda n: str(n._content.payload),
+    OperatorKind.REAL_CONSTANT: lambda n: str(n._content.payload),
+    OperatorKind.FLUENT_EXP: lambda n: (
+        n._content.payload.name + n.get_nary_expression_string(", ", n.args)
+    ),
+    OperatorKind.INTERPRETED_FUNCTION_EXP: lambda n: (
+        n._content.payload.name + n.get_nary_expression_string(", ", n.args)
+    ),
+    OperatorKind.DOT: lambda n: f"{n._content.payload}.{n.arg(0)}",
+    OperatorKind.PARAM_EXP: lambda n: n._content.payload.name,
+    OperatorKind.VARIABLE_EXP: lambda n: n._content.payload.name,
+    OperatorKind.OBJECT_EXP: lambda n: n._content.payload.name,
+    OperatorKind.TIMING_EXP: lambda n: str(n._content.payload),
+    OperatorKind.PRESENT_EXP: lambda n: str(n._content.payload),
+    OperatorKind.AND: lambda n: n.get_nary_expression_string(" and ", n.args),
+    OperatorKind.OR: lambda n: n.get_nary_expression_string(" or ", n.args),
+    OperatorKind.NOT: lambda n: f"(not {n.arg(0)})",
+    OperatorKind.IMPLIES: lambda n: n.get_nary_expression_string(" implies ", n.args),
+    OperatorKind.IFF: lambda n: n.get_nary_expression_string(" iff ", n.args),
+    OperatorKind.EXISTS: lambda n: (
+        f"Exists {n.get_nary_expression_string(', ', n._content.payload)} {n.arg(0)}"
+    ),
+    OperatorKind.FORALL: lambda n: (
+        f"Forall {n.get_nary_expression_string(', ', n._content.payload)} {n.arg(0)}"
+    ),
+    OperatorKind.ALWAYS: lambda n: f"Always({n.arg(0)})",
+    OperatorKind.SOMETIME: lambda n: f"Sometime({n.arg(0)})",
+    OperatorKind.SOMETIME_BEFORE: lambda n: (
+        f"Sometime-Before{n.get_nary_expression_string(', ', n.args)}"
+    ),
+    OperatorKind.SOMETIME_AFTER: lambda n: (
+        f"Sometime-After{n.get_nary_expression_string(', ', n.args)}"
+    ),
+    OperatorKind.AT_MOST_ONCE: lambda n: f"At-Most-Once({n.arg(0)})",
+    OperatorKind.PLUS: lambda n: n.get_nary_expression_string(" + ", n.args),
+    OperatorKind.MINUS: lambda n: n.get_nary_expression_string(" - ", n.args),
+    OperatorKind.TIMES: lambda n: n.get_nary_expression_string(" * ", n.args),
+    OperatorKind.DIV: lambda n: n.get_nary_expression_string(" / ", n.args),
+    OperatorKind.LE: lambda n: n.get_nary_expression_string(" <= ", n.args),
+    OperatorKind.LT: lambda n: n.get_nary_expression_string(" < ", n.args),
+    OperatorKind.EQUALS: lambda n: n.get_nary_expression_string(" == ", n.args),
+}

--- a/unified_planning/model/mixins/actions_set.py
+++ b/unified_planning/model/mixins/actions_set.py
@@ -16,6 +16,7 @@
 from warnings import warn
 import unified_planning as up
 from unified_planning.exceptions import UPProblemDefinitionError, UPValueError
+from unified_planning.model.mixins.name_index import NameIndex
 from typing import Iterator, List, Iterable
 
 
@@ -33,6 +34,9 @@ class ActionsSetMixin:
         self._add_user_type_method = add_user_type_method
         self._has_name_method = has_name_method
         self._actions: List["up.model.action.Action"] = []
+        self._actions_index: NameIndex["up.model.action.Action"] = NameIndex(
+            lambda a: a.name
+        )
 
     @property
     def environment(self) -> "up.environment.Environment":
@@ -111,10 +115,10 @@ class ActionsSetMixin:
         :param name: The `name` of the target `action`.
         :return: The `action` in the `problem` with the given `name`.
         """
-        for a in self._actions:
-            if a.name == name:
-                return a
-        raise UPValueError(f"Action of name: {name} is not defined!")
+        action = self._actions_index.get(self._actions, name)
+        if action is None:
+            raise UPValueError(f"Action of name: {name} is not defined!")
+        return action
 
     def has_action(self, name: str) -> bool:
         """
@@ -124,10 +128,7 @@ class ActionsSetMixin:
         :param name: The `name` of the target `action`.
         :return: `True` if the `problem` has an `action` with the given `name`, `False` otherwise.
         """
-        for a in self._actions:
-            if a.name == name:
-                return True
-        return False
+        return self._actions_index.contains(self._actions, name)
 
     def add_action(self, action: "up.model.action.Action"):
         """
@@ -147,6 +148,7 @@ class ActionsSetMixin:
             else:
                 warn(msg)
         self._actions.append(action)
+        self._actions_index.note_appended(self._actions)
         for param in action.parameters:
             if param.type.is_user_type():
                 self._add_user_type_method(param.type)

--- a/unified_planning/model/mixins/actions_set.py
+++ b/unified_planning/model/mixins/actions_set.py
@@ -34,9 +34,7 @@ class ActionsSetMixin:
         self._add_user_type_method = add_user_type_method
         self._has_name_method = has_name_method
         self._actions: List["up.model.action.Action"] = []
-        self._actions_index: NameIndex["up.model.action.Action"] = NameIndex(
-            lambda a: a.name
-        )
+        self._actions_index: NameIndex["up.model.action.Action"] = NameIndex()
 
     @property
     def environment(self) -> "up.environment.Environment":

--- a/unified_planning/model/mixins/actions_set.py
+++ b/unified_planning/model/mixins/actions_set.py
@@ -34,7 +34,9 @@ class ActionsSetMixin:
         self._add_user_type_method = add_user_type_method
         self._has_name_method = has_name_method
         self._actions: List["up.model.action.Action"] = []
-        self._actions_index: NameIndex["up.model.action.Action"] = NameIndex()
+        self._actions_index: NameIndex["up.model.action.Action"] = NameIndex(
+            track_renames=True
+        )
 
     @property
     def environment(self) -> "up.environment.Environment":

--- a/unified_planning/model/mixins/fluents_set.py
+++ b/unified_planning/model/mixins/fluents_set.py
@@ -160,6 +160,18 @@ class FluentsSetMixin:
 
         return fluent
 
+    def _remove_fluent(self, fluent: "up.model.fluent.Fluent"):
+        """
+        Removes the given `fluent` from this set, keeping the by-name index consistent.
+
+        The only place allowed to remove from `self._fluents`: the index cannot detect a
+        removal that a later append restores the length of, so it must be invalidated
+        explicitly. Does *not* touch the fluent's default or initial values -- see
+        :func:`~unified_planning.engines.compilers.utils.remove_fluents` for that.
+        """
+        self._fluents.remove(fluent)
+        self._fluents_index.invalidate()
+
     def clear_fluents(self):
         """
         Removes all the Fluent from the current Problem, together with their default.

--- a/unified_planning/model/mixins/fluents_set.py
+++ b/unified_planning/model/mixins/fluents_set.py
@@ -16,6 +16,7 @@
 from warnings import warn
 import unified_planning as up
 from unified_planning.model.expression import ConstantExpression
+from unified_planning.model.mixins.name_index import NameIndex
 from unified_planning.exceptions import UPProblemDefinitionError, UPValueError
 from typing import Optional, List, Dict, Union, Iterable, Set
 
@@ -40,6 +41,9 @@ class FluentsSetMixin:
         self._add_user_type_method = add_user_type_method
         self._has_name_method = has_name_method
         self._fluents: List["up.model.fluent.Fluent"] = []
+        self._fluents_index: NameIndex["up.model.fluent.Fluent"] = NameIndex(
+            lambda f: f.name
+        )
         self._fluents_defaults: Dict[
             "up.model.fluent.Fluent", "up.model.fnode.FNode"
         ] = {}
@@ -67,10 +71,10 @@ class FluentsSetMixin:
         :param name: The `name` of the target `fluent`:
         :return: The `fluent` with the given `name`.
         """
-        for f in self._fluents:
-            if f.name == name:
-                return f
-        raise UPValueError(f"Fluent of name: {name} is not defined!")
+        fluent = self._fluents_index.get(self._fluents, name)
+        if fluent is None:
+            raise UPValueError(f"Fluent of name: {name} is not defined!")
+        return fluent
 
     def has_fluent(self, name: str) -> bool:
         """
@@ -81,10 +85,7 @@ class FluentsSetMixin:
         :return: `True` if the `fluent` with the given `name` is in the `problem`,
             `False` otherwise.
         """
-        for f in self._fluents:
-            if f.name == name:
-                return True
-        return False
+        return self._fluents_index.contains(self._fluents, name)
 
     def add_fluents(self, fluents: Iterable["up.model.fluent.Fluent"]):
         """
@@ -145,6 +146,7 @@ class FluentsSetMixin:
             else:
                 warn(msg)
         self._fluents.append(fluent)
+        self._fluents_index.note_appended(self._fluents)
         if not default_initial_value is None:
             (v_exp,) = self.environment.expression_manager.auto_promote(
                 default_initial_value

--- a/unified_planning/model/mixins/fluents_set.py
+++ b/unified_planning/model/mixins/fluents_set.py
@@ -41,9 +41,7 @@ class FluentsSetMixin:
         self._add_user_type_method = add_user_type_method
         self._has_name_method = has_name_method
         self._fluents: List["up.model.fluent.Fluent"] = []
-        self._fluents_index: NameIndex["up.model.fluent.Fluent"] = NameIndex(
-            lambda f: f.name
-        )
+        self._fluents_index: NameIndex["up.model.fluent.Fluent"] = NameIndex()
         self._fluents_defaults: Dict[
             "up.model.fluent.Fluent", "up.model.fnode.FNode"
         ] = {}

--- a/unified_planning/model/mixins/name_index.py
+++ b/unified_planning/model/mixins/name_index.py
@@ -22,9 +22,17 @@ elements in a plain `list` and used to look an element up by name with a linear 
 `add_fluent`/..., adding N elements one at a time made that assembly step O(N^2).
 """
 
-from typing import Callable, Dict, Generic, List, Optional, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
 
 T = TypeVar("T")
+
+
+def name_of(item: Any) -> str:
+    """Default `NameIndex` key. Deliberately a module-level function and not a lambda: a
+    `NameIndex` is instance state of a `Problem`/`Agent`, and whole problems are pickled to be
+    sent to other processes (see `unified_planning/engines/parallel.py`, which uses the `spawn`
+    start method outside Linux), which a closure defined inside `__init__` would break."""
+    return item.name
 
 
 class NameIndex(Generic[T]):
@@ -46,13 +54,19 @@ class NameIndex(Generic[T]):
 
     __slots__ = ("_key", "_index", "_items", "_len")
 
-    def __init__(self, key: Callable[[T], str]) -> None:
+    def __init__(self, key: Callable[[T], str] = name_of) -> None:
         """:param key: Extracts the name from an element. Fixed for the lifetime of this
         index -- every element in the indexed list is expected to be named the same way."""
         self._key = key
         self._index: Optional[Dict[str, T]] = None
         self._items: Optional[List[T]] = None
         self._len: int = -1
+
+    def __getstate__(self):
+        # `_index`/`_items`/`_len` are a pure cache over a list this object does not own; don't
+        # carry them across a pickle round-trip (whole problems are sent to other processes),
+        # just let the next lookup rebuild it.
+        return (None, {"_key": self._key, "_index": None, "_items": None, "_len": -1})
 
     def _refresh(self, items: List[T]) -> None:
         if self._index is None or self._items is not items or self._len != len(items):

--- a/unified_planning/model/mixins/name_index.py
+++ b/unified_planning/model/mixins/name_index.py
@@ -1,0 +1,92 @@
+# Copyright 2021-2023 AIPlan4EU project
+# Copyright 2024-2026 Unified Planning library and its maintainers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A small self-validating name index shared by the `*SetMixin` classes.
+
+`ActionsSetMixin`/`FluentsSetMixin`/`ObjectsSetMixin`/`UserTypesSetMixin` each keep their
+elements in a plain `list` and used to look an element up by name with a linear scan
+(`has_action`, `action(name)`, ...). Since every element is added through `add_action`/
+`add_fluent`/..., adding N elements one at a time made that assembly step O(N^2).
+"""
+
+from typing import Callable, Dict, Generic, List, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class NameIndex(Generic[T]):
+    """A lazily-rebuilt ``name -> element`` index over a list of named elements.
+
+    The index is guarded by an identity+length token against the list it was built from, so
+    it self-heals (at the cost of one O(n) rebuild) against every way the underlying list can
+    change without going through :func:`note_appended`: wholesale reassignment (every
+    ``clone()``/``_clone_to`` path in this library replaces the list outright) or in-place
+    removal (``list.remove(...)``, used to drop a fluent). The one case this does not catch is
+    renaming an already-indexed element in place without changing the list's identity or
+    length (`Action.name` has a public setter) -- that was already unguarded before this index
+    existed, so this does not regress anything.
+
+    Preserves the original linear scan's first-occurrence semantics: when
+    ``Environment.error_used_name`` is disabled, two elements may share a name, and both
+    ``contains``/``get`` must agree with what a scan of the list in order would have found.
+    """
+
+    __slots__ = ("_key", "_index", "_items", "_len")
+
+    def __init__(self, key: Callable[[T], str]) -> None:
+        """:param key: Extracts the name from an element. Fixed for the lifetime of this
+        index -- every element in the indexed list is expected to be named the same way."""
+        self._key = key
+        self._index: Optional[Dict[str, T]] = None
+        self._items: Optional[List[T]] = None
+        self._len: int = -1
+
+    def _refresh(self, items: List[T]) -> None:
+        if self._index is None or self._items is not items or self._len != len(items):
+            index: Dict[str, T] = {}
+            for item in items:
+                name = self._key(item)
+                if name not in index:  # keep first occurrence, like a linear scan would
+                    index[name] = item
+            self._index = index
+            self._items = items
+            self._len = len(items)
+
+    def contains(self, items: List[T], name: str) -> bool:
+        self._refresh(items)
+        assert self._index is not None
+        return name in self._index
+
+    def get(self, items: List[T], name: str) -> Optional[T]:
+        self._refresh(items)
+        assert self._index is not None
+        return self._index.get(name)
+
+    def note_appended(self, items: List[T]) -> None:
+        """Call right after appending exactly one element to `items`, to keep the index
+        O(1) amortized instead of forcing a full rebuild on the next lookup. Safe to call
+        even when the index is stale or was never built: it then simply does nothing, and
+        the next `contains`/`get` call rebuilds from scratch."""
+        if (
+            self._index is not None
+            and self._items is items
+            and self._len == len(items) - 1
+        ):
+            last = items[-1]
+            name = self._key(last)
+            if name not in self._index:  # keep first occurrence
+                self._index[name] = last
+            self._len = len(items)

--- a/unified_planning/model/mixins/name_index.py
+++ b/unified_planning/model/mixins/name_index.py
@@ -61,18 +61,25 @@ class NameIndex(Generic[T]):
     """A lazily-rebuilt ``name -> element`` index over a list of named elements.
 
     The index is guarded by an identity+length token against the list it was built from, so
-    it self-heals (at the cost of one O(n) rebuild) against every way the underlying list can
-    change without going through :func:`note_appended`: wholesale reassignment (every
-    ``clone()``/``_clone_to`` path in this library replaces the list outright) or in-place
-    removal (``list.remove(...)``, used to drop a fluent). Renaming an already-indexed element
-    in place (`Action.name` has a public setter) changes neither the list's identity nor its
-    length, so it needs its own guard: pass ``track_renames=True`` and every indexed element
-    is stamped (via its ``_note_indexed()``) so that its `name` setter can call
-    :func:`note_renamed`, which this index checks against on every lookup (see
-    :data:`_rename_epoch`). Only elements with a mutable ``name`` need this -- currently just
-    `Action`/`DurativeAction` via `Transition.name` -- so only `ActionsSetMixin` passes
-    ``track_renames=True``; `Fluent`/`Object`/the user-type index have no name setter and pay
-    nothing extra.
+    it self-heals (at the cost of one O(n) rebuild) when the list is reassigned wholesale
+    (every ``clone()``/``_clone_to``/``clear_*`` path in this library replaces the list
+    outright) or changes length.
+
+    That token is deliberately cheap, and cheap means it cannot see two kinds of change:
+
+    * **In-place removal.** ``list.remove(...)`` followed by an append restores the original
+      length on the same list object, so neither half of the token moves and the index keeps
+      answering with the removed element while missing the appended one. Every remover must
+      therefore call :func:`invalidate` -- which is why removing a fluent goes through
+      ``FluentsSetMixin._remove_fluent`` rather than touching ``_fluents`` directly.
+    * **Renaming an already-indexed element** (`Action.name` has a public setter) changes
+      neither the list's identity nor its length either, and gets its own guard: pass
+      ``track_renames=True`` and every indexed element is stamped (via its
+      ``_note_indexed()``) so that its `name` setter can call :func:`note_renamed`, which
+      this index checks against on every lookup (see :data:`_rename_epoch`). Only elements
+      with a mutable ``name`` need this -- currently just `Action`/`DurativeAction` via
+      `Transition.name` -- so only `ActionsSetMixin` passes ``track_renames=True``;
+      `Fluent`/`Object`/the user-type index have no name setter and pay nothing extra.
 
     Preserves the original linear scan's first-occurrence semantics: when
     ``Environment.error_used_name`` is disabled, two elements may share a name, and both
@@ -110,6 +117,14 @@ class NameIndex(Generic[T]):
                 "_epoch": -1,
             },
         )
+
+    def invalidate(self) -> None:
+        """Drops the index, forcing a full rebuild on the next lookup. Must be called after
+        any in-place change to the indexed list that leaves its identity and length intact --
+        see the class docstring."""
+        self._index = None
+        self._items = None
+        self._len = -1
 
     def _refresh(self, items: List[T]) -> None:
         stale_rename = self._track_renames and self._epoch != current_rename_epoch()

--- a/unified_planning/model/mixins/name_index.py
+++ b/unified_planning/model/mixins/name_index.py
@@ -26,6 +26,28 @@ from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
 
 T = TypeVar("T")
 
+# Global counter bumped every time an already-indexed element has its name changed in place
+# (see `Transition.name`'s setter). A `NameIndex(track_renames=True)` stamps the counter's
+# current value onto itself whenever it (re)builds, and treats a mismatch at the next lookup
+# as "stale, rebuild" -- exactly like its existing identity/length token, just for a change
+# the list itself can't reveal. Deliberately global and coarse (one rename anywhere
+# invalidates every opted-in index) rather than a per-element notification: there is only one
+# indexed element kind with a mutable name (`Action`, via `Transition.name`), so a shared
+# counter is simpler than wiring each index up as an observer of each of its elements.
+_rename_epoch: int = 0
+
+
+def note_renamed() -> None:
+    """Call whenever an element some `NameIndex(track_renames=True)` may be holding has had
+    its name changed in place, so the next lookup rebuilds instead of trusting a mapping that
+    may now point at the wrong key."""
+    global _rename_epoch
+    _rename_epoch += 1
+
+
+def current_rename_epoch() -> int:
+    return _rename_epoch
+
 
 def name_of(item: Any) -> str:
     """Default `NameIndex` key. Deliberately a module-level function and not a lambda: a
@@ -42,42 +64,72 @@ class NameIndex(Generic[T]):
     it self-heals (at the cost of one O(n) rebuild) against every way the underlying list can
     change without going through :func:`note_appended`: wholesale reassignment (every
     ``clone()``/``_clone_to`` path in this library replaces the list outright) or in-place
-    removal (``list.remove(...)``, used to drop a fluent). The one case this does not catch is
-    renaming an already-indexed element in place without changing the list's identity or
-    length (`Action.name` has a public setter) -- that was already unguarded before this index
-    existed, so this does not regress anything.
+    removal (``list.remove(...)``, used to drop a fluent). Renaming an already-indexed element
+    in place (`Action.name` has a public setter) changes neither the list's identity nor its
+    length, so it needs its own guard: pass ``track_renames=True`` and every indexed element
+    is stamped (via its ``_note_indexed()``) so that its `name` setter can call
+    :func:`note_renamed`, which this index checks against on every lookup (see
+    :data:`_rename_epoch`). Only elements with a mutable ``name`` need this -- currently just
+    `Action`/`DurativeAction` via `Transition.name` -- so only `ActionsSetMixin` passes
+    ``track_renames=True``; `Fluent`/`Object`/the user-type index have no name setter and pay
+    nothing extra.
 
     Preserves the original linear scan's first-occurrence semantics: when
     ``Environment.error_used_name`` is disabled, two elements may share a name, and both
     ``contains``/``get`` must agree with what a scan of the list in order would have found.
     """
 
-    __slots__ = ("_key", "_index", "_items", "_len")
+    __slots__ = ("_key", "_index", "_items", "_len", "_track_renames", "_epoch")
 
-    def __init__(self, key: Callable[[T], str] = name_of) -> None:
+    def __init__(
+        self, key: Callable[[T], str] = name_of, track_renames: bool = False
+    ) -> None:
         """:param key: Extracts the name from an element. Fixed for the lifetime of this
-        index -- every element in the indexed list is expected to be named the same way."""
+        index -- every element in the indexed list is expected to be named the same way.
+        :param track_renames: Whether the indexed elements can have their name changed in
+            place after being indexed; see the class docstring."""
         self._key = key
         self._index: Optional[Dict[str, T]] = None
         self._items: Optional[List[T]] = None
         self._len: int = -1
+        self._track_renames = track_renames
+        self._epoch: int = -1
 
     def __getstate__(self):
-        # `_index`/`_items`/`_len` are a pure cache over a list this object does not own; don't
-        # carry them across a pickle round-trip (whole problems are sent to other processes),
-        # just let the next lookup rebuild it.
-        return (None, {"_key": self._key, "_index": None, "_items": None, "_len": -1})
+        # `_index`/`_items`/`_len`/`_epoch` are a pure cache over a list this object does not
+        # own; don't carry them across a pickle round-trip (whole problems are sent to other
+        # processes), just let the next lookup rebuild it.
+        return (
+            None,
+            {
+                "_key": self._key,
+                "_index": None,
+                "_items": None,
+                "_len": -1,
+                "_track_renames": self._track_renames,
+                "_epoch": -1,
+            },
+        )
 
     def _refresh(self, items: List[T]) -> None:
-        if self._index is None or self._items is not items or self._len != len(items):
+        stale_rename = self._track_renames and self._epoch != current_rename_epoch()
+        if (
+            self._index is None
+            or self._items is not items
+            or self._len != len(items)
+            or stale_rename
+        ):
             index: Dict[str, T] = {}
             for item in items:
                 name = self._key(item)
                 if name not in index:  # keep first occurrence, like a linear scan would
                     index[name] = item
+                if self._track_renames:
+                    item._note_indexed()  # type: ignore[attr-defined]
             self._index = index
             self._items = items
             self._len = len(items)
+            self._epoch = current_rename_epoch()
 
     def contains(self, items: List[T], name: str) -> bool:
         self._refresh(items)
@@ -93,14 +145,22 @@ class NameIndex(Generic[T]):
         """Call right after appending exactly one element to `items`, to keep the index
         O(1) amortized instead of forcing a full rebuild on the next lookup. Safe to call
         even when the index is stale or was never built: it then simply does nothing, and
-        the next `contains`/`get` call rebuilds from scratch."""
+        the next `contains`/`get` call rebuilds from scratch.
+
+        Also does nothing (deferring to that same full rebuild) when `track_renames` is set
+        and a rename has invalidated this index since it was last built: patching just the
+        newly appended element in would leave every earlier element's stale entry in place,
+        silently keeping it stale for another round instead of catching it up."""
         if (
             self._index is not None
             and self._items is items
             and self._len == len(items) - 1
+            and not (self._track_renames and self._epoch != current_rename_epoch())
         ):
             last = items[-1]
             name = self._key(last)
             if name not in self._index:  # keep first occurrence
                 self._index[name] = last
+            if self._track_renames:
+                last._note_indexed()  # type: ignore[attr-defined]
             self._len = len(items)

--- a/unified_planning/model/mixins/objects_set.py
+++ b/unified_planning/model/mixins/objects_set.py
@@ -35,9 +35,7 @@ class ObjectsSetMixin:
         self._add_user_type_method = add_user_type_method
         self._has_name_method = has_name_method
         self._objects: List["up.model.object.Object"] = []
-        self._objects_index: NameIndex["up.model.object.Object"] = NameIndex(
-            lambda o: o.name
-        )
+        self._objects_index: NameIndex["up.model.object.Object"] = NameIndex()
 
     @property
     def environment(self) -> "up.environment.Environment":

--- a/unified_planning/model/mixins/objects_set.py
+++ b/unified_planning/model/mixins/objects_set.py
@@ -16,6 +16,7 @@
 from warnings import warn
 import unified_planning as up
 from unified_planning.model.types import _UserType
+from unified_planning.model.mixins.name_index import NameIndex
 from unified_planning.exceptions import UPProblemDefinitionError, UPValueError
 from typing import Iterator, List, Union, Optional, cast, Iterable
 
@@ -34,6 +35,9 @@ class ObjectsSetMixin:
         self._add_user_type_method = add_user_type_method
         self._has_name_method = has_name_method
         self._objects: List["up.model.object.Object"] = []
+        self._objects_index: NameIndex["up.model.object.Object"] = NameIndex(
+            lambda o: o.name
+        )
 
     @property
     def environment(self) -> "up.environment.Environment":
@@ -80,6 +84,7 @@ class ObjectsSetMixin:
             else:
                 warn(msg)
         self._objects.append(obj)
+        self._objects_index.note_appended(self._objects)
         if obj.type.is_user_type():
             self._add_user_type_method(obj.type)
         return obj
@@ -99,10 +104,10 @@ class ObjectsSetMixin:
 
         :param name: The `name` of the target `object` in the `problem`.
         """
-        for o in self._objects:
-            if o.name == name:
-                return o
-        raise UPValueError(f"Object of name: {name} is not defined!")
+        obj = self._objects_index.get(self._objects, name)
+        if obj is None:
+            raise UPValueError(f"Object of name: {name} is not defined!")
+        return obj
 
     def has_object(self, name: str) -> bool:
         """
@@ -113,10 +118,7 @@ class ObjectsSetMixin:
         :return: `True` if an `object` with the given `name` is in the `problem`,
                 `False` otherwise.
         """
-        for o in self._objects:
-            if o.name == name:
-                return True
-        return False
+        return self._objects_index.contains(self._objects, name)
 
     def objects(
         self, typename: "up.model.types.Type"

--- a/unified_planning/model/mixins/user_types_set.py
+++ b/unified_planning/model/mixins/user_types_set.py
@@ -34,9 +34,7 @@ class UserTypesSetMixin:
         self._env = env
         self._has_name_method = has_name_method
         self._user_types: List["up.model.types.Type"] = []
-        self._user_types_index: NameIndex["up.model.types.Type"] = NameIndex(
-            lambda t: cast(_UserType, t).name
-        )
+        self._user_types_index: NameIndex["up.model.types.Type"] = NameIndex()
         # The field _user_types_hierarchy stores the information about the types and the list of their sons.
         self._user_types_hierarchy: Dict[
             Optional["up.model.types.Type"], List["up.model.types.Type"]

--- a/unified_planning/model/mixins/user_types_set.py
+++ b/unified_planning/model/mixins/user_types_set.py
@@ -16,6 +16,7 @@
 from warnings import warn
 import unified_planning as up
 from unified_planning.model.types import _UserType
+from unified_planning.model.mixins.name_index import NameIndex
 from unified_planning.exceptions import UPProblemDefinitionError, UPValueError
 from typing import List, Dict, Optional, cast
 
@@ -33,6 +34,9 @@ class UserTypesSetMixin:
         self._env = env
         self._has_name_method = has_name_method
         self._user_types: List["up.model.types.Type"] = []
+        self._user_types_index: NameIndex["up.model.types.Type"] = NameIndex(
+            lambda t: cast(_UserType, t).name
+        )
         # The field _user_types_hierarchy stores the information about the types and the list of their sons.
         self._user_types_hierarchy: Dict[
             Optional["up.model.types.Type"], List["up.model.types.Type"]
@@ -54,6 +58,7 @@ class UserTypesSetMixin:
             if ut.father is not None:
                 self._add_user_type(ut.father)
             self._user_types.append(type)
+            self._user_types_index.note_appended(self._user_types)
 
     @property
     def user_types(self) -> List["up.model.types.Type"]:
@@ -67,11 +72,10 @@ class UserTypesSetMixin:
         :param name: The target `name` for the `type`.
         :return: The `type` in the `problem` with the given `name`.
         """
-        for ut in self.user_types:
-            assert ut.is_user_type()
-            if cast(_UserType, ut).name == name:
-                return ut
-        raise UPValueError(f"UserType {name} is not defined!")
+        ut = self._user_types_index.get(self._user_types, name)
+        if ut is None:
+            raise UPValueError(f"UserType {name} is not defined!")
+        return ut
 
     def has_type(self, name: str) -> bool:
         """
@@ -82,11 +86,7 @@ class UserTypesSetMixin:
         :return: `True` if a `type` with the given `name` is in the `problem`,
             `False` otherwise.
         """
-        for ut in self.user_types:
-            assert ut.is_user_type()
-            if cast(_UserType, ut).name == name:
-                return True
-        return False
+        return self._user_types_index.contains(self._user_types, name)
 
     @property
     def user_types_hierarchy(

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -249,14 +249,23 @@ class Problem(  # type: ignore[misc]
         return res
 
     def clone(self):
-        new_p = self._clone_without_actions_and_metrics()
+        new_p = Problem(self._name, self._env)
+        self._clone_to(new_p)
+        return new_p
+
+    def _clone_to(self, new_p: "Problem"):  # type: ignore[override]
+        """
+        Copies this `Problem`'s state onto `new_p`, which must already be a fresh instance of
+        `Problem` (or a subclass sharing the same fields). Used by `clone()` and by subclasses
+        (e.g. `HierarchicalProblem`, `ContingentProblem`) that add their own state around it.
+        """
+        self._clone_to_without_actions_and_metrics(new_p)
         new_p._actions = [a.clone() for a in self._actions]
         # last as it requires actions to be cloned already
         MetricsMixin._clone_to(self, new_p, new_actions=new_p)
-        return new_p
 
-    def _clone_without_actions_and_metrics(self) -> "Problem":
-        """Same as :func:`clone`, but leaves the clone with no actions (an empty action
+    def _clone_to_without_actions_and_metrics(self, new_p: "Problem") -> None:
+        """Same as :func:`_clone_to`, but leaves `new_p` with no actions (an empty action
         list) and no quality metrics, instead of deep-cloning the current ones. Several
         compilers in `engines/compilers/` call `clone()` and then immediately
         `clear_actions()`, discarding every cloned action right away -- cloning them first
@@ -266,7 +275,6 @@ class Problem(  # type: ignore[misc]
         using this method is expected to add its own actions and, if needed, its own quality
         metrics afterward.
         """
-        new_p = Problem(self._name, self._env)
         UserTypesSetMixin._clone_to(self, new_p)
         ObjectsSetMixin._clone_to(self, new_p)
         FluentsSetMixin._clone_to(self, new_p)
@@ -287,7 +295,6 @@ class Problem(  # type: ignore[misc]
         new_p._fluents_inc_dec = {
             t: fs.copy() for t, fs in self._fluents_inc_dec.items()
         }
-        return new_p
 
     def has_name(self, name: str) -> bool:
         """

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -249,23 +249,30 @@ class Problem(  # type: ignore[misc]
         return res
 
     def clone(self):
-        new_p = Problem(self._name, self._env)
-        self._clone_to(new_p)
+        new_p = self._clone_without_actions()
+        new_p._actions = [a.clone() for a in self._actions]
+        # last as it requires actions to be cloned already
+        MetricsMixin._clone_to(self, new_p, new_actions=new_p)
         return new_p
 
-    def _clone_to(self, new_p: "Problem"):  # type: ignore[override]
+    def _clone_without_actions(self) -> "Problem":
+        """Same as :func:`clone`, but leaves the clone with no actions (an empty action
+        list) and no quality metrics, instead of deep-cloning the current ones. Several
+        compilers in `engines/compilers/` call `clone()` and then immediately
+        `clear_actions()`, discarding every cloned action right away -- cloning them first
+        is wasted work, and so is `MetricsMixin._clone_to`'s subsequent remapping of any
+        `MinimizeActionCosts` metric against those cloned actions (`new_actions.action(a.name)`
+        per cost entry), since it depends on the very actions that get thrown away. A caller
+        using this method is expected to add its own actions and, if needed, its own quality
+        metrics afterward.
         """
-        Copies this `Problem`'s state onto `new_p`, which must already be a fresh instance of
-        `Problem` (or a subclass sharing the same fields). Used by `clone()` and by subclasses
-        (e.g. `HierarchicalProblem`, `ContingentProblem`) that add their own state around it.
-        """
+        new_p = Problem(self._name, self._env)
         UserTypesSetMixin._clone_to(self, new_p)
         ObjectsSetMixin._clone_to(self, new_p)
         FluentsSetMixin._clone_to(self, new_p)
         InitialStateMixin._clone_to(self, new_p)
         TimeModelMixin._clone_to(self, new_p)
 
-        new_p._actions = [a.clone() for a in self._actions]
         new_p._events = [a.clone() for a in self._events]
         new_p._processes = [a.clone() for a in self._processes]
         new_p._timed_effects = {
@@ -280,9 +287,7 @@ class Problem(  # type: ignore[misc]
         new_p._fluents_inc_dec = {
             t: fs.copy() for t, fs in self._fluents_inc_dec.items()
         }
-
-        # last as it requires actions to be cloned already
-        MetricsMixin._clone_to(self, new_p, new_actions=new_p)
+        return new_p
 
     def has_name(self, name: str) -> bool:
         """

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -249,13 +249,13 @@ class Problem(  # type: ignore[misc]
         return res
 
     def clone(self):
-        new_p = self._clone_without_actions()
+        new_p = self._clone_without_actions_and_metrics()
         new_p._actions = [a.clone() for a in self._actions]
         # last as it requires actions to be cloned already
         MetricsMixin._clone_to(self, new_p, new_actions=new_p)
         return new_p
 
-    def _clone_without_actions(self) -> "Problem":
+    def _clone_without_actions_and_metrics(self) -> "Problem":
         """Same as :func:`clone`, but leaves the clone with no actions (an empty action
         list) and no quality metrics, instead of deep-cloning the current ones. Several
         compilers in `engines/compilers/` call `clone()` and then immediately

--- a/unified_planning/model/transition.py
+++ b/unified_planning/model/transition.py
@@ -44,6 +44,9 @@ class Transition(ABC):
     ):
         self._environment = get_environment(_env)
         self._name = _name
+        # Set (via `_note_indexed`) the first time some `NameIndex(track_renames=True)`
+        # indexes this transition -- see the `name` setter below.
+        self._is_indexed = False
         self._parameters: "OrderedDict[str, up.model.parameter.Parameter]" = (
             OrderedDict()
         )
@@ -107,6 +110,21 @@ class Transition(ABC):
     def name(self, new_name: str):
         """Sets the `Transition` `name`."""
         self._name = new_name
+        if self._is_indexed:
+            # Some `NameIndex(track_renames=True)` (currently only `ActionsSetMixin`'s) may
+            # be holding this transition under its old name -- tell it to rebuild rather than
+            # keep answering lookups with a mapping that now points at the wrong key.
+            # Imported lazily to avoid `model.transition` importing `model.mixins` (which
+            # imports several `model.*` submodules of its own) at module load time.
+            from unified_planning.model.mixins.name_index import note_renamed
+
+            note_renamed()
+
+    def _note_indexed(self) -> None:
+        """Called by a `NameIndex(track_renames=True)` the first time it indexes this
+        transition, so a later rename of its `name` (see the setter above) knows to
+        invalidate that index instead of leaving it silently stale."""
+        self._is_indexed = True
 
     @property
     def parameters(self) -> List["up.model.parameter.Parameter"]:

--- a/unified_planning/test/examples/testing_variants.py
+++ b/unified_planning/test/examples/testing_variants.py
@@ -1036,4 +1036,77 @@ def get_example_problems():
     )
     problems["robot_non_linear_continuous_1"] = robot_non_linear_continuous_1
 
+    # robot_package_delivery_joint_static_pruning
+    Robot = UserType("Robot")
+    Location = UserType("Location")
+    Package = UserType("Package")
+    can_carry = Fluent("can_carry", BoolType(), r=Robot, p=Package)
+    pkg_at = Fluent("pkg_at", BoolType(), p=Package, l=Location)
+    robot_at = Fluent("robot_at", BoolType(), r=Robot, l=Location)
+    delivered = Fluent("delivered", BoolType(), p=Package)
+    deliver = InstantaneousAction("deliver", r=Robot, l=Location, p=Package)
+    r = deliver.parameter("r")
+    l = deliver.parameter("l")
+    p = deliver.parameter("p")
+    # can_carry and pkg_at each jointly constrain two of deliver's three parameters --
+    # a static predicate independently narrowing r, l and p can't see that a robot able to
+    # carry a package is not necessarily the one standing where that package is, so pruning
+    # each parameter on its own still leaves every (r, l, p) combination to be cross-produced
+    # and only then rejected.
+    deliver.add_precondition(can_carry(r, p))
+    deliver.add_precondition(pkg_at(p, l))
+    deliver.add_precondition(robot_at(r, l))
+    deliver.add_precondition(Not(delivered(p)))
+    deliver.add_effect(delivered(p), True)
+    move = InstantaneousAction("move", r=Robot, l_from=Location, l_to=Location)
+    move.add_precondition(robot_at(move.parameter("r"), move.parameter("l_from")))
+    move.add_effect(robot_at(move.parameter("r"), move.parameter("l_from")), False)
+    move.add_effect(robot_at(move.parameter("r"), move.parameter("l_to")), True)
+    robots = [Object(f"r{i}", Robot) for i in range(2)]
+    locations = [Object(f"l{i}", Location) for i in range(3)]
+    packages = [Object(f"p{i}", Package) for i in range(3)]
+    problem = Problem("robot_package_delivery_joint_static_pruning")
+    problem.add_fluent(can_carry, default_initial_value=False)
+    problem.add_fluent(pkg_at, default_initial_value=False)
+    problem.add_fluent(robot_at, default_initial_value=False)
+    problem.add_fluent(delivered, default_initial_value=False)
+    problem.add_actions([deliver, move])
+    problem.add_objects(robots + locations + packages)
+    problem.set_initial_value(can_carry(robots[0], packages[0]), True)
+    problem.set_initial_value(can_carry(robots[0], packages[1]), True)
+    problem.set_initial_value(can_carry(robots[1], packages[2]), True)
+    problem.set_initial_value(pkg_at(packages[0], locations[0]), True)
+    problem.set_initial_value(pkg_at(packages[1], locations[1]), True)
+    problem.set_initial_value(pkg_at(packages[2], locations[2]), True)
+    problem.set_initial_value(robot_at(robots[0], locations[0]), True)
+    problem.set_initial_value(robot_at(robots[1], locations[0]), True)
+    problem.add_goal(delivered(packages[0]))
+    problem.add_goal(delivered(packages[2]))
+    plan = up.plans.SequentialPlan(
+        [
+            up.plans.ActionInstance(
+                deliver,
+                (ObjectExp(robots[0]), ObjectExp(locations[0]), ObjectExp(packages[0])),
+            ),
+            up.plans.ActionInstance(
+                move,
+                (
+                    ObjectExp(robots[1]),
+                    ObjectExp(locations[0]),
+                    ObjectExp(locations[2]),
+                ),
+            ),
+            up.plans.ActionInstance(
+                deliver,
+                (ObjectExp(robots[1]), ObjectExp(locations[2]), ObjectExp(packages[2])),
+            ),
+        ]
+    )
+    robot_package_delivery_joint_static_pruning = TestCase(
+        problem=problem, solvable=True, valid_plans=[plan]
+    )
+    problems["robot_package_delivery_joint_static_pruning"] = (
+        robot_package_delivery_joint_static_pruning
+    )
+
     return problems

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -1354,6 +1354,33 @@ class TestGrounderJoinPruning(unittest_TestCase):
         fallback_names = self._ground_names(problem, force_fallback_only=True)
         self.assertEqual(joined_names, fallback_names)
 
+    def test_join_wildcard_argument_does_not_duplicate_ground_actions(self):
+        # A wildcard argument position isn't projected into a join binding, so two distinct
+        # true tuples that agree on every non-wildcard position collapse onto the very same
+        # binding. Left undeduplicated, that binding is emitted once per matching true tuple,
+        # so the same parameter tuple is grounded (and added to the problem) more than once --
+        # which `Problem.add_action` rejects as a duplicate action name. Here `static(x, x+0)`
+        # is true for both `(1, 1)` and `(1, 2)`, both consistent with `x=1`.
+        problem = Problem("join_wildcard_duplicate")
+        int_type = IntType(0, 3)
+        static = Fluent("static", BoolType(), a=int_type, b=int_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=int_type)
+        x = action.parameter("x")
+        action.add_precondition(static(x, x + 0))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(static, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.set_initial_value(static(1, 1), True)
+        problem.set_initial_value(static(1, 2), True)
+        problem.add_action(action)
+
+        joined_names = self._ground_names(problem)
+        fallback_names = self._ground_names(problem, force_fallback_only=True)
+        self.assertEqual(joined_names, ["act_1"])
+        self.assertEqual(joined_names, fallback_names)
+
     def test_join_empty_relation(self):
         # A static atom whose relation has no true tuples at all must prune to zero
         # groundings, matching the per-parameter fallback.

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -1210,6 +1210,30 @@ class TestGrounderJoinPruning(unittest_TestCase):
                 f'the join diverged from the per-parameter fallback on example problem "{name}"',
             )
 
+    def test_join_prunes_more_than_the_fallback_on_an_example_problem(self):
+        # The equivalence test above asserts the join and the fallback always produce the
+        # SAME final ground-action list -- by design, since every join-pruned candidate still
+        # goes through the exact feasibility check every fallback-pruned candidate does. That
+        # means it would pass identically even if the join silently did nothing at all, so it
+        # can't tell whether the join is actually pruning anything on any of this repo's
+        # example problems. This checks its actual advantage on
+        # "robot_package_delivery_joint_static_pruning": its `deliver` action's two static
+        # preconditions (`can_carry`, `pkg_at`) each jointly constrain a different pair of its
+        # three parameters -- exactly the shape independent per-parameter pruning can't see,
+        # so it still has to cross-product and reject every (robot, location, package) combo.
+        problem = self.problems["robot_package_delivery_joint_static_pruning"].problem
+        assert isinstance(problem, Problem)
+        deliver = problem.action("deliver")
+
+        joined = list(GrounderHelper(problem).get_possible_parameters(deliver))
+        fallback = list(
+            GrounderHelper(problem, join_max_candidates=0).get_possible_parameters(
+                deliver
+            )
+        )
+        self.assertEqual(len(joined), 3)
+        self.assertEqual(len(fallback), 18)
+
     def test_join_zero_parameter_action(self):
         problem = Problem("join_zero_param")
         done = Fluent("done")

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -35,6 +35,7 @@ from unified_planning.test import (
 from unified_planning.test.examples import get_example_problems
 from unified_planning.engines import CompilationKind
 from unified_planning.engines.compilers import Grounder
+from unified_planning.engines.compilers.grounder import GrounderHelper
 from unified_planning.model.contingent import SensingAction
 
 
@@ -459,6 +460,41 @@ class TestGrounder(unittest_TestCase):
         self.assertEqual(len(grounded_problem.actions), 1)
         self.assertEqual(grounded_problem.actions[0].name, "act_a")
         self.assertEqual(len(grounded_problem.actions[0].parameters), 0)
+
+    def test_static_bool_condition_prunes_on_every_matching_position(self):
+        # A static atom that mentions the SAME parameter at more than one argument
+        # position (here, a "diagonal" relation applied as sym(?x, ?x)) must be pruned using
+        # the intersection of every matching position, not just the first one found: sym is
+        # only ever true off-diagonal, so no object can ever satisfy sym(x, x), and the
+        # grounder must produce zero ground actions.
+        problem = Problem("static_bool_all_positions")
+        item_type = UserType("Item")
+        objs = [Object(f"o{i}", item_type) for i in range(4)]
+        sym = Fluent("sym", BoolType(), a=item_type, b=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type)
+        x = action.parameter("x")
+        action.add_precondition(sym(x, x))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(sym, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(objs)
+        # o0 appears at position 0 and o1/o0 appear at position 1, but no tuple has equal
+        # arguments, so sym(x, x) is unsatisfiable for every x.
+        problem.set_initial_value(sym(objs[0], objs[1]), True)
+        problem.set_initial_value(sym(objs[1], objs[0]), True)
+        problem.set_initial_value(sym(objs[2], objs[1]), True)
+        problem.add_action(action)
+
+        # The join's hash-join also has to handle the same parameter appearing at more than
+        # one position of a single atom (its `binding[val] != arg_value` check, matching the
+        # per-parameter fallback's intersection above) -- must agree it's unsatisfiable too.
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(len(grounded_problem.actions), 0)
 
     def test_effect_target_arguments_are_simplified(self):
         # the effect's target fluent must be normalized like its value: f(x + 1) grounded
@@ -938,3 +974,262 @@ class TestGrounder(unittest_TestCase):
                     problem_kind=problem.kind, plan_kind=plan.kind
                 ) as pv:
                     self.assertTrue(pv.validate(problem, plan))
+
+
+class TestGrounderJoinPruning(unittest_TestCase):
+    """Tests for the grounder's join-based static-fluent pruning
+    (`GrounderHelper._compute_join_pruned_parameters`). Static atoms are hash-joined together
+    instead of pruning each action parameter independently, so a static predicate that
+    correlates several of an action's parameters together (which independent per-parameter
+    pruning can't see) gets pruned to the tuples actually consistent with it. When the join
+    isn't applicable/safe for a given action, that one action automatically falls back to the
+    older per-parameter-independent pruning (`GrounderHelper._purge_items_list`). The two must
+    always produce list-equal (not just set-equal) ground-action names, since the join is a
+    pure performance improvement over the fallback, never a behavior change: it only narrows
+    the per-parameter candidate lists that feed the exact, all-parameters-bound feasibility
+    check every candidate still goes through regardless of which one produced it.
+    """
+
+    def setUp(self):
+        unittest_TestCase.setUp(self)
+        self.problems = get_example_problems()
+
+    @staticmethod
+    def _ground_names(problem, force_fallback_only=False):
+        original_cap = GrounderHelper._JOIN_MAX_CANDIDATES
+        if force_fallback_only:
+            # A cap of 0 makes every join attempt bail out immediately, forcing every
+            # (non-zero-parameter) action through the per-parameter-independent fallback --
+            # used to check the join never changes output versus that fallback.
+            GrounderHelper._JOIN_MAX_CANDIDATES = 0
+        try:
+            result = Grounder().compile(problem, CompilationKind.GROUNDING)
+        finally:
+            GrounderHelper._JOIN_MAX_CANDIDATES = original_cap
+        grounded = result.problem
+        assert isinstance(grounded, Problem)
+        return [a.name for a in grounded.actions]
+
+    def test_join_unsafe_actually_prunes_and_does_not_silently_fail(self):
+        # `_compute_join_pruned_parameters` wraps everything in a bare `try/except Exception:
+        # return None`, so a broken join (a missing helper method, a typo, any internal bug)
+        # silently degrades to the per-parameter fallback -- correctly, but with none of the
+        # join's benefit, and invisibly to every other test in this class, since comparing
+        # "join" output to "fallback" output trivially matches when "join" is always silently
+        # failing and actually always running the fallback. This calls
+        # `_compute_join_pruned_parameters_unsafe` directly, bypassing that exception handler,
+        # so a broken join surfaces as a raised exception here instead of a silent no-op, and
+        # asserts the exact pruned candidate count, so a join that silently stopped pruning
+        # (while still returning *some* answer) would also be caught.
+        problem = Problem("join_actually_prunes")
+        item_type = UserType("Item")
+        items = [Object(f"i{i}", item_type) for i in range(4)]
+        rel = Fluent("rel", BoolType(), a=item_type, b=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type, y=item_type)
+        x = action.parameter("x")
+        y = action.parameter("y")
+        action.add_precondition(rel(x, y))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(rel, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        # Only 2 of the 4x4=16 possible (x, y) pairs are ever true.
+        problem.set_initial_value(rel(items[0], items[1]), True)
+        problem.set_initial_value(rel(items[2], items[3]), True)
+        problem.add_action(action)
+
+        gh = GrounderHelper(problem)
+        type_list = [p.type for p in action.parameters]
+        result = gh._compute_join_pruned_parameters_unsafe(action, type_list)
+        assert result is not None
+        self.assertEqual(
+            set(result),
+            {rel(items[0], items[1]).args, rel(items[2], items[3]).args},
+        )
+
+    def test_join_equivalent_to_fallback_pruning_on_example_problems(self):
+        # The single most important check: for every example problem this repo already has
+        # test fixtures for, the join and the per-parameter fallback must produce list-equal
+        # ground-action names.
+        for name, tc in self.problems.items():
+            problem = tc.problem
+            if not isinstance(problem, Problem) or not problem.actions:
+                continue
+            if not Grounder.supports(problem.kind):
+                continue
+            joined_names = self._ground_names(problem)
+            fallback_names = self._ground_names(problem, force_fallback_only=True)
+            self.assertEqual(
+                joined_names,
+                fallback_names,
+                f'the join diverged from the per-parameter fallback on example problem "{name}"',
+            )
+
+    def test_join_zero_parameter_action(self):
+        problem = Problem("join_zero_param")
+        done = Fluent("done")
+        action = InstantaneousAction("act")
+        action.add_effect(done, True)
+        problem.add_fluent(done, default_initial_value=False)
+        problem.add_action(action)
+
+        grounded = Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded, Problem)
+        self.assertEqual(len(grounded.actions), 1)
+        self.assertEqual(grounded.actions[0].name, "act")
+
+    def test_join_constant_argument(self):
+        # A static atom with a constant argument (e.g. `at(?x, l1)`) must correctly filter on
+        # that fixed value, not just on the parameter-bound positions.
+        problem = Problem("join_constant_arg")
+        item_type = UserType("Item")
+        loc_type = UserType("Location")
+        items = [Object(f"i{i}", item_type) for i in range(3)]
+        l1 = Object("l1", loc_type)
+        l2 = Object("l2", loc_type)
+        at = Fluent("at", BoolType(), i=item_type, l=loc_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type)
+        x = action.parameter("x")
+        action.add_precondition(at(x, l1))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(at, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items + [l1, l2])
+        problem.set_initial_value(at(items[0], l1), True)
+        problem.set_initial_value(
+            at(items[1], l2), True
+        )  # wrong location: must be pruned
+        problem.add_action(action)
+
+        grounded = Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded, Problem)
+        self.assertEqual([a.name for a in grounded.actions], ["act_i0"])
+
+    def test_join_hierarchical_typing(self):
+        # A static fact declared over a supertype must not bind an object to an action
+        # parameter typed to a subtype unless that object actually belongs to the subtype --
+        # otherwise this produces an ill-typed substitution.
+        location = UserType("Location")
+        grass = UserType("Grass", father=location)
+        problem = Problem("join_hierarchical_typing")
+        g1 = Object("g1", grass)
+        loc1 = Object("loc1", location)  # a Location but NOT a Grass
+        connected = Fluent("connected", BoolType(), a=location, b=location)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=grass)
+        x = action.parameter("x")
+        action.add_precondition(connected(x, x))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(connected, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects([g1, loc1])
+        problem.set_initial_value(connected(g1, g1), True)
+        problem.set_initial_value(connected(loc1, loc1), True)
+        problem.add_action(action)
+
+        # Must not raise a type error, and must not ground with x := loc1 (not a Grass).
+        grounded = Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded, Problem)
+        self.assertEqual([a.name for a in grounded.actions], ["act_g1"])
+
+    def test_join_default_true_fluent_with_explicit_overrides(self):
+        problem = Problem("join_default_true")
+        item_type = UserType("Item")
+        items = [Object(f"i{i}", item_type) for i in range(4)]
+        usable = Fluent("usable", BoolType(), i=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type)
+        x = action.parameter("x")
+        action.add_precondition(usable(x))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(usable, default_initial_value=True)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        problem.set_initial_value(usable(items[0]), False)  # explicit override
+        problem.add_action(action)
+
+        for force_fallback_only in (False, True):
+            names = sorted(
+                self._ground_names(problem, force_fallback_only=force_fallback_only)
+            )
+            self.assertEqual(
+                names,
+                ["act_i1", "act_i2", "act_i3"],
+                f"mismatch with force_fallback_only={force_fallback_only}",
+            )
+
+    def test_join_wildcard_nested_argument(self):
+        # An atom argument that is neither a bare action parameter nor a constant (here, a
+        # nested `Plus` expression) can't be used to filter parameters -- it must be treated
+        # as an unconstrained wildcard by the join, exactly like the per-parameter fallback
+        # already does.
+        problem = Problem("join_wildcard")
+        int_type = IntType(0, 3)
+        static = Fluent("static", BoolType(), a=int_type, b=int_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=int_type)
+        x = action.parameter("x")
+        action.add_precondition(static(x, x + 0))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(static, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.set_initial_value(static(1, 1), True)
+        problem.add_action(action)
+
+        joined_names = self._ground_names(problem)
+        fallback_names = self._ground_names(problem, force_fallback_only=True)
+        self.assertEqual(joined_names, fallback_names)
+
+    def test_join_empty_relation(self):
+        # A static atom whose relation has no true tuples at all must prune to zero
+        # groundings, matching the per-parameter fallback.
+        problem = Problem("join_empty_relation")
+        item_type = UserType("Item")
+        items = [Object(f"i{i}", item_type) for i in range(3)]
+        never_true = Fluent("never_true", BoolType(), i=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type)
+        x = action.parameter("x")
+        action.add_precondition(never_true(x))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(never_true, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        problem.add_action(action)
+
+        grounded = Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded, Problem)
+        self.assertEqual(len(grounded.actions), 0)
+
+    def test_join_max_candidates_fallback(self):
+        # Forcing the safety cap very low must fall back to the per-parameter cross-product
+        # path for the affected action, not lose any otherwise-valid ground action.
+        problem = Problem("join_fallback")
+        item_type = UserType("Item")
+        items = [Object(f"i{i}", item_type) for i in range(5)]
+        rel = Fluent("rel", BoolType(), a=item_type, b=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type, y=item_type)
+        x = action.parameter("x")
+        y = action.parameter("y")
+        action.add_precondition(rel(x, y))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(rel, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        for i in range(len(items) - 1):
+            problem.set_initial_value(rel(items[i], items[i + 1]), True)
+        problem.add_action(action)
+
+        expected = sorted(self._ground_names(problem, force_fallback_only=True))
+        actual = sorted(self._ground_names(problem))
+        self.assertEqual(expected, actual)

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -38,6 +38,7 @@ from unified_planning.engines.compilers import Grounder
 from unified_planning.engines.compilers.grounder import GrounderHelper
 from unified_planning.model.contingent import SensingAction
 from unified_planning.model.motion import InstantaneousMotionAction
+from unified_planning.environment import Environment
 
 
 class TestGrounder(unittest_TestCase):
@@ -1481,3 +1482,60 @@ class TestGrounderJoinPruning(unittest_TestCase):
         self.assertEqual(
             len(expected), 14
         )  # 16 pairs minus the 2 explicitly false ones
+
+    def test_true_arg_tuples_does_not_intern_new_expressions(self):
+        # `_fluent_true_arg_tuples`'s default-True branch used to enumerate a within-budget
+        # relation via `get_all_fluent_exp`, which calls `fluent(*args)` once per combination
+        # -- N**arity of them for a binary fluent over N objects -- interning a fresh `FNode`
+        # for each one into the `Environment`'s memo, which is unbounded and outlives the
+        # `GrounderHelper`. The budget check alone doesn't catch this: 30**2 = 900 tuples is
+        # nowhere near the default 1,000,000-row budget, so it was still fully enumerated the
+        # expensive way. Enumerating from the parameter types' own already-cached domain lists
+        # instead reuses existing `FNode`s and interns none of its own, so the
+        # interned-expression count stays O(N), not O(N**2), regardless of how many tuples the
+        # (still within-budget) enumeration itself produces.
+        #
+        # A private `Environment` keeps the interned-expression count meaningful: the global
+        # environment (used by every other test in this file) may already have this test's
+        # object names interned from unrelated fixtures, which would otherwise make the delta
+        # assertion depend on test execution order.
+        env = Environment()
+        item_type = env.type_manager.UserType("Item")
+        items = [Object(f"i{i}", item_type, env) for i in range(30)]
+        rel = Fluent(
+            "rel",
+            env.type_manager.BoolType(),
+            a=item_type,
+            b=item_type,
+            environment=env,
+        )
+        dummy = Fluent("dummy", env.type_manager.BoolType(), environment=env)
+        action = InstantaneousAction("act", x=item_type, y=item_type, _env=env)
+        x, y = action.parameter("x"), action.parameter("y")
+        action.add_precondition(rel(x, y))
+        action.add_effect(dummy, True)
+
+        problem = Problem("true_arg_tuples_no_intern", env)
+        problem.add_fluent(rel, default_initial_value=True)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        # An explicit override forces the default-True branch to actually enumerate (rather
+        # than trivially reporting the empty-relation/wildcard shortcuts elsewhere in this
+        # file), matching the reviewer's own "true everywhere except a few" example.
+        problem.set_initial_value(rel(items[0], items[0]), False)
+        problem.add_action(action)
+
+        em = env.expression_manager
+        before = len(em.expressions)
+        gh = GrounderHelper(problem)
+        result = gh._fluent_true_arg_tuples(rel)
+        after = len(em.expressions)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(len(result), len(items) ** 2 - 1)
+        # O(N), not O(N**2): only the domain items themselves ever get interned here (at most
+        # one per object; `set_initial_value` above already interned one of them, so the
+        # delta can be one less than `len(items)`), never one per (900-tuple) grounding.
+        self.assertLessEqual(after - before, len(items))
+        self.assertGreater(after - before, 0)

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -1427,3 +1427,57 @@ class TestGrounderJoinPruning(unittest_TestCase):
         expected = sorted(self._ground_names(problem, force_fallback_only=True))
         actual = sorted(self._ground_names(problem))
         self.assertEqual(expected, actual)
+
+    def test_oversized_default_true_static_fluent_is_not_materialized(self):
+        # `join_max_candidates` only ever compares rows that have already been built, so a
+        # static fluent defaulting to True -- whose true tuples are every one of its N**arity
+        # groundings -- used to be materialized in full before the first cap check. The size
+        # is now derived from the argument domains up front, and an over-budget relation is
+        # skipped without enumerating anything; skipping a conjunct only weakens the pruning,
+        # so the set of ground actions must come out unchanged.
+        problem = Problem("oversized_default_true")
+        item_type = UserType("Item")
+        items = [Object(f"i{i}", item_type) for i in range(4)]
+        tbl = Fluent("tbl", BoolType(), a=item_type, b=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type, y=item_type)
+        action.add_precondition(tbl(action.parameter("x"), action.parameter("y")))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(
+            tbl, default_initial_value=True
+        )  # static: nothing ever writes it
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        problem.add_action(action)
+        problem.set_initial_value(tbl(items[0], items[1]), False)
+        problem.set_initial_value(tbl(items[2], items[3]), False)
+
+        # 16 groundings: within the default budget, so the relation is materialized.
+        within_budget = GrounderHelper(problem)
+        self.assertIsNotNone(within_budget._fluent_true_arg_tuples(tbl))
+
+        # A budget below 16 must reject it from the argument domains alone, without ever
+        # building the tuple list -- `None` here, and the join then prunes nothing with it.
+        over_budget = GrounderHelper(problem, join_max_candidates=4)
+        self.assertIsNone(over_budget._fluent_true_arg_tuples(tbl))
+
+        # A cap of 0 means "disable the join" and keeps the default enumeration budget.
+        self.assertIsNotNone(
+            GrounderHelper(problem, join_max_candidates=0)._fluent_true_arg_tuples(tbl)
+        )
+
+        expected = sorted(self._ground_names(problem))
+        actual = sorted(
+            a.name
+            for a in cast(
+                Problem,
+                Grounder(join_max_candidates=4)
+                .compile(problem, CompilationKind.GROUNDING)
+                .problem,
+            ).actions
+        )
+        self.assertEqual(expected, actual)
+        self.assertEqual(
+            len(expected), 14
+        )  # 16 pairs minus the 2 explicitly false ones

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -59,6 +59,34 @@ class TestGrounder(unittest_TestCase):
         grounded_problem.name = problem.name
         self.assertEqual(grounded_problem, problem)
 
+    def test_grounding_keeps_the_action_cost_metric(self):
+        Item = UserType("Item")
+        i1 = Object("i1", Item)
+        i2 = Object("i2", Item)
+        done = Fluent("done", BoolType(), x=Item)
+        act = InstantaneousAction("act", x=Item)
+        x = act.parameter("x")
+        act.add_effect(done(x), True)
+
+        problem = Problem("mockup")
+        problem.add_object(i1)
+        problem.add_object(i2)
+        problem.add_fluent(done, default_initial_value=False)
+        problem.add_action(act)
+        problem.add_goal(done(i1))
+        problem.add_quality_metric(MinimizeActionCosts({act: 7}))
+
+        gro = Grounder()
+        res = gro.compile(problem, CompilationKind.GROUNDING)
+        grounded_problem = res.problem
+        assert isinstance(grounded_problem, Problem)
+
+        self.assertEqual(len(grounded_problem.quality_metrics), 1)
+        metric = grounded_problem.quality_metrics[0]
+        assert isinstance(metric, MinimizeActionCosts)
+        costs = {metric.get_action_cost(a) for a in grounded_problem.actions}
+        self.assertEqual(costs, {Int(7)})
+
     @skipIfNoOneshotPlannerForProblemKind(classical_kind.union(general_numeric_kind))
     @skipIfNoPlanValidatorForProblemKind(classical_kind.union(general_numeric_kind))
     def test_robot(self):

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -1055,16 +1055,15 @@ class TestGrounderJoinPruning(unittest_TestCase):
 
     @staticmethod
     def _ground_names(problem, force_fallback_only=False):
-        original_cap = GrounderHelper._JOIN_MAX_CANDIDATES
-        if force_fallback_only:
-            # A cap of 0 makes every join attempt bail out immediately, forcing every
-            # (non-zero-parameter) action through the per-parameter-independent fallback --
-            # used to check the join never changes output versus that fallback.
-            GrounderHelper._JOIN_MAX_CANDIDATES = 0
-        try:
-            result = Grounder().compile(problem, CompilationKind.GROUNDING)
-        finally:
-            GrounderHelper._JOIN_MAX_CANDIDATES = original_cap
+        # A cap of 0 disables the join outright, forcing every (non-zero-parameter) action
+        # through the per-parameter-independent fallback -- used to check the join never
+        # changes output versus that fallback.
+        join_max_candidates = (
+            0 if force_fallback_only else GrounderHelper.DEFAULT_JOIN_MAX_CANDIDATES
+        )
+        result = Grounder(join_max_candidates=join_max_candidates).compile(
+            problem, CompilationKind.GROUNDING
+        )
         grounded = result.problem
         assert isinstance(grounded, Problem)
         return [a.name for a in grounded.actions]
@@ -1107,6 +1106,42 @@ class TestGrounderJoinPruning(unittest_TestCase):
             set(result),
             {rel(items[0], items[1]).args, rel(items[2], items[3]).args},
         )
+
+    def test_join_max_candidates_zero_disables_the_join_even_on_zero_rows(self):
+        # `join_max_candidates <= 0` must disable the join outright (`None`, meaning "use the
+        # fallback"), even for an action whose first-folded static fluent alone empties
+        # `bindings` via the early `if not bindings: break` exit -- that path returns `[]`
+        # (a *legitimate* answer: the join proved there are zero valid candidates) without
+        # ever reaching the `len(bindings) > cap` check below it, so a cap of 0 does not, by
+        # itself, force that particular action through the check that's supposed to disable
+        # the join. Guarding on the cap before running the join at all (as `_compute_join_
+        # pruned_parameters` now does) is what makes disabling it airtight regardless of
+        # which exit path the join would otherwise have taken.
+        problem = Problem("join_disabled_zero_rows")
+        item_type = UserType("Item")
+        items = [Object(f"i{i}", item_type) for i in range(3)]
+        rel = Fluent("rel", BoolType(), a=item_type, b=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type, y=item_type)
+        x = action.parameter("x")
+        y = action.parameter("y")
+        action.add_precondition(rel(x, y))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(rel, default_initial_value=False)  # rel is never true
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        problem.add_action(action)
+        type_list = [p.type for p in action.parameters]
+
+        # With the join enabled, it correctly proves zero candidates on its own.
+        enabled = GrounderHelper(problem)
+        self.assertEqual(enabled._compute_join_pruned_parameters(action, type_list), [])
+
+        # With the join disabled, that must read as "no answer from the join", not as the
+        # join's own (here coincidentally identical) empty-list answer.
+        disabled = GrounderHelper(problem, join_max_candidates=0)
+        self.assertIsNone(disabled._compute_join_pruned_parameters(action, type_list))
 
     def test_join_equivalent_to_fallback_pruning_on_example_problems(self):
         # The single most important check: for every example problem this repo already has

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -37,6 +37,7 @@ from unified_planning.engines import CompilationKind
 from unified_planning.engines.compilers import Grounder
 from unified_planning.engines.compilers.grounder import GrounderHelper
 from unified_planning.model.contingent import SensingAction
+from unified_planning.model.motion import InstantaneousMotionAction
 
 
 class TestGrounder(unittest_TestCase):
@@ -889,6 +890,36 @@ class TestGrounder(unittest_TestCase):
         assert isinstance(ga, SensingAction)
         self.assertEqual(len(ga.parameters), 0)
         self.assertEqual(ga.observed_fluents, [hidden(l1)])
+
+    def test_instantaneous_motion_action_is_preserved_after_grounding(self):
+        # create_action_with_given_subs's InstantaneousAction branch must not downgrade a
+        # subclass it doesn't specifically special-case (unlike SensingAction, which it
+        # does): InstantaneousMotionAction relies on this too, via its own motion_constraints
+        # rather than observed_fluents, but the fix (falling back to a full clone() for any
+        # InstantaneousAction subclass, not just SensingAction) must cover it the same way.
+        from unified_planning.test.examples.tamp import (
+            get_example_problems as get_tamp_example_problems,
+        )
+
+        problem = get_tamp_example_problems()["tamp_feasible"].problem
+        assert isinstance(problem, Problem)
+        self.assertTrue(
+            any(isinstance(a, InstantaneousMotionAction) for a in problem.actions)
+        )
+
+        compiler = Grounder()
+        compiler.skip_checks = True
+        grounded_problem = compiler.compile(problem, CompilationKind.GROUNDING).problem
+        assert isinstance(grounded_problem, Problem)
+        self.assertGreater(len(grounded_problem.actions), 0)
+        for ga in grounded_problem.actions:
+            self.assertIsInstance(ga, InstantaneousMotionAction)
+            assert isinstance(ga, InstantaneousMotionAction)
+            self.assertEqual(len(ga.parameters), 0)
+            # motion_constraints must at least survive grounding (even though, like
+            # DurativeMotionAction, they are not substituted with the grounding parameters --
+            # a separate, pre-existing gap, not what this test is pinning down).
+            self.assertGreater(len(ga.motion_constraints), 0)
 
     def test_durative_action_continuous_effects_preserved_and_substituted_after_grounding(
         self,

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -1143,6 +1143,55 @@ class TestGrounderJoinPruning(unittest_TestCase):
         disabled = GrounderHelper(problem, join_max_candidates=0)
         self.assertIsNone(disabled._compute_join_pruned_parameters(action, type_list))
 
+    def test_join_cap_bails_out_of_a_large_intermediate_merge_soundly(self):
+        # Both merge shapes (the no-shared-column cross product and the hash join) used to
+        # be checked against `self._join_max_candidates` only after being fully built, so an
+        # intermediate merge result could balloon far past the cap before anything noticed --
+        # `p`/`q` below (each unconstrained on their own column) force exactly that: their
+        # cross product is domain_size**2 rows before `r` narrows it back down. This doesn't
+        # observe the peak-memory difference (that needs a profiler, not a unit test), but it
+        # does pin down that bailing out earlier -- from inside the merge instead of after --
+        # doesn't change the final, correct answer: grounding with a cap small enough to force
+        # that mid-merge bail-out must still match grounding with the default (large) cap.
+        problem = Problem("join_large_intermediate_merge")
+        item_type = UserType("Item")
+        items = [Object(f"i{i}", item_type) for i in range(6)]
+        p = Fluent("p", BoolType(), a=item_type)
+        q = Fluent("q", BoolType(), a=item_type)
+        r = Fluent("r", BoolType(), a=item_type, b=item_type)
+        dummy = Fluent("dummy")
+        action = InstantaneousAction("act", x=item_type, y=item_type, z=item_type)
+        x = action.parameter("x")
+        y = action.parameter("y")
+        action.add_precondition(p(x))
+        action.add_precondition(q(y))
+        action.add_precondition(r(x, y))
+        action.add_effect(dummy, True)
+
+        problem.add_fluent(p, default_initial_value=False)
+        problem.add_fluent(q, default_initial_value=False)
+        problem.add_fluent(r, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_objects(items)
+        for item in items:
+            problem.set_initial_value(p(item), True)
+            problem.set_initial_value(q(item), True)
+        # Only one (x, y) pair actually satisfies r, so the 6*6=36-row cross product of p and
+        # q (built before r ever narrows anything) is 6x larger than the join's final result.
+        problem.set_initial_value(r(items[0], items[0]), True)
+        problem.add_action(action)
+
+        default_names = self._ground_names(problem)
+        small_cap_result = Grounder(join_max_candidates=10).compile(
+            problem, CompilationKind.GROUNDING
+        )
+        small_cap_problem = small_cap_result.problem
+        assert isinstance(small_cap_problem, Problem)
+        small_cap_names = [a.name for a in small_cap_problem.actions]
+
+        self.assertEqual(small_cap_names, default_names)
+        self.assertEqual(len(default_names), len(items))  # r pins x=y=i0; z stays free
+
     def test_join_equivalent_to_fallback_pruning_on_example_problems(self):
         # The single most important check: for every example problem this repo already has
         # test fixtures for, the join and the per-parameter fallback must produce list-equal

--- a/unified_planning/test/test_model.py
+++ b/unified_planning/test/test_model.py
@@ -865,6 +865,35 @@ class TestModel(unittest_TestCase):
         self.assertIs(pickle.loads(pickle.dumps(BOOL)), BOOL)
         self.assertIs(pickle.loads(pickle.dumps(TIME)), TIME)
 
+    def test_problem_pickle_roundtrip_keeps_name_lookups(self):
+        # a problem is pickled whole when the parallel engine sends it to another process
+        # (with the `spawn` start method), so nothing reachable from it may be a closure;
+        # the by-name indexes must also still resolve on the unpickled copy
+        import pickle
+
+        problem = self.problems["robot"].problem
+        clone = pickle.loads(pickle.dumps(problem))
+
+        for fluent in problem.fluents:
+            self.assertTrue(clone.has_fluent(fluent.name))
+            self.assertEqual(clone.fluent(fluent.name).name, fluent.name)
+        for action in problem.actions:
+            self.assertTrue(clone.has_action(action.name))
+            self.assertEqual(clone.action(action.name).name, action.name)
+        for obj in problem.all_objects:
+            self.assertTrue(clone.has_object(obj.name))
+        for user_type in problem.user_types:
+            self.assertTrue(clone.has_type(user_type.name))
+
+        # the index must keep working for elements added after the round-trip
+        # (the `note_appended` fast path is keyed on the list it last saw)
+        clone.add_fluent(
+            Fluent("added_after_unpickling", BoolType(), environment=clone.environment),
+            default_initial_value=False,
+        )
+        self.assertTrue(clone.has_fluent("added_after_unpickling"))
+        self.assertFalse(problem.has_fluent("added_after_unpickling"))
+
     def test_set_initial_value_rejects_non_constant_arguments(self):
         # set_initial_value's own docstring says the fluent must be grounded; a fluent
         # expression whose argument is itself a fluent (not a constant) must be rejected

--- a/unified_planning/test/test_problem.py
+++ b/unified_planning/test/test_problem.py
@@ -14,11 +14,19 @@
 # limitations under the License.
 
 
+import warnings
+from typing import cast
 import unified_planning as up
 from unified_planning.shortcuts import *
+from unified_planning.environment import Environment
 from unified_planning.test import unittest_TestCase, main, examples
 from unified_planning.test.examples import get_example_problems
 from unified_planning.exceptions import UPTypeError
+from unified_planning.engines.compilers.utils import remove_fluents
+from unified_planning.model.htn import HierarchicalProblem
+from unified_planning.model.contingent import ContingentProblem
+from unified_planning.model.multi_agent import MultiAgentProblem, Agent
+from unified_planning.model.scheduling import SchedulingProblem
 
 
 class TestProblem(unittest_TestCase):
@@ -653,6 +661,148 @@ class TestProblem(unittest_TestCase):
         problem = self.problems["interpreted_functions_in_numeric_assignment"].problem
         self.assertTrue(problem.kind.has_interpreted_functions_in_numeric_assignments())
         self.assertFalse(problem.kind.has_simple_numeric_planning())
+
+    def test_name_index_consistency(self):
+        # ActionsSetMixin/FluentsSetMixin/ObjectsSetMixin/UserTypesSetMixin each keep a
+        # lazily-rebuilt name index (unified_planning/model/mixins/name_index.py) instead of
+        # a linear scan; this exercises every way the underlying list can change and asserts
+        # has_action/has_fluent/has_object/has_type (and the singular accessors) always agree
+        # with a brute-force scan, catching any desync the index's self-healing token might miss.
+        loc = UserType("Loc")
+
+        def check(problem):
+            for a in problem.actions:
+                self.assertTrue(problem.has_action(a.name))
+                self.assertIs(problem.action(a.name), a)
+            for f in problem.fluents:
+                self.assertTrue(problem.has_fluent(f.name))
+                self.assertIs(problem.fluent(f.name), f)
+            for o in problem.all_objects:
+                self.assertTrue(problem.has_object(o.name))
+                self.assertIs(problem.object(o.name), o)
+            for t in problem.user_types:
+                name = cast(up.model.types._UserType, t).name
+                self.assertTrue(problem.has_type(name))
+                self.assertIs(problem.user_type(name), t)
+            self.assertFalse(problem.has_action("__nonexistent__"))
+            self.assertFalse(problem.has_fluent("__nonexistent__"))
+            self.assertFalse(problem.has_object("__nonexistent__"))
+            self.assertFalse(problem.has_type("__nonexistent__"))
+
+        problem = Problem("name_index")
+        f1 = Fluent("f1", BoolType(), l=loc)
+        f2 = Fluent("f2", BoolType())
+        problem.add_fluent(f1, default_initial_value=False)
+        problem.add_fluent(f2, default_initial_value=False)
+        o1 = Object("o1", loc)
+        o2 = Object("o2", loc)
+        problem.add_objects([o1, o2])
+        a1 = InstantaneousAction("a1", x=loc)
+        a1.add_effect(f1(a1.parameter("x")), True)
+        a2 = InstantaneousAction("a2")
+        a2.add_effect(f2, True)
+        problem.add_action(a1)
+        problem.add_action(a2)
+        check(problem)
+
+        # clear_actions/clear_fluents reassign the underlying list wholesale.
+        problem.clear_actions()
+        check(problem)
+        problem.add_action(a1)
+        problem.clear_fluents()
+        check(problem)
+        problem.add_fluent(f1, default_initial_value=False)
+        check(problem)
+
+        # remove_fluents mutates the list in place (list.remove), not via clear_fluents.
+        problem.add_fluent(f2, default_initial_value=False)
+        remove_fluents(problem, {f2})
+        check(problem)
+
+        # clone() reassigns every list wholesale, bypassing add_*/clear_*.
+        cloned = problem.clone()
+        check(cloned)
+
+        # Renaming an action in place (list identity and length both unchanged) is a known,
+        # pre-existing gap, not introduced by the index: if the index was already built (by
+        # an earlier has_action/action call) before the rename, it keeps reporting the old
+        # name as present, since nothing about the list itself changed to trigger a rebuild.
+        # This matches test_pddl_io.py's test_renamings, which relies on exactly this: it
+        # renames an action after reading it via problem.action(...), and a subsequent
+        # add_object call must not treat the rename as a fresh collision. Documented here so
+        # a future change to this behavior is deliberate, not a silent regression.
+        renamed = problem.clone()
+        target = renamed.actions[0]
+        old_name = target.name
+        self.assertTrue(renamed.has_action(old_name))  # force the index to build now
+        target.name = "renamed_action"
+        self.assertTrue(renamed.has_action(old_name))  # stale: rename isn't tracked
+        self.assertFalse(renamed.has_action("renamed_action"))
+
+        # A name shared ACROSS categories (here, an action and a fluent) is legal when
+        # error_used_name is disabled -- add_action's own duplicate guard always raises for
+        # two entries of the *same* category regardless of this flag, so that case can't
+        # arise through the public API. Each category keeps its own independent index, so
+        # this must not create any cross-category confusion.
+        env = Environment()
+        env.error_used_name = False
+        dup_problem = Problem("dup_names", env)
+        dup_fluent = Fluent("dup", BoolType(), environment=env)
+        dup_problem.add_fluent(dup_fluent, default_initial_value=False)
+        dup_action = InstantaneousAction("dup", _env=env)
+        dup_action.add_effect(dup_fluent, True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            dup_problem.add_action(dup_action)
+        self.assertTrue(dup_problem.has_action("dup"))
+        self.assertTrue(dup_problem.has_fluent("dup"))
+        self.assertIs(dup_problem.action("dup"), dup_action)
+        self.assertIs(dup_problem.fluent("dup"), dup_fluent)
+
+    def test_name_index_consistency_on_problem_subclasses(self):
+        # Lighter smoke checks that the same index machinery is wired correctly through every
+        # AbstractProblem subclass with its own has_name composition (see
+        # unified_planning/model/mixins/name_index.py's docstring for why a shared global
+        # index would be wrong here: each subclass's has_name covers a different set of
+        # name-bearing collections).
+        loc = UserType("Loc")
+
+        htn = HierarchicalProblem("htn_name_index")
+        f = Fluent("f", BoolType())
+        htn.add_fluent(f, default_initial_value=False)
+        a = InstantaneousAction("a")
+        a.add_effect(f, True)
+        htn.add_action(a)
+        self.assertTrue(htn.has_action("a") and htn.has_fluent("f"))
+        self.assertIs(htn.action("a"), a)
+        cloned_htn = htn.clone()
+        self.assertTrue(cloned_htn.has_action("a"))
+        self.assertIsNot(cloned_htn.action("a"), a)  # actions are cloned, not shared
+
+        cp = ContingentProblem("contingent_name_index")
+        cp.add_fluent(f, default_initial_value=False)
+        cp.add_action(a)
+        self.assertTrue(cp.has_action("a") and cp.has_fluent("f"))
+        cloned_cp = cp.clone()
+        self.assertTrue(cloned_cp.has_action("a"))
+
+        ma = MultiAgentProblem("ma_name_index")
+        agent = Agent("ag1", ma)
+        agent.add_fluent(f, default_initial_value=False)
+        agent.add_action(a)
+        ma.add_agent(agent)
+        o = Object("o1", loc)
+        ma.add_object(o)
+        self.assertTrue(ma.has_object("o1"))
+        self.assertTrue(agent.has_action("a") and agent.has_fluent("f"))
+        self.assertIs(agent.action("a"), a)
+
+        sp = SchedulingProblem("scheduling_name_index")
+        sp.add_fluent(f, default_initial_value=False)
+        sp.add_object(o)
+        self.assertTrue(sp.has_fluent("f") and sp.has_object("o1"))
+        self.assertIs(sp.fluent("f"), f)
+        self.assertIs(sp.object("o1"), o)
 
     def test_interpreted_functions_complex(self):
         problem = self.problems["go_home_with_rain_and_interpreted_functions"].problem

--- a/unified_planning/test/test_problem.py
+++ b/unified_planning/test/test_problem.py
@@ -27,6 +27,7 @@ from unified_planning.model.htn import HierarchicalProblem
 from unified_planning.model.contingent import ContingentProblem
 from unified_planning.model.multi_agent import MultiAgentProblem, Agent
 from unified_planning.model.scheduling import SchedulingProblem
+from unified_planning.model.mixins import name_index
 
 
 class TestProblem(unittest_TestCase):
@@ -723,21 +724,34 @@ class TestProblem(unittest_TestCase):
         cloned = problem.clone()
         check(cloned)
 
-        # Renaming an action in place (list identity and length both unchanged) is a known,
-        # pre-existing gap, not introduced by the index: if the index was already built (by
-        # an earlier has_action/action call) before the rename, it keeps reporting the old
-        # name as present, since nothing about the list itself changed to trigger a rebuild.
-        # This matches test_pddl_io.py's test_renamings, which relies on exactly this: it
-        # renames an action after reading it via problem.action(...), and a subsequent
-        # add_object call must not treat the rename as a fresh collision. Documented here so
-        # a future change to this behavior is deliberate, not a silent regression.
+        # Renaming an action in place (list identity and length both unchanged) does not by
+        # itself trigger the index's usual identity/length staleness check -- it's tracked
+        # separately, via a global rename counter that `Transition.name`'s setter bumps and
+        # `NameIndex(track_renames=True)` compares itself against on every lookup (see
+        # unified_planning/model/mixins/name_index.py). Force the index to build *before* the
+        # rename, so this actually exercises the invalidation path rather than just a rebuild
+        # that would have picked up the new name anyway.
         renamed = problem.clone()
         target = renamed.actions[0]
         old_name = target.name
         self.assertTrue(renamed.has_action(old_name))  # force the index to build now
         target.name = "renamed_action"
-        self.assertTrue(renamed.has_action(old_name))  # stale: rename isn't tracked
-        self.assertFalse(renamed.has_action("renamed_action"))
+        self.assertFalse(renamed.has_action(old_name))
+        self.assertTrue(renamed.has_action("renamed_action"))
+        self.assertIs(renamed.action("renamed_action"), target)
+
+        # The in-library rename pattern (several compilers clone an action, rename it via
+        # `get_fresh_name`, *then* add it) must stay cheap: renaming an action that has never
+        # been indexed yet must not bump the shared rename counter, so it can't force a
+        # rebuild of some unrelated, already-built index.
+        epoch_before = name_index.current_rename_epoch()
+        fresh_action = a1.clone()
+        fresh_action.name = "not_indexed_yet"  # never indexed: must not bump the epoch
+        self.assertEqual(name_index.current_rename_epoch(), epoch_before)
+        other = problem.clone()
+        other.add_action(fresh_action)
+        self.assertTrue(other.has_action("not_indexed_yet"))
+        self.assertIs(other.action("not_indexed_yet"), fresh_action)
 
         # A name shared ACROSS categories (here, an action and a fluent) is legal when
         # error_used_name is disabled -- add_action's own duplicate guard always raises for

--- a/unified_planning/test/test_problem.py
+++ b/unified_planning/test/test_problem.py
@@ -21,7 +21,7 @@ from unified_planning.shortcuts import *
 from unified_planning.environment import Environment
 from unified_planning.test import unittest_TestCase, main, examples
 from unified_planning.test.examples import get_example_problems
-from unified_planning.exceptions import UPTypeError
+from unified_planning.exceptions import UPTypeError, UPValueError
 from unified_planning.engines.compilers.utils import remove_fluents
 from unified_planning.model.htn import HierarchicalProblem
 from unified_planning.model.contingent import ContingentProblem
@@ -772,6 +772,32 @@ class TestProblem(unittest_TestCase):
         self.assertTrue(dup_problem.has_fluent("dup"))
         self.assertIs(dup_problem.action("dup"), dup_action)
         self.assertIs(dup_problem.fluent("dup"), dup_fluent)
+
+    def test_name_index_removing_then_adding_a_fluent_keeps_lookups_consistent(self):
+        # The name index's staleness token is identity+length, which a remove followed by an
+        # append restores exactly: same list object, same length, so nothing looks stale even
+        # though both the removed and the added fluent are now wrong. FluentsSetMixin's
+        # _remove_fluent must invalidate the index explicitly.
+        problem = Problem("remove_then_add")
+        f1 = Fluent("f1")
+        f2 = Fluent("f2")
+        f3 = Fluent("f3")
+        problem.add_fluent(f1, default_initial_value=False)
+        problem.add_fluent(f2, default_initial_value=False)
+
+        self.assertTrue(problem.has_fluent("f1"))  # builds the index at length 2
+        problem._remove_fluent(f2)
+        problem._fluents.append(
+            f3
+        )  # bare append: no has_name call to refresh the index
+        problem._fluents_index.note_appended(problem._fluents)
+
+        self.assertEqual([f.name for f in problem.fluents], ["f1", "f3"])
+        self.assertFalse(problem.has_fluent("f2"))
+        self.assertTrue(problem.has_fluent("f3"))
+        self.assertIs(problem.fluent("f3"), f3)
+        with self.assertRaises(UPValueError):
+            problem.fluent("f2")
 
     def test_name_index_consistency_on_problem_subclasses(self):
         # Lighter smoke checks that the same index machinery is wired correctly through every


### PR DESCRIPTION
## Summary
- Index `*SetMixin` name lookups (`NameIndex`) so building a problem is no longer O(N^2).
- Fast-path `FNode` in expression promotion and cache `FNode.__repr__`'s dispatch table.
- Add hash-join pruning of action parameters against static fluents, replacing per-parameter-only pruning for the common case, and fix it to intersect every matching argument position of a static fluent instead of just the first.
- Skip deep-cloning actions in `Grounder._compile` when they're immediately discarded, and skip deep-cloning a candidate grounded action's effects until after its preconditions are known to be feasible.

## Hash-join static-fluent pruning

**Goal:** given one action and the type domains of its parameters, compute the exact list
of parameter tuples that satisfy all of the action's static-boolean-fluent conditions --
via a relational hash-join instead of the existing per-parameter (independent) pruning.
When the join isn't safe for an action (unbounded/unenumerable parameter type, a candidate
count above a safety cap, an unrecognized action type, or any unexpected exception), that
one action falls back to the existing pruning, so the join is strictly non-regressive.

**High-level shape:** it's a classic database join. Each static fluent in the action's
conditions is a "table" of rows -- the argument tuples for which that fluent is true -- and
the algorithm joins these tables together on whatever action-parameter columns they share,
incrementally narrowing a running result set. Parameter columns no fluent ever constrains
are left free and cross-produced in only at the end.

**Why the old pruning misses this:** it narrows each parameter's domain independently to
the objects seen at a matching argument position of some true static-fluent atom. That's
blind to a static fluent that correlates several parameters together (e.g. a lookup table
relating two of them): every value that's valid for a parameter *somewhere* survives, even
when no single combination of survivors is jointly valid, so the full cross product still
gets enumerated (and then rejected later, when preconditions are checked).

**Example:** action `deliver(?r: Robot, ?l: Location, ?p: Package)` with domains
`Robot={r1,r2}`, `Location={l1,l2}`, `Package={p1,p2}` (8 combinations, unpruned) and static
conditions `robot_can_carry(?r,?p)` true for `(r1,p1), (r1,p2), (r2,p1)`, and
`package_at(?p,?l)` true for `(p1,l1), (p2,l2)`.

Per-parameter pruning can't shrink anything here: `r1`, `r2`, `l1`, `l2`, `p1`, `p2` each
appear in at least one true tuple, so all 8 combinations -- including invalid ones like
`(r2, l2, p2)`, since r2 never carries p2 -- would still be cross-produced.

The join instead folds in `robot_can_carry` first, producing partial bindings
`{r:r1,p:p1}, {r:r1,p:p2}, {r:r2,p:p1}`; then folds in `package_at`, joining on their
shared `p` column (`p1` only pairs with `l1`, `p2` only with `l2`), leaving exactly
`(r1,l1,p1), (r1,l2,p2), (r2,l1,p1)` -- the 3 combinations that are jointly consistent with
both conditions.

**Along the way:** the existing (fallback) pruning is also fixed to intersect *every*
matching argument position of a static fluent instead of stopping at the first -- needed
for a symmetric predicate applied as `sym(?x, ?x)` -- and static-fluent/domain lookups are
cached, since both pruning paths were otherwise recomputing them per action/parameter.
