### PR TITLE
fix: use the correct ProblemKind setters in resulting_problem_kind

### DIFF
--- a/unified_planning/engines/compilers/quantifiers_remover.py
+++ b/unified_planning/engines/compilers/quantifiers_remover.py
@@ -150,7 +150,7 @@ class QuantifiersRemover(engines.engine.Engine, CompilerMixin):
         new_kind.unset_conditions_kind("UNIVERSAL_CONDITIONS")
         new_kind.unset_effects_kind("FORALL_EFFECTS")
         if problem_kind.has_existential_conditions():
-            new_kind.set_conditions("DISJUNCTIVE_CONDITIONS")
+            new_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
         return new_kind
 
     def _compile(

--- a/unified_planning/engines/compilers/state_invariants_remover.py
+++ b/unified_planning/engines/compilers/state_invariants_remover.py
@@ -119,7 +119,7 @@ class StateInvariantsRemover(engines.engine.Engine, CompilerMixin):
     ) -> ProblemKind:
         new_kind = problem_kind.clone()
         if new_kind.has_state_invariants():
-            new_kind.unset_constraints("STATE_INVARIANTS")
+            new_kind.unset_constraints_kind("STATE_INVARIANTS")
         return new_kind
 
     def _compile(

--- a/unified_planning/test/test_quantifier_remover.py
+++ b/unified_planning/test/test_quantifier_remover.py
@@ -86,6 +86,36 @@ class TestQuantifiersRemover(unittest_TestCase):
             ) as pv:
                 self.assertTrue(pv.validate(problem, new_plan))
 
+    def test_resulting_problem_kind_with_existential_conditions(self):
+        problem = self.problems["basic_exists"].problem
+        self.assertTrue(problem.kind.has_existential_conditions())
+
+        new_kind = QuantifiersRemover.resulting_problem_kind(
+            problem.kind, CompilationKind.QUANTIFIERS_REMOVING
+        )
+        self.assertFalse(new_kind.has_existential_conditions())
+        self.assertFalse(new_kind.has_universal_conditions())
+        self.assertFalse(new_kind.has_forall_effects())
+        # Exists is expanded into a disjunction over the problem's objects
+        self.assertTrue(new_kind.has_disjunctive_conditions())
+
+        compiled = (
+            QuantifiersRemover()
+            .compile(problem, CompilationKind.QUANTIFIERS_REMOVING)
+            .problem
+        )
+        assert isinstance(compiled, Problem)
+        self.assertTrue(compiled.kind <= new_kind)
+
+    def test_compilers_pipeline_with_existential_conditions(self):
+        problem = self.problems["basic_exists"].problem
+        with Compiler(
+            problem_kind=problem.kind,
+            compilation_kinds=[CompilationKind.QUANTIFIERS_REMOVING],
+        ) as compiler:
+            compiled = compiler.compile(problem).problem
+        self.assertFalse(compiled.kind.has_existential_conditions())
+
     @skipIfNoOneshotPlannerForProblemKind(classical_kind.union(simple_numeric_kind))
     @skipIfNoPlanValidatorForProblemKind(full_classical_kind.union(simple_numeric_kind))
     def test_robot_locations_connected(self):

--- a/unified_planning/test/test_state_invariants.py
+++ b/unified_planning/test/test_state_invariants.py
@@ -28,7 +28,10 @@ from unified_planning.test import (
     skipIfNoOneshotPlannerForProblemKind,
 )
 from unified_planning.test.examples import get_example_problems
-from unified_planning.engines.compilers import ConditionalEffectsRemover
+from unified_planning.engines.compilers import (
+    ConditionalEffectsRemover,
+    StateInvariantsRemover,
+)
 from unified_planning.engines import CompilationKind
 
 
@@ -58,3 +61,29 @@ class TestStateInvariantsRemover(unittest_TestCase):
                 compiled_problem.goals[0],
                 compiled_problem.environment.expression_manager.FALSE(),
             )
+
+    def test_resulting_problem_kind_with_state_invariants(self):
+        problem = self.problems["robot_loader_weak_bridge"].problem
+        self.assertTrue(problem.kind.has_state_invariants())
+
+        new_kind = StateInvariantsRemover.resulting_problem_kind(
+            problem.kind, CompilationKind.STATE_INVARIANTS_REMOVING
+        )
+        self.assertFalse(new_kind.has_state_invariants())
+
+        compiled = (
+            StateInvariantsRemover()
+            .compile(problem, CompilationKind.STATE_INVARIANTS_REMOVING)
+            .problem
+        )
+        assert isinstance(compiled, Problem)
+        self.assertTrue(compiled.kind <= new_kind)
+
+    def test_compilers_pipeline_with_state_invariants(self):
+        problem = self.problems["robot_loader_weak_bridge"].problem
+        with Compiler(
+            problem_kind=problem.kind,
+            compilation_kinds=[CompilationKind.STATE_INVARIANTS_REMOVING],
+        ) as compiler:
+            compiled = compiler.compile(problem).problem
+        self.assertFalse(compiled.kind.has_state_invariants())


### PR DESCRIPTION
## Summary
- `QuantifiersRemover.resulting_problem_kind` and `StateInvariantsRemover.resulting_problem_kind` called `ProblemKind` methods (`set_conditions`, `unset_constraints`) that don't exist — the real metaclass-generated names are `set_conditions_kind` / `unset_constraints_kind`.
- Both crashed with `AttributeError` whenever the guarding condition was true (existential conditions / state invariants present), which also broke the public `Compiler(problem_kind=problem.kind, compilation_kinds=[...])` pipeline path, since `Factory._get_engine` calls `resulting_problem_kind` while building the pipeline.
- Added regression tests covering both the direct `resulting_problem_kind` call and the `compilation_kinds` pipeline path for each compiler.

## Test plan
- [x] `unified_planning/test/test_quantifier_remover.py`, `unified_planning/test/test_state_invariants.py` — all pass