### PR TITLE
fix: write PDDL real literals as plain decimals

### DIFF
--- a/unified_planning/interop/from_pddl.py
+++ b/unified_planning/interop/from_pddl.py
@@ -155,7 +155,12 @@ class _ExpressionConverter:
             ) = stack.pop()
 
             if isinstance(current_formula, NumericValue):
-                formula_value = Fraction(current_formula.value)
+                # NumericValue.value is a Python float; str() of a float is its
+                # shortest round-tripping decimal representation, so building the
+                # Fraction from that string (rather than from the float itself)
+                # avoids baking in IEEE-754 binary rounding error (e.g. Fraction(0.1)
+                # is not exactly 1/10, but Fraction(str(0.1)) is).
+                formula_value = Fraction(str(current_formula.value))
                 if formula_value.denominator == 1:
                     result_stack.append(em.Int(formula_value.numerator))
                 else:

--- a/unified_planning/io/anml_writer.py
+++ b/unified_planning/io/anml_writer.py
@@ -14,13 +14,13 @@
 #
 
 
-from decimal import Decimal, localcontext
 from fractions import Fraction
 import re
 import sys
 import unified_planning as up
 import unified_planning.environment
 import unified_planning.model.walkers as walkers
+from unified_planning.io.utils import decimal_literal
 from unified_planning.model import (
     DurativeAction,
     InstantaneousAction,
@@ -31,7 +31,6 @@ from unified_planning.model import (
 from unified_planning.model.types import _UserType, _RealType, _IntType
 from typing import IO, Dict, List, Optional, cast, Union
 from io import StringIO
-from warnings import warn
 
 ANML_KEYWORDS = {
     "action",
@@ -101,6 +100,8 @@ INITIAL_LETTER: Dict[type, str] = {
 
 class ConverterToANMLString(walkers.DagWalker):
     """Expression converter to an ANML string."""
+
+    DECIMAL_PRECISION = 10  # Number of decimal places used for real type bounds
 
     def __init__(
         self,
@@ -454,22 +455,6 @@ class ANMLWriter:
             return f"{left_bracket} {self._convert_anml_timing(interval.lower)}, {self._convert_anml_timing(interval.upper)} {right_bracket}"
 
 
-ANML_DECIMAL_PRECISION = 10  # Number of decimal places used for real type bounds
-
-
-def _anml_decimal(frac: Fraction) -> str:
-    """Formats a Fraction as an ANML `real` literal (digits "." digits)."""
-    with localcontext() as ctx:
-        ctx.prec = ANML_DECIMAL_PRECISION
-        dec = frac.numerator / Decimal(frac.denominator, ctx)
-        if Fraction(dec) != frac:
-            warn(
-                f"The ANML printer cannot exactly represent the real constant '{frac}'"
-            )
-        res = format(dec, "f")  # never scientific notation
-    return res if "." in res else f"{res}.0"  # the grammar requires a fractional part
-
-
 def _is_valid_anml_name(name: str) -> bool:
     regex = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*")
     if (
@@ -547,12 +532,12 @@ def _get_anml_name(
             left_bound = (
                 "(-infinity"
                 if num_real_type.lower_bound is None
-                else f"[{_anml_decimal(num_real_type.lower_bound)}"
+                else f"[{decimal_literal(num_real_type.lower_bound, ConverterToANMLString.DECIMAL_PRECISION, 'ANML')}"
             )
             right_bound = (
                 "infinity)"
                 if num_real_type.upper_bound is None
-                else f"{_anml_decimal(num_real_type.upper_bound)}]"
+                else f"{decimal_literal(num_real_type.upper_bound, ConverterToANMLString.DECIMAL_PRECISION, 'ANML')}]"
             )
             new_name = f"float {left_bound}, {right_bound}"
         else:  # We mangle the name and get a fresh one

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -14,15 +14,14 @@
 #
 
 
-from fractions import Fraction
 import sys
 import re
 
-from decimal import Decimal, localcontext
 from warnings import warn
 
 import unified_planning as up
 import unified_planning.model.walkers as walkers
+from unified_planning.io.utils import decimal_literal
 from unified_planning.model import (
     InstantaneousAction,
     DurativeAction,
@@ -163,7 +162,7 @@ MangleFunction = Callable[[WithName], str]
 class ConverterToPDDLString(walkers.DagWalker):
     """Expression converter to a PDDL string."""
 
-    DECIMAL_PRECISION = 10  # Number of decimal places to print real constants
+    DECIMAL_PRECISION = 10  # Number of significant digits used to print real constants
 
     def __init__(
         self,
@@ -178,17 +177,9 @@ class ConverterToPDDLString(walkers.DagWalker):
         """Converts the given expression to a PDDL string."""
         return self.walk(self.simplifier.simplify(expression))
 
-    def convert_fraction(self, frac):
-        with localcontext() as ctx:
-            ctx.prec = self.DECIMAL_PRECISION
-            dec = frac.numerator / Decimal(frac.denominator, ctx)
-
-            if Fraction(dec) != frac:
-                warn(
-                    "The PDDL printer cannot exactly represent the real constant '%s'"
-                    % frac
-                )
-            return float(dec)
+    def convert_fraction(self, frac) -> str:
+        """Formats a Fraction as a PDDL number literal (digits ["." digits])."""
+        return decimal_literal(frac, self.DECIMAL_PRECISION, "PDDL")
 
     def walk_exists(self, expression, args):
         assert len(args) == 1
@@ -272,7 +263,7 @@ class ConverterToPDDLString(walkers.DagWalker):
     def walk_real_constant(self, expression, args):
         assert len(args) == 0
         frac = expression.constant_value()
-        return str(self.convert_fraction(frac))
+        return self.convert_fraction(frac)
 
     def walk_int_constant(self, expression, args):
         assert len(args) == 0
@@ -784,7 +775,7 @@ class PDDLWriter:
         for tm, le in self.problem.timed_effects.items():
             for e in le:
                 out.write(f"\n             ")
-                out.write(f" (at {str(converter.convert_fraction(tm.delay))}")
+                out.write(f" (at {converter.convert_fraction(tm.delay)}")
                 _write_effect(
                     e,
                     None,

--- a/unified_planning/io/pddl_writer.py
+++ b/unified_planning/io/pddl_writer.py
@@ -857,10 +857,22 @@ class PDDLWriter:
                 out.write(f"{_format_action_instance(ai)}\n")
         elif isinstance(plan, TimeTriggeredPlan):
             for s, ai, dur in plan.timed_actions:
-                start = s.numerator if s.denominator == 1 else float(s)
+                start = (
+                    s.numerator
+                    if s.denominator == 1
+                    else decimal_literal(
+                        s, ConverterToPDDLString.DECIMAL_PRECISION, "PDDL"
+                    )
+                )
                 out.write(f"{start}: {_format_action_instance(ai)}")
                 if dur is not None:
-                    duration = dur.numerator if dur.denominator == 1 else float(dur)
+                    duration = (
+                        dur.numerator
+                        if dur.denominator == 1
+                        else decimal_literal(
+                            dur, ConverterToPDDLString.DECIMAL_PRECISION, "PDDL"
+                        )
+                    )
                     out.write(f"[{duration}]")
                 out.write("\n")
         else:

--- a/unified_planning/io/utils.py
+++ b/unified_planning/io/utils.py
@@ -1,0 +1,49 @@
+# Copyright 2021-2023 AIPlan4EU project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Helpers shared by the text-based writers in this package."""
+
+from decimal import Decimal, localcontext
+from fractions import Fraction
+from warnings import warn
+
+
+def decimal_literal(frac: Fraction, precision: int, printer: str) -> str:
+    """Formats a Fraction as a `digits "." digits` decimal literal.
+
+    Neither the PDDL nor the ANML numeric grammar accepts scientific notation or a
+    `numerator/denominator` fraction, so the value is rendered with `format(dec, "f")`
+    and always given a fractional part (which the ANML `real` production requires and
+    PDDL accepts).
+
+    :param frac: The value to render.
+    :param precision: Significant digits used to round `frac`.
+    :param printer: Printer name used in the warning raised when `frac` has no exact
+        terminating decimal representation at `precision` digits.
+    :return: `frac` formatted as a plain decimal literal.
+
+    >>> decimal_literal(Fraction(1, 100000), 10, "PDDL")
+    '0.00001'
+    >>> decimal_literal(Fraction(10), 10, "ANML")
+    '10.0'
+    """
+    with localcontext() as ctx:
+        ctx.prec = precision
+        dec = frac.numerator / Decimal(frac.denominator, ctx)
+        if Fraction(dec) != frac:
+            warn(
+                f"The {printer} printer cannot exactly represent the real constant '{frac}'"
+            )
+        res = format(dec, "f")  # never scientific notation
+    return res if "." in res else f"{res}.0"  # some grammars require a fractional part

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -14,6 +14,7 @@
 # limitations under the License
 
 import os
+import re
 import tempfile
 import pytest
 from typing import cast
@@ -869,6 +870,36 @@ class TestPddlIO(unittest_TestCase):
             parsed_problem_small.initial_value(parsed_battery_small()),
             Real(Fraction(1, 100000)),
         )
+
+    def test_small_rationals(self):
+        # A real constant whose magnitude makes Python's str()/repr() switch to
+        # scientific notation (below 1e-4) must still be written as a plain decimal:
+        # PDDL's numeric-literal grammar has no exponent notation, so e.g. "1e-05" is
+        # not valid PDDL and the strict ai-pddl-parser rejects it outright.
+        problem = self.problems["robot_decrease"].problem.clone()
+        battery = problem.fluent("battery_charge")
+        problem.set_initial_value(battery, Fraction(1, 100000))
+        w = PDDLWriter(problem)
+        pddl_txt = w.get_problem()
+        self.assertIsNone(re.search(r"\de[+-]?\d", pddl_txt))
+        self.assertIn("0.00001", pddl_txt)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            domain_filename = os.path.join(tempdir, "domain.pddl")
+            problem_filename = os.path.join(tempdir, "problem.pddl")
+            w.write_domain(domain_filename)
+            w.write_problem(problem_filename)
+
+            for reader in (
+                PDDLReader(force_ai_planning_reader=True),
+                PDDLReader(force_up_pddl_reader=True),
+            ):
+                parsed_problem = reader.parse_problem(domain_filename, problem_filename)
+                parsed_battery = parsed_problem.fluent("battery_charge")
+                self.assertEqual(
+                    parsed_problem.initial_value(parsed_battery()),
+                    Real(Fraction(1, 100000)),
+                )
 
     def test_ad_hoc_1(self):
         when = UserType("when")

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -37,7 +37,7 @@ from unified_planning.exceptions import (
     UPUnsupportedProblemTypeError,
 )
 from unified_planning.model.metrics import MinimizeSequentialPlanLength
-from unified_planning.plans import SequentialPlan
+from unified_planning.plans import SequentialPlan, TimeTriggeredPlan
 from unified_planning.model.problem_kind import simple_numeric_kind
 from unified_planning.model.types import _UserType
 from unified_planning.interop import (
@@ -900,6 +900,51 @@ class TestPddlIO(unittest_TestCase):
                     parsed_problem.initial_value(parsed_battery()),
                     Real(Fraction(1, 100000)),
                 )
+
+    def test_time_triggered_plan_small_rationals(self):
+        # PDDLWriter._write_plan formatted TimeTriggeredPlan start times/durations
+        # with a raw float(...), bypassing convert_fraction entirely, so a small
+        # enough value (e.g. 1/100000) was written in scientific notation and
+        # UPPDDLReader's own plan-parsing regex (which only accepts plain decimals)
+        # could not read it back.
+        problem = self.problems["matchcellar"].problem
+        light_match = problem.action("light_match")
+        m1 = problem.object("m1")
+        w = PDDLWriter(problem)
+
+        plan = TimeTriggeredPlan(
+            [
+                (
+                    Fraction(1, 100000),
+                    up.plans.ActionInstance(light_match, (ObjectExp(m1),)),
+                    Fraction(1, 100000),
+                )
+            ]
+        )
+        plan_str = w.get_plan(plan)
+        self.assertIsNone(re.search(r"\de[+-]?\d", plan_str))
+        self.assertEqual(plan_str, "0.00001: (light_match m1)[0.00001]\n")
+        parsed_plan = UPPDDLReader().parse_plan_string(
+            problem, plan_str, w.get_item_named
+        )
+        self.assertEqual(parsed_plan, plan)
+
+        # Non-tiny values keep printing exactly as before.
+        plan_2 = TimeTriggeredPlan(
+            [
+                (
+                    Fraction(1, 2),
+                    up.plans.ActionInstance(light_match, (ObjectExp(m1),)),
+                    Fraction(3, 2),
+                )
+            ]
+        )
+        plan_str_2 = w.get_plan(plan_2)
+        self.assertEqual(plan_str_2, "0.5: (light_match m1)[1.5]\n")
+        parsed_plan_2 = UPPDDLReader().parse_plan_string(
+            problem, plan_str_2, w.get_item_named
+        )
+        self.assertEqual(parsed_plan_2, plan_2)
 
     def test_ad_hoc_1(self):
         when = UserType("when")

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -837,6 +837,39 @@ class TestPddlIO(unittest_TestCase):
             self.assertNotIn("10/3", pddl_txt)
             self.assertIn("3.333333333", pddl_txt)
 
+    def test_strict_reader_decimal_precision(self):
+        # NumericValue.value from the `pddl` package is a binary float, so converting
+        # it with `Fraction(value)` bakes in IEEE-754 rounding error (`Fraction(0.1)`
+        # is not exactly 1/10). The strict ai-pddl-parser path must build the Fraction
+        # from the literal's string instead, exactly like ANMLReader does for ANML's
+        # decimal literals.
+        problem = self.problems["robot_decrease"].problem
+        w = PDDLWriter(problem)
+        domain_str = w.get_domain()
+
+        problem_str = """(define (problem robot_decrease-problem)
+ (:domain robot_decrease-domain)
+ (:init (= (battery_charge) 0.1))
+ (:goal (and))
+)
+"""
+        reader = PDDLReader(force_ai_planning_reader=True)
+        parsed_problem = reader.parse_problem_string(domain_str, problem_str)
+        parsed_battery = parsed_problem.fluent("battery_charge")
+        self.assertEqual(
+            parsed_problem.initial_value(parsed_battery()), Real(Fraction(1, 10))
+        )
+
+        problem_str_small = problem_str.replace("0.1", "0.00001")
+        parsed_problem_small = reader.parse_problem_string(
+            domain_str, problem_str_small
+        )
+        parsed_battery_small = parsed_problem_small.fluent("battery_charge")
+        self.assertEqual(
+            parsed_problem_small.initial_value(parsed_battery_small()),
+            Real(Fraction(1, 100000)),
+        )
+
     def test_ad_hoc_1(self):
         when = UserType("when")
         fl = Fluent("4ction")


### PR DESCRIPTION
## Summary
- `ConverterToPDDLString.convert_fraction` round-tripped real constants through `float`, so any value whose magnitude made Python's `str(float)` switch to exponent notation (below `1e-4`) was written as e.g. `1e-05` — not valid PDDL, since the grammar has no exponent notation. Fixed by sharing the fixed-precision decimal-string helper introduced for `ANMLWriter` (`unified_planning/io/utils.decimal_literal`) between both writers.
- `PDDLWriter._write_plan` had the same bug independently for `TimeTriggeredPlan` start times/durations, bypassing `convert_fraction` entirely.
- The strict ai-pddl-parser read path built `Fraction(NumericValue.value)` from the `pddl` package's binary `float`, losing precision on read (e.g. `0.1` became `3602879701896397/36028797018963968`). Fixed by building the `Fraction` from the value's string instead, mirroring the equivalent ANML reader fix (#791).

## Test plan
- [x] Added `test_strict_reader_decimal_precision`, `test_small_rationals`, and `test_time_triggered_plan_small_rationals` to `unified_planning/test/test_pddl_io.py`, each confirmed to fail on the pre-fix code before the corresponding commit.