### PR TITLE
fix: forward timeout correctly in the Parallel engine

### DIFF
--- a/unified_planning/engines/parallel.py
+++ b/unified_planning/engines/parallel.py
@@ -85,7 +85,9 @@ class Parallel(
         # The supported plan depends on its actual engines
         return True
 
-    def _run_parallel(self, fname, *args) -> List[Result]:
+    def _run_parallel(
+        self, fname, problem: "up.model.AbstractProblem", *args, **kwargs
+    ) -> List[Result]:
         signaling_queue: Queue = _mp_context.Queue()
         processes = []
         for idx, (engine_name, opts) in enumerate(self.engines):
@@ -102,7 +104,9 @@ class Parallel(
                     self.error_on_failed_checks,
                     signaling_queue,
                     fname,
-                    *args,
+                    problem,
+                    args,
+                    kwargs,
                 ),
             )
             processes.append(_p)
@@ -120,7 +124,7 @@ class Parallel(
             else:
                 assert isinstance(res, Result)
                 # If the planner is sure about the result (optimality of the result or impossibility of the problem or the problem does not need optimality) exit the loop
-                if res.is_definitive_result(*args):
+                if res.is_definitive_result(problem):
                     definitive_result_found = True
                     break
                 else:
@@ -145,8 +149,15 @@ class Parallel(
             warnings.warn(
                 "Parallel engines do not support the output stream system.", UserWarning
             )
+        if heuristic is not None:
+            warnings.warn(
+                "Parallel engines do not support heuristic functions; the heuristic will be ignored.",
+                UserWarning,
+            )
 
-        final_reports = self._run_parallel("solve", problem, timeout, None)
+        final_reports = self._run_parallel(
+            "solve", problem, heuristic=None, timeout=timeout, output_stream=None
+        )
 
         result_order: List[PlanGenerationResultStatus] = [
             PlanGenerationResultStatus.SOLVED_OPTIMALLY,  # List containing the results in the order we prefer them
@@ -215,14 +226,16 @@ def _run(
     error_on_failed_checks: bool,
     signaling_queue: Queue,
     fname: str,
-    *args,
+    problem: "up.model.AbstractProblem",
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
 ):
     EngineClass = factory.engine(engine_name)
     with EngineClass(**options) as s:
         s.skip_checks = skip_checks
         s.error_on_failed_checks = error_on_failed_checks
         try:
-            local_res = getattr(s, fname)(*args)
+            local_res = getattr(s, fname)(problem, *args, **kwargs)
         except Exception as ex:
             signaling_queue.put((idx, ex))
             return

--- a/unified_planning/test/test_parallel.py
+++ b/unified_planning/test/test_parallel.py
@@ -1,0 +1,102 @@
+# Copyright 2021-2023 AIPlan4EU project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from unified_planning.environment import Environment
+from unified_planning.engines.engine import Engine
+from unified_planning.engines.mixins.oneshot_planner import OneshotPlannerMixin
+from unified_planning.engines.results import (
+    PlanGenerationResult,
+    PlanGenerationResultStatus,
+)
+from unified_planning.model import Fluent, InstantaneousAction, Problem, ProblemKind
+from unified_planning.plans import SequentialPlan
+from unified_planning.test import unittest_TestCase, main
+
+
+class ArgRecordingEngine(Engine, OneshotPlannerMixin):
+    """Oneshot planner that reports the arguments it actually received back in the result metrics."""
+
+    def __init__(self, **kwargs):
+        Engine.__init__(self)
+        OneshotPlannerMixin.__init__(self)
+
+    @property
+    def name(self) -> str:
+        return "arg-recording-engine"
+
+    @staticmethod
+    def supported_kind() -> ProblemKind:
+        return ProblemKind()
+
+    @staticmethod
+    def supports(problem_kind: ProblemKind) -> bool:
+        return True
+
+    def _solve(self, problem, heuristic=None, timeout=None, output_stream=None):
+        return PlanGenerationResult(
+            PlanGenerationResultStatus.UNSOLVABLE_INCOMPLETELY,
+            None,
+            self.name,
+            metrics={"heuristic": repr(heuristic), "timeout": repr(timeout)},
+        )
+
+
+class TestParallel(unittest_TestCase):
+    def setUp(self):
+        unittest_TestCase.setUp(self)
+        # Use a dedicated Environment so registering the dummy engine does not
+        # leak into the global factory used by the rest of the test suite.
+        self.env = Environment()
+        self.env.factory.add_engine(
+            "arg-recording-engine", __name__, "ArgRecordingEngine"
+        )
+
+        a = Fluent("a", environment=self.env)
+        act = InstantaneousAction("act", _env=self.env)
+        act.add_effect(a, True)
+        problem = Problem("test", self.env)
+        problem.add_fluent(a, default_initial_value=False)
+        problem.add_action(act)
+        problem.add_goal(a)
+        self.problem = problem
+        self.act = act
+
+    def test_solve_forwards_timeout_to_sub_engines(self):
+        with self.env.factory.OneshotPlanner(
+            names=["arg-recording-engine"], params=[{}]
+        ) as planner:
+            result = planner.solve(self.problem, timeout=42.0)
+            self.assertEqual(result.metrics["timeout"], repr(42.0))
+            self.assertEqual(result.metrics["heuristic"], repr(None))
+
+    def test_solve_warns_on_ignored_heuristic(self):
+        with self.env.factory.OneshotPlanner(
+            names=["arg-recording-engine"], params=[{}]
+        ) as planner:
+            with self.assertWarns(UserWarning):
+                result = planner.solve(self.problem, heuristic=lambda state: 0.0)
+            self.assertEqual(result.metrics["heuristic"], repr(None))
+
+    def test_validate_still_dispatches(self):
+        plan = SequentialPlan([self.act()], environment=self.env)
+        with self.env.factory.PlanValidator(
+            names=["sequential_plan_validator", "sequential_plan_validator"]
+        ) as validator:
+            validation_result = validator.validate(self.problem, plan)
+            self.assertTrue(validation_result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

`Parallel._solve` (`unified_planning/engines/parallel.py`) called
`self._run_parallel("solve", problem, timeout, None)`, and `_run_parallel`/`_run`
forwarded those arguments positionally as `engine.solve(*args)`. But
`OneshotPlannerMixin.solve`'s signature is
`solve(problem, heuristic=None, timeout=None, output_stream=None, ...)`, so the
caller's `timeout` value ended up bound to each sub-engine's `heuristic`
parameter, while the sub-engine's actual `timeout` was always `None`
(unbounded). Any `OneshotPlanner(names=[...])` portfolio/parallel run therefore
ignored the requested timeout and passed a float where a heuristic callable was
expected. The caller's own `heuristic` argument was silently dropped with no
warning.

## Fix

`_run_parallel`/`_run` now take `problem` explicitly and dispatch the rest of
the arguments to each sub-engine by keyword
(`getattr(s, fname)(problem, *args, **kwargs)`), so the call no longer depends
on positional order matching each mixin's method signature. `Parallel._solve`
forwards `timeout` to the sub-engines' `timeout` parameter and warns (mirroring
the existing `output_stream` warning) when a `heuristic` is given, since a
callable can't be safely sent across the process boundary.

## Test plan

- [x] Added `unified_planning/test/test_parallel.py`, a TDD regression test with
      a dummy in-process engine that reports the arguments it actually received;
      confirmed it failed before the fix (timeout dropped, heuristic mis-fed)
      and passes after