### PR TITLE
fix: compare oth.environment in ContingentPlan.__eq__

### DIFF
--- a/unified_planning/plans/contingent_plan.py
+++ b/unified_planning/plans/contingent_plan.py
@@ -147,7 +147,7 @@ class ContingentPlan(plans.plan.Plan):
         self._root_node = root_node
 
     def __eq__(self, oth: object) -> bool:
-        if isinstance(oth, ContingentPlan) and self.environment == self.environment:
+        if isinstance(oth, ContingentPlan) and self.environment == oth.environment:
             return self.root_node == oth.root_node
         else:
             return False


### PR DESCRIPTION
## Summary
- `ContingentPlan.__eq__` guarded on `self.environment == self.environment`
  instead of `self.environment == oth.environment`, so the environment check
  never actually gated anything.
- For plans with a non-empty `root_node`, this was masked because
  `ContingentPlanNode.__eq__` already fails across environments via
  `ActionInstance.is_semantically_equivalent`. An empty `ContingentPlan`
  (`root_node is None`) has no such fallback, so two empty plans built
  against different `Environment`s incorrectly compared equal.