### PR TITLE
fix: forward converter Environment throughout AIPDDLConverter

### DIFF
--- a/unified_planning/interop/from_pddl.py
+++ b/unified_planning/interop/from_pddl.py
@@ -133,7 +133,9 @@ class _ExpressionConverter:
         key = (variable.name, assert_not_none_type(self._types[tt]))
         if key not in self._variables:
             self._variables[key] = UPVariable(
-                variable.name, assert_not_none_type(self._types[tt])
+                variable.name,
+                assert_not_none_type(self._types[tt]),
+                self._em.environment,
             )
         return self._variables[key]
 
@@ -430,12 +432,19 @@ class AIPDDLConverter:
         return assert_not_none_type(self._up_type(tt))
 
     def _variable_to_param(self, variable: Variable) -> Parameter:
-        return Parameter(variable.name, self._variable_type(variable))
+        return Parameter(
+            variable.name, self._variable_type(variable), self._environment
+        )
 
     def _convert_predicate_to_fluent(self, predicate: Predicate):
         assert self._up_problem is not None
         params = OrderedDict((v.name, self._variable_type(v)) for v in predicate.terms)
-        fluent = Fluent(predicate.name, self._tm.BoolType(), **params)
+        fluent = Fluent(
+            predicate.name,
+            self._tm.BoolType(),
+            _signature=params,
+            environment=self._environment,
+        )
         self._fluents[predicate.name] = fluent
         self._up_problem.add_fluent(fluent, default_initial_value=self._em.FALSE())
 
@@ -465,7 +474,12 @@ class AIPDDLConverter:
             self._action_costs = {}
             return
         params = OrderedDict((v.name, self._variable_type(v)) for v in function.terms)
-        f = Fluent(function.name, self._tm.RealType(), **params)
+        f = Fluent(
+            function.name,
+            self._tm.RealType(),
+            _signature=params,
+            environment=self._environment,
+        )
         self._fluents[function.name] = f
         self._up_problem.add_fluent(f, default_initial_value=self._em.Int(0))
 
@@ -479,9 +493,13 @@ class AIPDDLConverter:
         assert self._up_problem is not None
         if obj.type_tags is None:
             raise UPUnsupportedProblemTypeError(f"Object {obj.name} has no type tag")
-        obj = Object(obj.name, assert_not_none_type(self._up_type(obj.type_tag)))
-        self._objects[obj.name] = obj
-        self._up_problem.add_object(obj)
+        up_obj = Object(
+            obj.name,
+            assert_not_none_type(self._up_type(obj.type_tag)),
+            self._environment,
+        )
+        self._objects[up_obj.name] = up_obj
+        self._up_problem.add_object(up_obj)
 
     def _convert_constants(self):
         for obj in self._domain.constants:
@@ -646,7 +664,7 @@ class AIPDDLConverter:
                 new_quantifier_variables = current_quantifier_variables.copy()
                 for v in current_effect.variables:
                     new_quantifier_variables[v.name] = UPVariable(
-                        v.name, self._variable_type(v)
+                        v.name, self._variable_type(v), self._environment
                     )
                 stack.append(
                     (current_effect.effect, new_quantifier_variables, current_condition)
@@ -668,11 +686,13 @@ class AIPDDLConverter:
             (v.name, self._variable_type(v)) for v in action.parameters
         )
         action_parameters_expression = {
-            p_name: Parameter(p_name, p_type)
+            p_name: Parameter(p_name, p_type, self._environment)
             for p_name, p_type in action_parameters.items()
         }
 
