### PR TITLE
fix: report all features introduced by the interpreted functions remover

### DIFF
--- a/unified_planning/engines/compilers/interpreted_functions_remover.py
+++ b/unified_planning/engines/compilers/interpreted_functions_remover.py
@@ -175,18 +175,98 @@ class InterpretedFunctionsRemover(engines.engine.Engine, CompilerMixin):
     ) -> ProblemKind:
         assert isinstance(problem_kind, ProblemKind)
         new_kind = problem_kind.clone()
-        if new_kind.has_interpreted_functions_in_conditions():
+
+        if_in_conditions = new_kind.has_interpreted_functions_in_conditions()
+        if_in_durations = new_kind.has_interpreted_functions_in_durations()
+        if_in_bool_assignments = (
+            new_kind.has_interpreted_functions_in_boolean_assignments()
+        )
+        if_in_numeric_assignments = (
+            new_kind.has_interpreted_functions_in_numeric_assignments()
+        )
+        if_in_object_assignments = (
+            new_kind.has_interpreted_functions_in_object_assignments()
+        )
+        # an interpreted function anywhere in the problem forces _compile to introduce
+        # a fresh helper fluent for its "known value" branch (see below); an interpreted
+        # function in an effect additionally forces a "is unknown" tracking fluent.
+        if_in_effects = (
+            if_in_bool_assignments
+            or if_in_numeric_assignments
+            or if_in_object_assignments
+        )
+        if_anywhere = if_in_conditions or if_in_durations or if_in_effects
+
+        if if_in_conditions:
             new_kind.unset_conditions_kind("INTERPRETED_FUNCTIONS_IN_CONDITIONS")
-        if new_kind.has_interpreted_functions_in_durations():
+            # the "known value" helper fluent (`_f_<ifun>`) is typed with the
+            # interpreted function's own return type, which the input kind does not
+            # record; over-approximate with every fluent type it could be.
+            new_kind.set_fluents_type("INT_FLUENTS")
+            new_kind.set_fluents_type("REAL_FLUENTS")
+            new_kind.set_fluents_type("OBJECT_FLUENTS")
+        if if_in_durations:
             new_kind.unset_expression_duration("INTERPRETED_FUNCTIONS_IN_DURATIONS")
             new_kind.set_expression_duration("INT_TYPE_DURATIONS")
-        if new_kind.has_interpreted_functions_in_boolean_assignments():
+            # when the value is not known, the duration bound falls back to the fixed
+            # real interval [1, 1000000], introducing a real, unequal duration bound
+            # regardless of what the original duration looked like.
+            new_kind.set_expression_duration("REAL_TYPE_DURATIONS")
+            new_kind.set_time("DURATION_INEQUALITIES")
+            # the "known value" helper fluent substituted into the duration is static.
+            new_kind.set_expression_duration("STATIC_FLUENTS_IN_DURATIONS")
+            new_kind.set_fluents_type("INT_FLUENTS")
+            new_kind.set_fluents_type("REAL_FLUENTS")
+        if if_in_bool_assignments:
             new_kind.unset_effects_kind("INTERPRETED_FUNCTIONS_IN_BOOLEAN_ASSIGNMENTS")
