### PR TITLE
fix: use the correct ProblemKind accessor in DurativeActionToProcesses.resulting_problem_kind

### DIFF
--- a/unified_planning/engines/compilers/durative_actions_to_processes.py
+++ b/unified_planning/engines/compilers/durative_actions_to_processes.py
@@ -165,7 +165,7 @@ class DurativeActionToProcesses(engines.engine.Engine, CompilerMixin):
     ) -> ProblemKind:
         new_kind = problem_kind.clone()
         new_kind.unset_time("INTERMEDIATE_CONDITIONS_AND_EFFECTS")
-        if new_kind.has("DURATION_INEQUALITIES"):
+        if new_kind.has_duration_inequalities():
             new_kind.unset_time("DURATION_INEQUALITIES")
             new_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
         new_kind.unset_time("INTERMEDIATE_CONDITIONS_AND_EFFECTS")

--- a/unified_planning/test/test_durative_actions_to_processes.py
+++ b/unified_planning/test/test_durative_actions_to_processes.py
@@ -26,6 +26,9 @@ from unified_planning.test import (
 )
 from unified_planning.test.examples import get_example_problems
 from unified_planning.engines import CompilationKind
+from unified_planning.engines.compilers.durative_actions_to_processes import (
+    DurativeActionToProcesses,
+)
 from unified_planning.engines.results import (
     ValidationResultStatus,
     PlanGenerationResultStatus,
@@ -641,6 +644,26 @@ class TestDurativeActionsToProcesses(unittest_TestCase):
         new_problem = res.problem
         events = len(problem.actions) * 2 + 2 + 1
         self.assertEqual(len(new_problem.events), events)
+
+    def test_resulting_problem_kind_with_duration_inequalities(self):
+        problem = self.problems["robot_with_variable_duration"].problem
+        self.assertTrue(problem.kind.has_duration_inequalities())
+
+        new_kind = DurativeActionToProcesses.resulting_problem_kind(
+            problem.kind, CompilationKind.DURATIVE_ACTIONS_TO_PROCESSES
+        )
+        self.assertFalse(new_kind.has_duration_inequalities())
+        # Duration inequalities are compiled into disjunctive events/conditions.
+        self.assertTrue(new_kind.has_disjunctive_conditions())
+
+        # Smoke test: actually compiling a problem with duration inequalities
+        # must not raise either.
+        compiled = (
+            DurativeActionToProcesses()
+            .compile(problem, CompilationKind.DURATIVE_ACTIONS_TO_PROCESSES)
+            .problem
+        )
+        assert isinstance(compiled, Problem)
 
     @skipIfEngineNotAvailable("opt-pddl-planner")
     def test_all(self):


### PR DESCRIPTION
## Summary
- `DurativeActionToProcesses.resulting_problem_kind` called `new_kind.has("DURATION_INEQUALITIES")`, a method that doesn't exist on `ProblemKind` - it only exposes per-feature accessors like `has_duration_inequalities()`. The call ran unconditionally, so every invocation raised `AttributeError`, regardless of the input kind.
- Replaced it with `has_duration_inequalities()`, the correct generated accessor.

## Test plan
- [x] Added `test_resulting_problem_kind_with_duration_inequalities`, which reproduced the `AttributeError` before the fix and now passes.