-        up_action = InstantaneousAction(action.name, **action_parameters)
+        up_action = InstantaneousAction(
+            action.name, action_parameters, self._environment
+        )
 
         up_action.add_precondition(
             self._expression_converter.convert_expression(
@@ -745,7 +765,9 @@ class AIPDDLConverter:
                 for action_name, cost in self._action_costs.items():
                     action_costs[self._up_problem.action(action_name)] = cost
                 self._up_problem.add_quality_metric(
-                    MinimizeActionCosts(action_costs, self._em.Int(0))
+                    MinimizeActionCosts(
+                        action_costs, self._em.Int(0), self._environment
+                    )
                 )
         elif self._problem is not None:
             metric = self._problem.metric
@@ -757,9 +779,11 @@ class AIPDDLConverter:
                 if metric.optimization == Metric.MINIMIZE:
                     up_metric: Union[
                         MinimizeExpressionOnFinalState, MaximizeExpressionOnFinalState
-                    ] = MinimizeExpressionOnFinalState(expression)
+                    ] = MinimizeExpressionOnFinalState(expression, self._environment)
                 else:
-                    up_metric = MaximizeExpressionOnFinalState(expression)
+                    up_metric = MaximizeExpressionOnFinalState(
+                        expression, self._environment
+                    )
                 self._up_problem.add_quality_metric(up_metric)
 
     def convert(self) -> UPProblem:

--- a/unified_planning/test/test_pddl_io.py
+++ b/unified_planning/test/test_pddl_io.py
@@ -19,6 +19,12 @@ import tempfile
 import pytest
 from typing import cast
 import unified_planning
+from unified_planning.environment import Environment
+from unified_planning.model.action import InstantaneousAction
+from unified_planning.model.metrics import (
+    MaximizeExpressionOnFinalState,
+    MinimizeExpressionOnFinalState,
+)
 from unified_planning.shortcuts import *
 from unified_planning.test import (
     unittest_TestCase,
@@ -1618,6 +1624,147 @@ class TestPddlIO(unittest_TestCase):
         with self.assertRaises(SyntaxError) as ctx:
             reader.parse_problem_string(domain, problem_str)
         self.assertIn("nonexistent_type", str(ctx.exception))
+
+    def test_ai_pddl_reader_custom_environment(self):
+        """The AI-PDDL fast path (`AIPDDLConverter`) must build every model object
+        (fluents, objects, actions/parameters, forall-effect variables, quality
+        metrics) in the `Environment` given to the `PDDLReader`, not the global one."""
+        domain = """
+(define (domain custom-env-d)
+    (:requirements :strips :typing :negative-preconditions :equality
+                   :existential-preconditions :universal-preconditions
+                   :conditional-effects :numeric-fluents :action-costs)
+    (:types loc item)
+    (:constants depot - loc)
+    (:predicates (at ?i - item ?l - loc) (clear ?l - loc))
+    (:functions (fuel ?l - loc) (total-cost))
+    (:action move
+        :parameters (?i - item ?from - loc ?to - loc)
+        :precondition (and
+            (at ?i ?from)
+            (not (= ?from ?to))
+            (exists (?j - item) (at ?j ?to))
+        )
+        :effect (and
+            (not (at ?i ?from))
+            (at ?i ?to)
+            (forall (?l - loc) (when (clear ?l) (at ?i ?l)))
+            (increase (fuel ?to) 1)
+            (increase (total-cost) 3)
+        )
+    )
+)
+"""
+        problem = """
+(define (problem custom-env-p) (:domain custom-env-d)
+    (:objects l1 - loc i1 - item)
+    (:init (at i1 l1) (clear l1) (clear depot)
+           (= (fuel l1) 0) (= (fuel depot) 0) (= (total-cost) 0))
+    (:goal (at i1 depot))
+    (:metric minimize (total-cost))
+)
+"""
+        env = Environment()
+        self.assertTrue(check_ai_pddl_requirements(extract_pddl_requirements(domain)))
+        up_problem = PDDLReader(
+            env, force_ai_planning_reader=True
+        ).parse_problem_string(domain, problem)
+
+        self.assertIs(up_problem.environment, env)
+        for fluent in up_problem.fluents:
+            self.assertIs(fluent.environment, env)
+        for obj in up_problem.all_objects:
+            self.assertIs(obj.environment, env)
+        for action in up_problem.actions:
+            self.assertIs(action.environment, env)
+            for param in action.parameters:
+                self.assertIs(param.environment, env)
+            assert isinstance(action, InstantaneousAction)
+            for effect in action.effects:
+                self.assertIs(effect.fluent.environment, env)
+                self.assertIs(effect.value.environment, env)
+                self.assertIs(effect.condition.environment, env)
+                for v in effect.forall:
+                    self.assertIs(v.environment, env)
+        for metric in up_problem.quality_metrics:
+            self.assertIs(metric.environment, env)
+
+        # parsing the same PDDL text into a second fresh environment must be
+        # semantics-preserving and environment-independent
+        up_problem_2 = PDDLReader(
+            Environment(), force_ai_planning_reader=True
+        ).parse_problem_string(domain, problem)
+        self.assertEqual(str(up_problem), str(up_problem_2))
+
+    def test_ai_pddl_reader_custom_environment_expression_metric(self):
+        """A `minimize`/`maximize` final-state-expression metric (as opposed to
+        the action-costs metric) must also be built in the given `Environment`."""
+        domain = """
+(define (domain custom-env-metric-d)
+    (:requirements :strips :typing :numeric-fluents)
+    (:types loc)
+    (:predicates (at ?l - loc))
+    (:functions (fuel))
+    (:action noop
+        :parameters (?l - loc)
+        :precondition (at ?l)
+        :effect (increase (fuel) 1)
+    )
+)
+"""
+        problem = """
+(define (problem custom-env-metric-p) (:domain custom-env-metric-d)
+    (:objects l1 - loc)
+    (:init (at l1) (= (fuel) 0))
+    (:goal (at l1))
+    (:metric minimize (fuel))
+)
+"""
+        env = Environment()
+        up_problem = PDDLReader(
+            env, force_ai_planning_reader=True
+        ).parse_problem_string(domain, problem)
+        self.assertEqual(len(up_problem.quality_metrics), 1)
+        metric = up_problem.quality_metrics[0]
+        assert isinstance(
+            metric, (MinimizeExpressionOnFinalState, MaximizeExpressionOnFinalState)
+        )
+        self.assertIs(metric.environment, env)
+        self.assertIs(metric.expression.environment, env)
+
+    def test_ai_pddl_reader_custom_environment_parameter_named_environment(self):
+        """A predicate/action parameter literally named `?environment` must not
+        collide with the `environment=` keyword used internally to forward the
+        converter's Environment to `Fluent`/`InstantaneousAction`."""
+        domain = """
+(define (domain custom-env-name-d)
+    (:requirements :strips :typing)
+    (:types loc)
+    (:predicates (p ?environment - loc))
+    (:action a
+        :parameters (?environment - loc)
+        :precondition (p ?environment)
+        :effect (p ?environment)
+    )
+)
+"""
+        problem = """
+(define (problem custom-env-name-p) (:domain custom-env-name-d)
+    (:objects l1 - loc)
+    (:init (p l1))
+    (:goal (p l1))
+)
+"""
+        env = Environment()
+        up_problem = PDDLReader(
+            env, force_ai_planning_reader=True
+        ).parse_problem_string(domain, problem)
+        self.assertEqual(
+            [p.name for p in up_problem.fluent("p").signature], ["environment"]
+        )
+        self.assertEqual(
+            [p.name for p in up_problem.action("a").parameters], ["environment"]
+        )
 
 
 def _have_same_user_types_considering_renamings(


### PR DESCRIPTION
## Summary
- `AIPDDLConverter` (the AI-PDDL fast path used by `PDDLReader`) built every `Type` from the caller's `Environment`, but most of the model-object constructors it called (`Fluent`, `Object`, `Parameter`, `InstantaneousAction`, `Variable`, and the quality-metric classes) didn't forward that same `Environment`, so those objects silently fell back to the process-global one and construction failed with an `AssertionError` whenever a non-default `Environment` was used.
- Forwards the converter's `Environment` at all ten affected call sites; uses the `_signature=`/positional-parameter form for `Fluent`/`InstantaneousAction` rather than an `environment=` keyword, since a PDDL parameter can legally be named `?environment` and would otherwise collide with that keyword.

## Test plan
- [x] Added `test_ai_pddl_reader_custom_environment`, `test_ai_pddl_reader_custom_environment_expression_metric`, and `test_ai_pddl_reader_custom_environment_parameter_named_environment` in `unified_planning/test/test_pddl_io.py`, all pinned to the AI-PDDL path via `force_ai_planning_reader=True`.