### PR TITLE
fix: re-indent nested repr in MotionActivity.__repr__

### DIFF
--- a/unified_planning/model/motion/activity.py
+++ b/unified_planning/model/motion/activity.py
@@ -55,13 +55,13 @@ class MotionActivity(Activity, MotionConstraintsSetMixin):
 
     def __repr__(self) -> str:
         s = ["motion-activity {"]
-        s.append(super().__repr__().replace("/n", "\n  "))
+        s.append("  " + super().__repr__().replace("\n", "\n  "))
         s.append("  motion-constraints")
         for c in self._motion_constraints:
-            s.append(f"      {str(c)}\n")
+            s.append(f"      {str(c)}")
         s.append("  motion-effects")
-        for e in self._motion_effects:
-            s.append(f"      {str(e)}\n")
+        for movable, config in self._motion_effects.items():
+            s.append(f"      {str(movable)} := {str(config)}")
         s.append("}")
         return "\n".join(s)
 

--- a/unified_planning/test/test_tamp.py
+++ b/unified_planning/test/test_tamp.py
@@ -38,3 +38,63 @@ class TestTAMPProblem(unittest_TestCase):
         move = problem.action("move")
         self.assertEqual(1, len(move.motion_constraints))
         self.assertTrue(isinstance(move.motion_constraints[0], Waypoints))
+
+
+class TestMotionActivity(unittest_TestCase):
+    def test_repr_bare(self):
+        act = MotionActivity("act1", duration=2)
+        self.assertEqual(
+            repr(act),
+            "\n".join(
+                [
+                    "motion-activity {",
+                    "  act1 {",
+                    "      duration = [2, 2]",
+                    "    }",
+                    "  motion-constraints",
+                    "  motion-effects",
+                    "}",
+                ]
+            ),
+        )
+
+    def test_repr_with_constraints_and_effects(self):
+        Robot = MovableType("robot")
+        occupancy_map = OccupancyMap("map.yaml", SE2(0, 0, 0))
+        RobotConfig = ConfigurationType(
+            "robot_config", occupancy_map, ConfigurationKind.SE2
+        )
+        c1 = ConfigurationObject("c1", RobotConfig, SE2(0.0, 0.0, 0.0))
+        c2 = ConfigurationObject("c2", RobotConfig, SE2(1.0, 1.0, 0.0))
+        r1 = MovableObject(
+            "r1",
+            Robot,
+            footprint=[(-1.0, 0.5), (1.0, 0.5), (1.0, -0.5), (-1.0, -0.5)],
+            motion_model=MotionModels.REEDSSHEPP,
+            control_parameters={"turning_radius": 1.0},
+        )
+
+        act = MotionActivity("act1", duration=2)
+        constraint = Waypoints(r1, c1, [c2])
+        act.add_motion_constraint(constraint)
+        act.add_motion_effect(r1, c2)
+
+        r = repr(act)
+
+        self.assertEqual(
+            r,
+            "\n".join(
+                [
+                    "motion-activity {",
+                    "  act1 {",
+                    "      duration = [2, 2]",
+                    "    }",
+                    "  motion-constraints",
+                    f"      {str(constraint)}",
+                    "  motion-effects",
+                    f"      {str(r1)} := {str(c2)}",
+                    "}",
+                ]
+            ),
+        )
+        self.assertNotIn("\n\n", r)


### PR DESCRIPTION
## Summary
- `MotionActivity.__repr__` replaced `"/n"` (forward slash + `n`) instead of
  `"\n"` (a real newline), so the intended re-indentation of the inherited
  `Chronicle.__repr__` block was a silent no-op.
- Also fixed two related formatting bugs in the same method: a stray blank
  line after every motion constraint/effect entry, and motion effects being
  printed as bare movable keys instead of `movable := config` (the dict
  values were never read).

## Test plan
- [x] Added `TestMotionActivity` to `unified_planning/test/test_tamp.py`
      covering a bare `MotionActivity` repr and one with a motion constraint
      and motion effect attached; confirmed both fail against the old code
      and pass after the fix.