### PR TITLE
fix(problem-kind): flag Iff conditions as disjunctive

### DIFF
--- a/unified_planning/model/multi_agent/ma_problem.py
+++ b/unified_planning/model/multi_agent/ma_problem.py
@@ -371,7 +371,11 @@ class MultiAgentProblem(  # type: ignore[misc]
             self._kind.set_conditions_kind("EQUALITIES")
         if OperatorKind.NOT in ops:
             self._kind.set_conditions_kind("NEGATIVE_CONDITIONS")
-        if OperatorKind.OR in ops or OperatorKind.IMPLIES in ops:
+        if (
+            OperatorKind.OR in ops
+            or OperatorKind.IMPLIES in ops
+            or OperatorKind.IFF in ops
+        ):
             self._kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
         if OperatorKind.EXISTS in ops:
             self._kind.set_conditions_kind("EXISTENTIAL_CONDITIONS")

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -1070,7 +1070,11 @@ class _KindFactory:
             self.kind.set_conditions_kind("EQUALITIES")
         if OperatorKind.NOT in ops:
             self.kind.set_conditions_kind("NEGATIVE_CONDITIONS")
-        if OperatorKind.OR in ops or OperatorKind.IMPLIES in ops:
+        if (
+            OperatorKind.OR in ops
+            or OperatorKind.IMPLIES in ops
+            or OperatorKind.IFF in ops
+        ):
             self.kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
         if OperatorKind.EXISTS in ops:
             self.kind.set_conditions_kind("EXISTENTIAL_CONDITIONS")

--- a/unified_planning/test/test_model.py
+++ b/unified_planning/test/test_model.py
@@ -436,6 +436,30 @@ class TestModel(unittest_TestCase):
         self.assertTrue(kind.has_disjunctive_conditions())
         self.assertTrue(kind.has_increase_effects())
 
+    def test_iff_condition_kind(self):
+        a = Fluent("a", BoolType())
+        b = Fluent("b", BoolType())
+
+        act = InstantaneousAction("act")
+        act.add_precondition(Iff(a, b))
+        act.add_effect(a, True)
+
+        precondition_problem = Problem("p1")
+        precondition_problem.add_fluent(a, default_initial_value=False)
+        precondition_problem.add_fluent(b, default_initial_value=False)
+        precondition_problem.add_action(act)
+
+        goal_problem = Problem("p2")
+        goal_problem.add_fluent(a, default_initial_value=False)
+        goal_problem.add_fluent(b, default_initial_value=False)
+        goal_problem.add_action(act)
+        goal_problem.add_goal(Iff(a, b))
+
+        for problem in (precondition_problem, goal_problem):
+            kind = problem.kind
+            self.assertTrue(kind.has_disjunctive_conditions())
+            self.assertFalse(kind.has_negative_conditions())
+
     def test_istantaneous_action(self):
         Location = UserType("Location")
         move = InstantaneousAction("move", l_from=Location, l_to=Location)

--- a/unified_planning/test/test_multi_agent.py
+++ b/unified_planning/test/test_multi_agent.py
@@ -15,6 +15,7 @@
 
 import unified_planning as up
 from unified_planning.shortcuts import *
+from unified_planning.model.multi_agent import *
 from unified_planning.test import unittest_TestCase, main
 from unified_planning.test.examples.multi_agent import get_example_problems
 
@@ -32,6 +33,25 @@ class TestProblem(unittest_TestCase):
         self.assertEqual(len(problem.agents[0].fluents), 1)
         self.assertEqual(len(problem.agents[0].actions), 1)
         self.assertEqual(len(problem.all_objects), 2)
+
+    def test_iff_condition_kind(self):
+        problem = MultiAgentProblem("ma-iff")
+
+        a = Fluent("a", BoolType())
+        b = Fluent("b", BoolType())
+
+        r = Agent("robot", problem)
+        r.add_fluent(a, default_initial_value=False)
+        r.add_fluent(b, default_initial_value=False)
+        act = InstantaneousAction("act")
+        act.add_precondition(Iff(a, b))
+        act.add_effect(a, True)
+        r.add_action(act)
+        problem.add_agent(r)
+
+        kind = problem.kind
+        self.assertTrue(kind.has_disjunctive_conditions())
+        self.assertFalse(kind.has_negative_conditions())
 
     def test_loader(self):
         problem = self.problems["ma-loader"].problem

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -77,6 +77,22 @@ class TestPddlIO(unittest_TestCase):
         self.assertIn("(:init)", pddl_problem)
         self.assertIn("(:goal (and (x)))", pddl_problem)
 
+    def test_iff_condition_writer(self):
+        a = Fluent("a", BoolType())
+        b = Fluent("b", BoolType())
+        act = InstantaneousAction("act")
+        act.add_precondition(Iff(a, b))
+        act.add_effect(a, True)
+
+        problem = Problem("iff_problem")
+        problem.add_fluent(a, default_initial_value=False)
+        problem.add_fluent(b, default_initial_value=False)
+        problem.add_action(act)
+
+        w = PDDLWriter(problem)
+        pddl_domain = self._normalized_pddl_str(w.get_domain())
+        self.assertIn("(:requirements :strips :disjunctive-preconditions)", pddl_domain)
+
     def test_basic_non_constant_boolean_assignment(self):
         problem = self.problems["basic"].problem.clone()
         x = problem.fluent("x")


### PR DESCRIPTION
## Summary
- `update_problem_kind_expression` only set `DISJUNCTIVE_CONDITIONS` for `Or`/`Implies`, never for `Iff`.
- The same downstream symptom hits `PDDLWriter`: it emits `imply` for `Iff` but never declares `:disjunctive-preconditions`.
- Fixed both `Problem`'s `_KindFactory` and the identical copy in `MultiAgentProblem`.

## Test plan
- [x] Added `test_iff_condition_kind` (`test_model.py`, `test_multi_agent.py`) covering precondition and goal paths
- [x] Added `test_iff_condition_writer` (`test_pddl_io.py`) pinning the `:disjunctive-preconditions` requirement