### PR TITLE
fix: report negative conditions after removing disjunctions

### DIFF
--- a/unified_planning/engines/compilers/disjunctive_conditions_remover.py
+++ b/unified_planning/engines/compilers/disjunctive_conditions_remover.py
@@ -139,7 +139,13 @@ class DisjunctiveConditionsRemover(engines.engine.Engine, CompilerMixin):
         problem_kind: ProblemKind, compilation_kind: Optional[CompilationKind] = None
     ) -> ProblemKind:
         new_kind = problem_kind.clone()
-        new_kind.unset_conditions_kind("DISJUNCTIVE_CONDITIONS")
+        if new_kind.has_disjunctive_conditions():
+            new_kind.unset_conditions_kind("DISJUNCTIVE_CONDITIONS")
+            # Removing a disjunction rewrites the condition in DNF (NNF first), which
+            # can turn an implication or an iff into a genuine negation, e.g.:
+            #   Implies(a, b) -> Or(Not(a), b)
+            #   Iff(a, b)     -> Or(And(a, b), And(Not(a), Not(b)))
+            new_kind.set_conditions_kind("NEGATIVE_CONDITIONS")
         return new_kind
 
     def _compile(

--- a/unified_planning/engines/compilers/ma_disjunctive_conditions_remover.py
+++ b/unified_planning/engines/compilers/ma_disjunctive_conditions_remover.py
@@ -67,14 +67,6 @@ class MADisjunctiveConditionsRemover(DisjunctiveConditionsRemover):
     def supports(problem_kind):
         return problem_kind <= MADisjunctiveConditionsRemover.supported_kind()
 
-    @staticmethod
-    def resulting_problem_kind(
-        problem_kind: ProblemKind, compilation_kind: Optional[CompilationKind] = None
-    ) -> ProblemKind:
-        new_kind = problem_kind.clone()
-        new_kind.unset_conditions_kind("DISJUNCTIVE_CONDITIONS")
-        return new_kind
-
     def _compile(
         self,
         problem: "up.model.AbstractProblem",

--- a/unified_planning/test/test_disjunctive_conditions_remover.py
+++ b/unified_planning/test/test_disjunctive_conditions_remover.py
@@ -96,6 +96,42 @@ class TestDisjunctiveConditionsRemover(unittest_TestCase):
                     ).problem
                     assert isinstance(compiled_problem, Problem)
                     self.assertFalse(compiled_problem.kind.has_disjunctive_conditions())
+                    self.assertTrue(
+                        compiled_problem.kind <= dcr.resulting_problem_kind(p.kind)
+                    )
+
+    def test_resulting_kind_implies_is_negative(self):
+        # `Implies(a, b)` becomes `Or(Not(a), b)` in NNF, so the compiled problem has a
+        # `Not` precondition even though the input problem has no negation at all.
+        # `resulting_problem_kind` must claim `NEGATIVE_CONDITIONS` here.
+        a = Fluent("a")
+        b = Fluent("b")
+        act = InstantaneousAction("act")
+        act.add_precondition(Implies(a, b))
+        act.add_effect(a, True)
+        problem = Problem("test")
+        problem.add_fluent(a, default_initial_value=False)
+        problem.add_fluent(b, default_initial_value=False)
+        problem.add_action(act)
+        problem.add_goal(a)
+
+        self.assertTrue(problem.kind.has_disjunctive_conditions())
+        self.assertFalse(problem.kind.has_negative_conditions())
+
+        dcr = DisjunctiveConditionsRemover()
+        resulting_kind = dcr.resulting_problem_kind(
+            problem.kind, CompilationKind.DISJUNCTIVE_CONDITIONS_REMOVING
+        )
+        comp_res = dcr.compile(problem, CompilationKind.DISJUNCTIVE_CONDITIONS_REMOVING)
+        assert isinstance(comp_res.problem, Problem)
+        compiled_kind = comp_res.problem.kind
+
+        # the compiled problem really has a `Not` in it...
+        self.assertTrue(compiled_kind.has_negative_conditions())
+        # ...and the claimed resulting kind must not hide that.
+        self.assertFalse(resulting_kind.has_disjunctive_conditions())
+        self.assertTrue(resulting_kind.has_negative_conditions())
+        self.assertTrue(compiled_kind <= resulting_kind)
 
     def test_ad_hoc_1(self):
         # mockup problem

--- a/unified_planning/test/test_ma_disjunctive_conditions_remover.py
+++ b/unified_planning/test/test_ma_disjunctive_conditions_remover.py
@@ -27,6 +27,42 @@ class TestMADisjunctiveConditionsRemover(unittest_TestCase):
     def setUp(self):
         unittest_TestCase.setUp(self)
 
+    def test_resulting_kind_implies_is_negative(self):
+        # `Implies(a, b)` becomes `Or(Not(a), b)` in NNF, so the compiled problem has a
+        # `Not` precondition even though the input problem has no negation at all.
+        # `resulting_problem_kind` must claim `NEGATIVE_CONDITIONS` here.
+        problem = MultiAgentProblem("test")
+        a1 = Agent("a1", problem)
+        a = Fluent("a")
+        b = Fluent("b")
+        act = InstantaneousAction("act")
+        act.add_precondition(Implies(a, b))
+        act.add_effect(a, True)
+        a1.add_fluent(a, default_initial_value=False)
+        a1.add_fluent(b, default_initial_value=False)
+        a1.add_action(act)
+        problem.add_agent(a1)
+        problem.set_initial_value(Dot(a1, a), False)
+        problem.set_initial_value(Dot(a1, b), False)
+        problem.add_goal(Dot(a1, a))
+
+        self.assertTrue(problem.kind.has_disjunctive_conditions())
+        self.assertFalse(problem.kind.has_negative_conditions())
+
+        madcr = MADisjunctiveConditionsRemover()
+        resulting_kind = madcr.resulting_problem_kind(
+            problem.kind, CompilationKind.DISJUNCTIVE_CONDITIONS_REMOVING
+        )
+        compiled = madcr.compile(
+            problem, CompilationKind.DISJUNCTIVE_CONDITIONS_REMOVING
+        ).problem
+        assert isinstance(compiled, MultiAgentProblem)
+
+        self.assertTrue(compiled.kind.has_negative_conditions())
+        self.assertFalse(resulting_kind.has_disjunctive_conditions())
+        self.assertTrue(resulting_kind.has_negative_conditions())
+        self.assertTrue(compiled.kind <= resulting_kind)
+
     def test_ad_hoc_1(self):
         # mockup problem
         problem: MultiAgentProblem = MultiAgentProblem("simple_test")


### PR DESCRIPTION
## Summary

`DisjunctiveConditionsRemover._compile` rewrites conditions into DNF (NNF first,
`unified_planning/model/walkers/dnf.py`), which turns `Implies(a, b)` into
`Or(Not(a), b)` and `Iff(a, b)` into `Or(And(a, b), And(Not(a), Not(b)))`. But
`resulting_problem_kind` unconditionally unset `DISJUNCTIVE_CONDITIONS` and never set
`NEGATIVE_CONDITIONS`:

```python
new_kind = problem_kind.clone()
new_kind.unset_conditions_kind("DISJUNCTIVE_CONDITIONS")
return new_kind
```

Reproduced with a problem whose only precondition is `Implies(a, b)` (no `Not`
anywhere in the input):

```
input kind:    ['ACTION_BASED', 'DISJUNCTIVE_CONDITIONS']
claimed kind:  ['ACTION_BASED']
actual kind:   ['ACTION_BASED', 'NEGATIVE_CONDITIONS']
```

Any caller that trusts `resulting_problem_kind` to pick the next compilation stage or a
compatible engine without running the compiler first (`Factory._get_engine` does
exactly this when chaining a `CompilersPipeline`) could pick an engine that doesn't
actually support the compiled problem.

Fix: always set `NEGATIVE_CONDITIONS` when `DISJUNCTIVE_CONDITIONS` is removed, mirroring
the fix already applied to `NegativeConditionsRemover.resulting_problem_kind`.
`resulting_problem_kind` only receives a `ProblemKind`, not the actual expression tree,
so it can't tell a bare `Or` of positive atoms from an `Implies`/`Iff` that expands into
negations - it must over-approximate rather than risk under-reporting.

`MADisjunctiveConditionsRemover.resulting_problem_kind` was a byte-identical copy of the
parent's despite the class already subclassing `DisjunctiveConditionsRemover`; deleted
the redundant override so it inherits the fix.

## Test plan
- [x] Added `test_resulting_kind_implies_is_negative` to `test_disjunctive_conditions_remover.py` and `test_ma_disjunctive_conditions_remover.py`
- [x] Strengthened `test_all_problem_kind` with a `compiled.kind <= resulting_problem_kind(...)` assertion over all example problems