-        if new_kind.has_interpreted_functions_in_numeric_assignments():
+            new_kind.set_effects_kind("STATIC_FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
+        if if_in_numeric_assignments:
             new_kind.unset_effects_kind("INTERPRETED_FUNCTIONS_IN_NUMERIC_ASSIGNMENTS")
-        if new_kind.has_interpreted_functions_in_object_assignments():
+            new_kind.set_effects_kind("STATIC_FLUENTS_IN_NUMERIC_ASSIGNMENTS")
+            new_kind.set_fluents_type("INT_FLUENTS")
+            new_kind.set_fluents_type("REAL_FLUENTS")
+        if if_in_object_assignments:
             new_kind.unset_effects_kind("INTERPRETED_FUNCTIONS_IN_OBJECT_ASSIGNMENTS")
+            new_kind.set_effects_kind("STATIC_FLUENTS_IN_OBJECT_ASSIGNMENTS")
             new_kind.set_fluents_type("OBJECT_FLUENTS")
+
+        if if_in_effects:
+            # every interpreted function used in an effect gets an "is unknown"
+            # tracking fluent, reset via `Effect(tracker, Or(<other trackers>))` - a
+            # boolean assignment that depends on other (possibly static) fluents.
+            new_kind.set_effects_kind("FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
+            new_kind.set_effects_kind("STATIC_FLUENTS_IN_BOOLEAN_ASSIGNMENTS")
+            # a fluent whose only assignment came from an interpreted function's value
+            # is no longer assigned at all in the compiled problem (it becomes a plain
+            # tracked/static fluent instead), so any non-static assignment/duration
+            # feature could turn into its static counterpart.
+            if new_kind.has_fluents_in_numeric_assignments():
+                new_kind.set_effects_kind("STATIC_FLUENTS_IN_NUMERIC_ASSIGNMENTS")
+            if new_kind.has_fluents_in_object_assignments():
+                new_kind.set_effects_kind("STATIC_FLUENTS_IN_OBJECT_ASSIGNMENTS")
+            if new_kind.has_fluents_in_durations():
+                new_kind.set_expression_duration("STATIC_FLUENTS_IN_DURATIONS")
+            if new_kind.has_fluents_in_actions_cost():
+                new_kind.set_actions_cost_kind("STATIC_FLUENTS_IN_ACTIONS_COST")
+
+        if if_anywhere:
+            # the compiled goal/conditions are rewritten to `Or(cond, <is-unknown
+            # trackers>)` to account for the interpreted function's value staying
+            # unknown, and the "known value" helper fluent is guarded by
+            # `Equals`/`Implies(..., Equals(...))` conditions and, on the unknown
+            # branch, a `Not(And(...))` condition - none of which need to have been
+            # present in the input problem.
+            new_kind.set_conditions_kind("DISJUNCTIVE_CONDITIONS")
+            new_kind.set_conditions_kind("NEGATIVE_CONDITIONS")
+            new_kind.set_conditions_kind("EQUALITIES")
+            # the helper fluents are parameterized by a fresh `kNum_<ifun>` UserType.
+            new_kind.set_typing("FLAT_TYPING")
+            # a problem with any int/real fluent always has exactly one of
+            # SIMPLE_/GENERAL_NUMERIC_PLANNING, and this compilation can flip which
+            # one applies; claim both when either could end up in the compiled problem.
+            if new_kind.has_int_fluents() or new_kind.has_real_fluents():
+                new_kind.set_problem_type("SIMPLE_NUMERIC_PLANNING")
+                new_kind.set_problem_type("GENERAL_NUMERIC_PLANNING")
 
         return new_kind
 

--- a/unified_planning/test/test_interpreted_functions_remover.py
+++ b/unified_planning/test/test_interpreted_functions_remover.py
@@ -361,6 +361,121 @@ class TestInterpretedFunctionsRemover(unittest_TestCase):
 
         self.assertEqual(to_check_cut, test_cut)
 
+    def test_all_problem_kind(self):
+        # for every shared example problem this compiler supports, the claimed
+        # resulting kind must cover the actually compiled problem's kind.
+        ifr = InterpretedFunctionsRemover()
+        checked = 0
+        for example in self.problems.values():
+            problem = example.problem
+            if not isinstance(problem, Problem):
+                continue
+            kind = problem.kind
+            if not InterpretedFunctionsRemover.supports(kind):
+                continue
+            if not (
+                kind.has_interpreted_functions_in_conditions()
+                or kind.has_interpreted_functions_in_durations()
+                or kind.has_interpreted_functions_in_boolean_assignments()
+                or kind.has_interpreted_functions_in_numeric_assignments()
+                or kind.has_interpreted_functions_in_object_assignments()
+            ):
+                continue
+            comp_res = ifr.compile(
+                problem, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING
+            )
+            assert isinstance(comp_res.problem, Problem)
+            compiled_kind = comp_res.problem.kind
+            resulting_kind = InterpretedFunctionsRemover.resulting_problem_kind(
+                kind, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING
+            )
+            self.assertTrue(
+                compiled_kind <= resulting_kind,
+                msg=f"{problem.name}: compiled kind has features "
+                f"{sorted(set(compiled_kind.features) - set(resulting_kind.features))} "
+                "that resulting_problem_kind does not claim",
+            )
+            checked += 1
+        self.assertGreater(checked, 0)
+
+    def test_resulting_kind_unknown_goal_is_disjunctive(self):
+        # the compiled goal is rewritten to `Or(goal, <tracker fluent>)` to account for
+        # the case where the interpreted function's value stays unknown, so the compiled
+        # problem gains a disjunction that was not present in the input problem.
+        problem = self.problems["interpreted_functions_in_boolean_assignment"].problem
+        self.assertFalse(problem.kind.has_disjunctive_conditions())
+
+        ifr = InterpretedFunctionsRemover()
+        resulting_kind = InterpretedFunctionsRemover.resulting_problem_kind(
+            problem.kind, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING
+        )
+        comp_res = ifr.compile(problem, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING)
+        assert isinstance(comp_res.problem, Problem)
+        compiled_kind = comp_res.problem.kind
+
+        self.assertTrue(compiled_kind.has_disjunctive_conditions())
+        self.assertTrue(resulting_kind.has_disjunctive_conditions())
+        self.assertTrue(compiled_kind <= resulting_kind)
+
+    def test_resulting_kind_unknown_duration_is_a_real_inequality(self):
+        # when the interpreted function used in a duration bound is not known, `_compile`
+        # falls back to the fixed real interval [1, 1000000], introducing a real-typed,
+        # unequal duration bound even though the input only has `INT_TYPE_DURATIONS`.
+        problem = self.problems["go_home_with_rain_and_interpreted_functions"].problem
+        self.assertFalse(problem.kind.has_real_type_durations())
+        self.assertFalse(problem.kind.has_duration_inequalities())
+
+        ifr = InterpretedFunctionsRemover()
+        resulting_kind = InterpretedFunctionsRemover.resulting_problem_kind(
+            problem.kind, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING
+        )
+        comp_res = ifr.compile(problem, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING)
+        assert isinstance(comp_res.problem, Problem)
+        compiled_kind = comp_res.problem.kind
+
+        self.assertTrue(compiled_kind.has_real_type_durations())
+        self.assertTrue(compiled_kind.has_duration_inequalities())
+        self.assertTrue(resulting_kind.has_real_type_durations())
+        self.assertTrue(resulting_kind.has_duration_inequalities())
+        self.assertTrue(resulting_kind.has_int_type_durations())
+        self.assertTrue(compiled_kind <= resulting_kind)
+
+    def test_resulting_kind_with_known_values(self):
+        # when the compiler is given known interpreted-function values, the "known" branch
+        # of the compiled action introduces fresh helper fluents/objects/UserTypes and
+        # Equals/Implies/Not guards around them - none of which are visible from the input
+        # problem's kind alone.
+        problem = self.problems["IF_in_conditions_complex_1"].problem
+        if_obj = problem.action("f").preconditions[0].args[0].interpreted_function()
+        self.assertTrue(isinstance(if_obj, InterpretedFunction))
+        knowledge = {InterpretedFunctionExp(if_obj, [1]): 2}
+
+        self.assertFalse(problem.kind.has_equalities())
+        self.assertFalse(problem.kind.has_flat_typing())
+        self.assertFalse(problem.kind.has_negative_conditions())
+        self.assertFalse(problem.kind.has_disjunctive_conditions())
+
+        resulting_kind = InterpretedFunctionsRemover.resulting_problem_kind(
+            problem.kind, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING
+        )
+        with InterpretedFunctionsRemover(knowledge) as if_remover:
+            comp_res = if_remover.compile(
+                problem, CompilationKind.INTERPRETED_FUNCTIONS_REMOVING
+            )
+        assert isinstance(comp_res.problem, Problem)
+        compiled_kind = comp_res.problem.kind
+
+        self.assertTrue(compiled_kind.has_equalities())
+        self.assertTrue(compiled_kind.has_flat_typing())
+        self.assertTrue(compiled_kind.has_negative_conditions())
+        self.assertTrue(compiled_kind.has_disjunctive_conditions())
+
+        self.assertTrue(resulting_kind.has_equalities())
+        self.assertTrue(resulting_kind.has_flat_typing())
+        self.assertTrue(resulting_kind.has_negative_conditions())
+        self.assertTrue(resulting_kind.has_disjunctive_conditions())
+        self.assertTrue(compiled_kind <= resulting_kind)
+
 
 def contains_condition_helper(
     to_check: List[FNode], correct_args: List, expected_type: OperatorKind


### PR DESCRIPTION
## Summary
- `InterpretedFunctionsRemover.resulting_problem_kind` under-reported the compiled
  problem's kind: it only unset the `INTERPRETED_FUNCTIONS_IN_*` flags and never
  accounted for the disjunctions, negations, equalities, real/unequal durations, fresh
  UserTypes and static-fluent conversions that `_compile` actually introduces (both with
  and without a supplied knowledge dict of interpreted-function values).
- `Factory`/`compilers_pipeline.py` feed this claimed kind into the next compilation
  stage/engine-selection step, so an under-reported kind could pick an engine that can't
  actually handle the compiled problem.
- Made `resulting_problem_kind` a sound over-approximation, mirroring the fix already
  applied to `NegativeConditionsRemover`/`DisjunctiveConditionsRemover`.

## Test plan
- [x] Added `test_all_problem_kind`, looping over every shared example problem and
      asserting `compiled.kind <= resulting_problem_kind(problem.kind)`
- [x] Added targeted regressions for: the disjunctive "unknown outcome" goal rewrite,
      the real/unequal duration fallback, and the known-value substitution path