### PR TITLE
feat(grounder): fold per-ground-atom static fluents during grounding

### DIFF
--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -98,6 +98,7 @@ class GrounderHelper:
         grounding_actions_map: Optional[Dict[Action, List[Tuple[FNode, ...]]]] = None,
         prune_actions: bool = True,
         join_max_candidates: int = DEFAULT_JOIN_MAX_CANDIDATES,
+        fold_static_fluent_exps: bool = True,
     ):
         """
         Creates an instance of the GrounderHelper.
@@ -128,12 +129,22 @@ class GrounderHelper:
             action falls back to the per-parameter-independent pruning instead. A value `<= 0`
             disables the join outright (every action uses the fallback), which is mainly useful
             to test the fallback path itself in isolation.
+        :param fold_static_fluent_exps: If `True` (the default) and `prune_actions` is also `True`,
+            the `Simplifier` this class runs every substituted precondition/condition/effect
+            value/duration bound/action cost through additionally folds a ground fluent atom to
+            its initial value whenever *that specific atom* -- not just its whole fluent schema,
+            as `problem.get_static_fluents()` alone would -- is never the target of any effect in
+            the problem (see `unified_planning.model.walkers.Simplifier`'s
+            `fold_static_fluent_exps` parameter). Has no effect when `prune_actions` is `False`,
+            since that path uses the problem-less, static-fluent-unaware `environment.simplifier`
+            instead.
         """
         assert isinstance(problem, Problem)
         self._problem = problem
         self._grounding_actions_map = grounding_actions_map
         self._prune_actions = prune_actions
         self._join_max_candidates = join_max_candidates
+        self._fold_static_fluent_exps = fold_static_fluent_exps
         if grounding_actions_map is not None:
             for action, params_list in grounding_actions_map.items():
                 for params in params_list:
@@ -166,7 +177,9 @@ class GrounderHelper:
         ] = {}
         env = problem.environment
         if prune_actions:
-            self._simplifier = Simplifier(env, problem)
+            self._simplifier = Simplifier(
+                env, problem, fold_static_fluent_exps=fold_static_fluent_exps
+            )
         else:
             self._simplifier = env.simplifier
 
@@ -717,8 +730,10 @@ class Grounder(engines.engine.Engine, CompilerMixin):
     the integration of external grounders inside the library. To see a practical example, checkout the :class:`~unified_planning.engines.compilers.TarskiGrounder` `_compile`
     implementation.
     The Grounder class can also optionally take a `prune_actions` flag to enable/disable the pruning of
-    actions exploiting the simplification of static fluents, and a `join_max_candidates` safety-valve
-    threshold for that pruning's join -- see
+    actions exploiting the simplification of static fluents, a `join_max_candidates` safety-valve
+    threshold for that pruning's join, and a `fold_static_fluent_exps` flag to enable/disable
+    folding a per-ground-atom (rather than whole-fluent-schema) static fluent atom to its initial
+    value during grounding -- see
     :func:`GrounderHelper.__init__ <unified_planning.engines.compilers.GrounderHelper>` for details.
 
     Interpreted functions are treated as ordinary sub-expressions: calls appearing in conditions, effect
@@ -735,12 +750,14 @@ class Grounder(engines.engine.Engine, CompilerMixin):
         grounding_actions_map: Optional[Dict[Action, List[Tuple[FNode, ...]]]] = None,
         prune_actions: bool = True,
         join_max_candidates: int = GrounderHelper.DEFAULT_JOIN_MAX_CANDIDATES,
+        fold_static_fluent_exps: bool = True,
     ):
         engines.engine.Engine.__init__(self)
         CompilerMixin.__init__(self, CompilationKind.GROUNDING)
         self._grounding_actions_map = grounding_actions_map
         self._prune_actions = prune_actions
         self._join_max_candidates = join_max_candidates
+        self._fold_static_fluent_exps = fold_static_fluent_exps
 
     @property
     def name(self):
@@ -849,6 +866,7 @@ class Grounder(engines.engine.Engine, CompilerMixin):
             self._grounding_actions_map,
             self._prune_actions,
             self._join_max_candidates,
+            self._fold_static_fluent_exps,
         )
         trace_back_map: Dict[Action, Tuple[Action, List[FNode]]] = {}
 

--- a/unified_planning/engines/compilers/trajectory_constraints_remover.py
+++ b/unified_planning/engines/compilers/trajectory_constraints_remover.py
@@ -29,7 +29,7 @@ from unified_planning.engines.compilers.grounder import Grounder
 from unified_planning.engines.compilers.utils import (
     lift_action_instance,
 )
-from typing import List, Dict, Tuple, Optional
+from typing import List, Dict, Tuple, Optional, cast
 
 
 NUM = "num"
@@ -150,7 +150,14 @@ class TrajectoryConstraintsRemover(engines.engine.Engine, CompilerMixin):
         new_problem = grounded_problem.clone()
         assert isinstance(new_problem, Problem)
         new_problem.name = f"{self.name}_{problem.name}"
-        I = new_problem.initial_values
+        # `I` is substituted into every trajectory constraint below (`_evaluate_constraint`,
+        # `_get_monitoring_atoms`), once per constraint; normalizing it once here instead of
+        # letting `FNode.substitute` re-normalize (auto_promote + type-check) the whole
+        # initial-value map on every one of those calls avoids doing that rebuild once per
+        # constraint -- see `Substituter.substitute_normalized`.
+        I = env.substituter.normalize_substitutions(
+            cast(Dict[Expression, Expression], new_problem.initial_values)
+        )
         C = []
         for c in new_problem.trajectory_constraints:
             new_c = expression_quantifier_remover.remove_quantifiers(c, new_problem)
@@ -337,38 +344,42 @@ class TrajectoryConstraintsRemover(engines.engine.Engine, CompilerMixin):
         return relevant_constrains
 
     def _evaluate_constraint(self, env, constr, init_values):
+        # `init_values` is already normalized (see `_compile`); substitute_normalized skips the
+        # per-call auto_promote/type-check rebuild `.substitute()` would otherwise redo here.
+        subs = env.substituter.substitute_normalized
         if constr.is_sometime():
-            return HOLD, constr.args[0].substitute(init_values).simplify()
+            return HOLD, subs(constr.args[0], init_values).simplify()
         elif constr.is_sometime_after():
             return (
                 HOLD,
                 env.expression_manager.Or(
-                    constr.args[1].substitute(init_values),
-                    env.expression_manager.Not(constr.args[0].substitute(init_values)),
+                    subs(constr.args[1], init_values),
+                    env.expression_manager.Not(subs(constr.args[0], init_values)),
                 ).simplify(),
             )
         elif constr.is_sometime_before():
             return (
                 SEEN_PSI,
-                constr.args[1].substitute(init_values).simplify(),
+                subs(constr.args[1], init_values).simplify(),
             )
         elif constr.is_at_most_once():
             return (
                 SEEN_PHI,
-                constr.args[0].substitute(init_values).simplify(),
+                subs(constr.args[0], init_values).simplify(),
             )
         elif constr.is_bool_constant():
             return None, constr
         else:
-            return None, constr.args[0].substitute(init_values).simplify()
+            return None, subs(constr.args[0], init_values).simplify()
 
     def _get_monitoring_atoms(self, env, C, I):
         monitoring_atoms = []
         monitoring_atoms_counter = 0
         initial_state_prime = []
+        subs = env.substituter.substitute_normalized
         for constr in C:
             if constr.is_always():
-                if constr.args[0].substitute(I).simplify().is_false():
+                if subs(constr.args[0], I).simplify().is_false():
                     raise UPProblemDefinitionError(
                         "PROBLEM NOT SOLVABLE: an always is violated in the initial state"
                     )
@@ -384,7 +395,7 @@ class TrajectoryConstraintsRemover(engines.engine.Engine, CompilerMixin):
                 if init_state_value.is_true():
                     initial_state_prime.append(monitoring_atom)
                 if constr.is_sometime_before():
-                    if constr.args[0].substitute(I).simplify().is_true():
+                    if subs(constr.args[0], I).simplify().is_true():
                         raise UPProblemDefinitionError(
                             "PROBLEM NOT SOLVABLE: a sometime-before is violated in the initial state"
                         )

--- a/unified_planning/model/problem.py
+++ b/unified_planning/model/problem.py
@@ -406,6 +406,13 @@ class Problem(  # type: ignore[misc]
             for e in ev.effects:
                 remove_used_fluents(e.fluent, e.value, e.condition)
                 static_fluents.discard(e.fluent.fluent())
+            if ev.simulated_effect is not None:
+                # Same reasoning as the InstantaneousAction case above: a simulated effect can
+                # read (and assign) anything, so no fluent it targets can be considered static or
+                # unused.
+                unused_fluents.clear()
+                for f in ev.simulated_effect.fluents:
+                    static_fluents.discard(f.fluent())
         for pro in self._processes:
             for e in pro.effects:
                 remove_used_fluents(e.fluent, e.value, e.condition)

--- a/unified_planning/model/walkers/simplifier.py
+++ b/unified_planning/model/walkers/simplifier.py
@@ -16,7 +16,7 @@
 
 from fractions import Fraction
 from collections import OrderedDict
-from typing import List, Optional, FrozenSet, Union, cast
+from typing import Dict, Iterable, List, Optional, FrozenSet, Tuple, Union, cast
 import unified_planning as up
 import unified_planning.environment
 from unified_planning.exceptions import UPUnreachableCodeError
@@ -24,6 +24,130 @@ import unified_planning.model.walkers as walkers
 from unified_planning.model.fnode import FNode
 from unified_planning.model.types import _UserType
 import unified_planning.model.operators as op
+
+
+# One argument-position pattern of a recorded effect target, as classified by
+# `_EffectTargetIndex._arg_spec`: `("const", fnode)` matches only that one constant argument,
+# `("type", type)` matches any argument whose type is compatible with `type` (an action parameter
+# or a forall-bound variable's type), and `("wild", None)` matches anything (a nested expression
+# or object-fluent call the index can't otherwise classify).
+_ArgSpec = Tuple[str, object]
+
+
+class _EffectTargetIndex:
+    """Over-approximates, for one :class:`~unified_planning.model.Problem`, which ground atoms of
+    which fluents its actions/events/processes/timed-effects can ever write.
+
+    :func:`~unified_planning.model.Problem.get_static_fluents` only answers at *schema*
+    granularity: a fluent is static only if `no` grounding of it is ever written. That misses the
+    common case of a fluent whose schema is written for some argument tuples but never others --
+    e.g. a `pos(?o: Object)` fluent that is only ever assigned through an action parameter typed
+    `Boat`, so `pos(some_fixed_waypoint)` never changes even though `pos` itself is not static.
+    `may_write` answers that per-atom question instead, by recording one *pattern* per effect
+    target (one spec per argument position, see `_ArgSpec`) and checking a candidate ground atom
+    against every recorded pattern of the same fluent.
+
+    Argument positions are checked independently of each other, so a correlation between two
+    parameters of the same effect (e.g. an effect that only ever fires when two of an action's
+    parameters happen to be equal) is invisible to this index -- which only ever makes `may_write`
+    return `True` more often than strictly necessary, the safe direction: every atom that really
+    is written is matched by its own pattern, so it is never mistakenly folded to a constant.
+
+    Important NOTE: same contract as `Simplifier` itself -- the `Problem` given at construction
+    time must not be modified afterwards, or this index's answers (and its cache) become stale.
+    """
+
+    def __init__(self, problem: "up.model.problem.Problem"):
+        self._patterns: Dict["up.model.fluent.Fluent", List[Tuple[_ArgSpec, ...]]] = {}
+        self._may_write_cache: Dict[FNode, bool] = {}
+        for a in problem.actions:
+            self._scan_action(a)
+        for ev in problem.events:
+            self._scan_effects(ev.effects)
+            self._scan_simulated_effects(ev.simulated_effect)
+        for pro in problem.processes:
+            self._scan_effects(pro.effects)
+        for effs in problem.timed_effects.values():
+            self._scan_effects(effs)
+
+    def _scan_action(self, a: "up.model.action.Action"):
+        if isinstance(a, up.model.action.InstantaneousAction):
+            self._scan_effects(a.effects)
+            self._scan_simulated_effects(a.simulated_effect)
+        elif isinstance(a, up.model.action.DurativeAction):
+            for effs in a.effects.values():
+                self._scan_effects(effs)
+            for effs in a.continuous_effects.values():
+                self._scan_effects(effs)
+            for se in a.simulated_effects.values():
+                self._scan_simulated_effects(se)
+        else:
+            raise NotImplementedError(
+                f"_EffectTargetIndex does not know how to scan the effects of {type(a)}"
+            )
+
+    def _scan_effects(self, effects: Iterable["up.model.effect.Effect"]):
+        for e in effects:
+            self._record_target(e.fluent)
+
+    def _scan_simulated_effects(self, se: Optional["up.model.effect.SimulatedEffect"]):
+        if se is None:
+            return
+        # SimulatedEffect.fluents entries are, by construction, plain fluent expressions whose
+        # arguments are constants or action-parameter expressions only (never a nested
+        # expression, a Dot, or a forall-bound variable -- a simulated effect can't be
+        # forall-quantified), so they fit the same per-position classification as a regular
+        # effect target and need no separate handling.
+        for f in se.fluents:
+            self._record_target(f)
+
+    def _record_target(self, target: FNode):
+        if target.is_dot():
+            # Multi-agent effect target: unwrap the `Dot` to the underlying fluent expression --
+            # see UntimedEffectMixin.add_effect, which accepts `fluent_exp.is_dot()`.
+            target = target.arg(0)
+        fluent = target.fluent()
+        pattern = tuple(self._arg_spec(arg) for arg in target.args)
+        self._patterns.setdefault(fluent, []).append(pattern)
+
+    @staticmethod
+    def _arg_spec(arg: FNode) -> _ArgSpec:
+        if arg.is_constant():
+            return ("const", arg)
+        if arg.is_parameter_exp():
+            return ("type", arg.parameter().type)
+        if arg.is_variable_exp():
+            return ("type", arg.variable().type)
+        return ("wild", None)
+
+    def may_write(self, fluent_exp: FNode) -> bool:
+        """`True` if some recorded effect target might, for some grounding, write exactly
+        `fluent_exp` -- `fluent_exp` must have only constant arguments."""
+        cached = self._may_write_cache.get(fluent_exp)
+        if cached is not None:
+            return cached
+        patterns = self._patterns.get(fluent_exp.fluent())
+        result = False
+        if patterns:
+            args = fluent_exp.args
+            for pattern in patterns:
+                if all(
+                    self._arg_matches(spec, arg) for spec, arg in zip(pattern, args)
+                ):
+                    result = True
+                    break
+        self._may_write_cache[fluent_exp] = result
+        return result
+
+    @staticmethod
+    def _arg_matches(spec: _ArgSpec, arg: FNode) -> bool:
+        kind, payload = spec
+        if kind == "wild":
+            return True
+        if kind == "const":
+            return arg == payload
+        assert kind == "type"
+        return cast("up.model.types.Type", payload).is_compatible(arg.type)
 
 
 class Simplifier(walkers.dag.DagWalker):
@@ -37,7 +161,24 @@ class Simplifier(walkers.dag.DagWalker):
         self,
         environment: "unified_planning.environment.Environment",
         problem: Optional["unified_planning.model.problem.Problem"] = None,
+        fold_static_fluent_exps: bool = False,
     ):
+        """
+        :param environment: The `Environment` this `Simplifier` operates in.
+        :param problem: If given, static fluents (`problem.get_static_fluents()`) are folded to
+            their initial value.
+        :param fold_static_fluent_exps: If `True`, also fold a ground fluent atom that is not
+            static at the *schema* level (`problem.get_static_fluents()` doesn't include its
+            fluent, because some other grounding of it IS written somewhere) but that this exact
+            atom is nonetheless never the target of any effect in `problem` -- see
+            `_EffectTargetIndex`. Requires `problem` to be a plain
+            :class:`~unified_planning.model.Problem` (or a subclass that adds no extra effect
+            source, e.g. `HierarchicalProblem`/`ContingentProblem`); ignored (folding stays off)
+            for a `problem` of any other type, such as `SchedulingProblem`/`MultiAgentProblem`,
+            which don't expose the effect surface `_EffectTargetIndex` scans. Defaults to `False`
+            so existing callers (and `problem.kind`, which is computed through its own
+            `Simplifier`) are unaffected.
+        """
         walkers.dag.DagWalker.__init__(self)
         self.environment = environment
         self.manager = environment.expression_manager
@@ -46,6 +187,9 @@ class Simplifier(walkers.dag.DagWalker):
         else:
             self.static_fluents = set()
         self.problem: Optional["unified_planning.model.problem.Problem"] = problem
+        self._effect_target_index: Optional[_EffectTargetIndex] = None
+        if fold_static_fluent_exps and isinstance(problem, up.model.problem.Problem):
+            self._effect_target_index = _EffectTargetIndex(problem)
 
     def _number_to_fnode(self, value: Union[int, float, Fraction]) -> FNode:
         if isinstance(value, int):
@@ -319,18 +463,26 @@ class Simplifier(walkers.dag.DagWalker):
 
     def walk_fluent_exp(self, expression: FNode, args: List[FNode]) -> FNode:
         new_exp = self.manager.FluentExp(expression.fluent(), tuple(args))
-        if expression.fluent() not in self.static_fluents:
+        fluent_is_static = expression.fluent() in self.static_fluents
+        if not fluent_is_static and self._effect_target_index is None:
+            # No schema-level staticness and per-atom folding isn't enabled
             return new_exp
-        else:
-            assert self.problem is not None
-            for a in args:
-                if not a.is_constant():
-                    return new_exp
-            static_value = self.problem.initial_value(new_exp)
-            if static_value is not None:
-                return static_value
-            else:  # value is static but is not defined in the initial state
+        for a in args:
+            if not a.is_constant():
                 return new_exp
+        if not fluent_is_static:
+            # Not static at the schema level (some grounding of this fluent IS written
+            # somewhere), but this specific ground atom is never among the effect targets the
+            # index recorded -- fold it exactly like a schema-static one, below.
+            assert self._effect_target_index is not None
+            if self._effect_target_index.may_write(new_exp):
+                return new_exp
+        assert self.problem is not None
+        static_value = self.problem.initial_value(new_exp)
+        if static_value is not None:
+            return static_value
+        else:  # value is static but is not defined in the initial state
+            return new_exp
 
     def walk_interpreted_function_exp(
         self, expression: FNode, args: List[FNode]

--- a/unified_planning/model/walkers/substituter.py
+++ b/unified_planning/model/walkers/substituter.py
@@ -107,6 +107,24 @@ class Substituter(IdentityDagWalker):
 
         if len(substitutions) == 0:
             return expression
+        return self.walk(expression, subs=self.normalize_substitutions(substitutions))
+
+    def normalize_substitutions(
+        self, substitutions: Dict[Expression, Expression] = {}
+    ) -> Dict[FNode, FNode]:
+        """
+        Auto-promotes and type-checks every entry of the given substitutions map, returning the
+        `FNode -> FNode` dictionary that :func:`substitute` would build internally on every call.
+
+        Factored out of :func:`substitute` so a caller that calls :func:`substitute_normalized`
+        (or :func:`walk` directly, with ``subs=...``) in a loop with the same substitutions can
+        build this dictionary once instead of paying the `auto_promote`/type-check pass again for
+        every expression -- see :func:`substitute_normalized`.
+
+        :param substitutions: The map containing the substitutions, every time a key is found,
+            it is substituted with it's value.
+        :return: The equivalent `FNode -> FNode` substitutions map.
+        """
         new_substitutions: Dict[FNode, FNode] = {}
         for k, v in substitutions.items():
             new_k, new_v = self.manager.auto_promote(k, v)
@@ -116,7 +134,30 @@ class Substituter(IdentityDagWalker):
                 raise UPTypeError(
                     f"The expression type of {str(k)} is not compatible with the given substitution {str(v)}"
                 )
-        return self.walk(expression, subs=new_substitutions)
+        return new_substitutions
+
+    def substitute_normalized(
+        self, expression: FNode, substitutions: Dict[FNode, FNode]
+    ) -> FNode:
+        """
+        Same as :func:`substitute`, but skips the `auto_promote`/type-check rebuild of
+        ``substitutions`` on every call: ``substitutions`` must already be an `FNode -> FNode`
+        dictionary produced by :func:`normalize_substitutions` (or an equivalent one, built by
+        hand from `FNode`s only).
+
+        Intended for a caller that substitutes the same (typically large) map into many
+        expressions in a loop -- e.g. one problem's whole
+        :func:`initial_values <unified_planning.model.mixins.InitialStateMixin.initial_values>`
+        substituted into many separate constraints -- where :func:`substitute` would otherwise
+        redo that rebuild once per expression.
+
+        :param expression: The target expression for the substitution.
+        :param substitutions: The already-normalized map containing the substitutions.
+        :return: The expression where every key expression is substituted with it's value.
+        """
+        if len(substitutions) == 0:
+            return expression
+        return self.walk(expression, subs=substitutions)
 
     @walkers.handles(OperatorKind)
     def walk_replace_or_identity(

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -1035,6 +1035,86 @@ class TestGrounder(unittest_TestCase):
                 ) as pv:
                     self.assertTrue(pv.validate(problem, plan))
 
+    def test_per_atom_static_fluent_precondition_is_folded_and_prunes_actions(self):
+        # pos(o: Object) is written only through the Boat-typed parameter of "move", so
+        # pos(waypoint) -- never targeted by any effect -- is a de-facto constant for the
+        # whole problem even though pos itself is not schema-static
+        # (Problem.get_static_fluents() would still keep it fully symbolic). Folding it
+        # collapses "check_waypoint"'s precondition to False, so that action must be dropped
+        # entirely by the default (fold_static_fluent_exps=True) grounder.
+        object_type = UserType("Object")
+        boat_type = UserType("Boat", father=object_type)
+        place_type = UserType("Place", father=object_type)
+        pos = Fluent("pos", IntType(), o=object_type)
+        boat = Object("boat", boat_type)
+        waypoint = Object("waypoint", place_type)
+
+        move = InstantaneousAction("move", b=boat_type, v=IntType(0, 10))
+        b, v = move.parameter("b"), move.parameter("v")
+        move.add_effect(pos(b), v)
+
+        check_waypoint = InstantaneousAction("check_waypoint")
+        check_waypoint.add_precondition(Equals(pos(waypoint), 5))
+        dummy = Fluent("dummy")
+        check_waypoint.add_effect(dummy, True)
+
+        problem = Problem("per_atom_static_precondition")
+        problem.add_fluent(pos, default_initial_value=0)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_object(boat)
+        problem.add_object(waypoint)
+        problem.set_initial_value(pos(waypoint), 7)
+        problem.add_action(move)
+        problem.add_action(check_waypoint)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        # pos(waypoint) == 7, not 5: the precondition folds to False and the action is
+        # dropped, leaving only move's own groundings.
+        self.assertFalse(grounded_problem.has_action("check_waypoint"))
+        for a in grounded_problem.actions:
+            self.assertTrue(a.name.startswith("move"))
+
+    def test_fold_static_fluent_exps_false_matches_pre_folding_behavior(self):
+        # Same problem as above, but with fold_static_fluent_exps=False: pos(waypoint) must
+        # stay a symbolic fluent reference in the grounded precondition, exactly as the
+        # grounder behaved before this per-atom folding existed.
+        object_type = UserType("Object")
+        boat_type = UserType("Boat", father=object_type)
+        place_type = UserType("Place", father=object_type)
+        pos = Fluent("pos", IntType(), o=object_type)
+        boat = Object("boat", boat_type)
+        waypoint = Object("waypoint", place_type)
+
+        move = InstantaneousAction("move", b=boat_type, v=IntType(0, 10))
+        b, v = move.parameter("b"), move.parameter("v")
+        move.add_effect(pos(b), v)
+
+        check_waypoint = InstantaneousAction("check_waypoint")
+        check_waypoint.add_precondition(Equals(pos(waypoint), 5))
+        dummy = Fluent("dummy")
+        check_waypoint.add_effect(dummy, True)
+
+        problem = Problem("per_atom_static_precondition_no_fold")
+        problem.add_fluent(pos, default_initial_value=0)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_object(boat)
+        problem.add_object(waypoint)
+        problem.set_initial_value(pos(waypoint), 7)
+        problem.add_action(move)
+        problem.add_action(check_waypoint)
+
+        grounded_problem = (
+            Grounder(fold_static_fluent_exps=False)
+            .compile(problem, CompilationKind.GROUNDING)
+            .problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        ga = cast(InstantaneousAction, grounded_problem.action("check_waypoint"))
+        self.assertEqual(ga.preconditions, [Equals(pos(waypoint), 5)])
+
 
 class TestGrounderJoinPruning(unittest_TestCase):
     """Tests for the grounder's join-based static-fluent pruning

--- a/unified_planning/test/test_simplifier.py
+++ b/unified_planning/test/test_simplifier.py
@@ -767,5 +767,117 @@ class TestWithSubstituter(unittest_TestCase):
         self.assertEqual(r5, t)
 
 
+class TestPerAtomStaticFluentFolding(unittest_TestCase):
+    """`Simplifier(env, problem, fold_static_fluent_exps=True)` folds a ground fluent atom to
+    its initial value not only when the whole fluent schema is static
+    (`problem.get_static_fluents()`), but also when this specific atom is simply never the
+    target of any effect in the problem -- even though other groundings of the same fluent are
+    written elsewhere.
+    """
+
+    def setUp(self):
+        unittest_TestCase.setUp(self)
+        object_type = UserType("Object")
+        self.boat_type = UserType("Boat", father=object_type)
+        self.place_type = UserType("Place", father=object_type)
+        self.pos = Fluent("pos", IntType(), o=object_type)
+        self.boat = Object("b0", self.boat_type)
+        self.waypoint = Object("p0", self.place_type)
+
+        move = InstantaneousAction("move", b=self.boat_type)
+        b = move.parameter("b")
+        move.add_effect(self.pos(b), 5)
+        self.move = move
+
+    def _problem(self) -> "Problem":
+        problem = Problem("hierarchical_typing")
+        problem.add_fluent(self.pos, default_initial_value=0)
+        problem.add_object(self.boat)
+        problem.add_object(self.waypoint)
+        problem.set_initial_value(self.pos(self.waypoint), 7)
+        problem.add_action(self.move)
+        return problem
+
+    def test_unwritten_ground_atom_is_folded_when_opted_in(self):
+        problem = self._problem()
+        s = Simplifier(problem.environment, problem, fold_static_fluent_exps=True)
+        # pos(p0) is never an effect target of any action -- only pos(b) is, through the
+        # Boat-typed parameter -- so it is a de-facto constant even though pos is not
+        # schema-static (problem.get_static_fluents() == set()).
+        self.assertEqual(problem.get_static_fluents(), set())
+        self.assertEqual(s.simplify(GT(self.pos(self.waypoint), 5)), Bool(True))
+
+    def test_written_ground_atom_is_not_folded(self):
+        problem = self._problem()
+        s = Simplifier(problem.environment, problem, fold_static_fluent_exps=True)
+        # pos(b0) IS an effect target (through move's parameter b), so it must stay symbolic.
+        e = GT(self.pos(self.boat), 5)
+        self.assertEqual(s.simplify(e), e)
+
+    def test_default_simplifier_does_not_fold_per_atom_static_fluents(self):
+        problem = self._problem()
+        # Without opting in, behavior must be unchanged: pos(p0) stays symbolic even though it
+        # is never written.
+        s = Simplifier(problem.environment, problem)
+        e = GT(self.pos(self.waypoint), 5)
+        self.assertEqual(s.simplify(e), e)
+
+    def test_constant_argument_effect_target_keeps_that_atom_symbolic(self):
+        # x(o0) is written directly (a constant-argument effect target), so it must stay
+        # symbolic; x(o1), which no effect ever targets, must still fold.
+        item_type = UserType("Item")
+        o0 = Object("o0", item_type)
+        o1 = Object("o1", item_type)
+        x = Fluent("x", IntType(), o=item_type)
+        act = InstantaneousAction("act")
+        act.add_effect(x(o0), 1)
+
+        problem = Problem("constant_target")
+        problem.add_fluent(x, default_initial_value=0)
+        problem.add_objects([o0, o1])
+        problem.set_initial_value(x(o1), 42)
+        problem.add_action(act)
+
+        s = Simplifier(problem.environment, problem, fold_static_fluent_exps=True)
+        self.assertEqual(s.simplify(GT(x(o0), 0)), GT(x(o0), Int(0)))
+        self.assertEqual(s.simplify(GT(x(o1), 0)), Bool(True))
+
+    def test_forall_effect_excludes_its_whole_variable_type_from_folding(self):
+        # b(l: Base) is only ever written by a forall effect quantified over the Sub subtype,
+        # so any Sub-typed argument stays symbolic (the effect might target it for some
+        # grounding), while a Base-only (non-Sub) object still folds.
+        base_type = UserType("Base")
+        sub_type = UserType("Sub", father=base_type)
+        b = Fluent("b", BoolType(), l=base_type)
+        base_obj = Object("base_obj", base_type)
+        sub_obj = Object("sub_obj", sub_type)
+
+        act = InstantaneousAction("act")
+        v = Variable("v", sub_type)
+        act.add_effect(b(v), True, forall=[v])
+
+        problem = Problem("forall_target")
+        problem.add_fluent(b, default_initial_value=False)
+        problem.add_objects([base_obj, sub_obj])
+        problem.add_action(act)
+
+        s = Simplifier(problem.environment, problem, fold_static_fluent_exps=True)
+        self.assertEqual(s.simplify(b(sub_obj)), b(sub_obj))
+        self.assertEqual(s.simplify(b(base_obj)), Bool(False))
+
+    def test_unwritten_atom_with_no_initial_value_stays_symbolic(self):
+        # pos(p0) is never written, but its initial value was also never set (and pos has no
+        # default): folding must not invent a value for it.
+        problem = Problem("no_initial_value")
+        problem.add_fluent(self.pos)
+        problem.add_object(self.boat)
+        problem.add_object(self.waypoint)
+        problem.add_action(self.move)
+
+        s = Simplifier(problem.environment, problem, fold_static_fluent_exps=True)
+        e = GT(self.pos(self.waypoint), 5)
+        self.assertEqual(s.simplify(e), e)
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- `Simplifier` only folded a static fluent at the whole-schema level
  (`Problem.get_static_fluents()`), so a fluent written for only some of its groundings (e.g.
  `pos(o)` assigned only through a `Boat`-typed parameter) kept every other ground atom
  (`pos(fixed_waypoint)`) fully symbolic.
- Adds `_EffectTargetIndex`, which records an argument pattern per effect target across the
  problem and answers whether a given ground atom could ever be written.
- `Simplifier` gains an opt-in `fold_static_fluent_exps` flag (default `False`, so existing
  callers are unaffected) that uses the index to fold such atoms in `walk_fluent_exp`; `Grounder`
  enables it by default, pruning more actions whose preconditions become `False` as a result.
- Also: `get_static_fluents()` now scans `Event.simulated_effect` like it already does for
  `InstantaneousAction`; `Substituter.substitute()` no longer rebuilds its substitutions dict on
  every call (`normalize_substitutions()` + `substitute_normalized()`), used by
  `trajectory_constraints_remover`, which substitutes the same initial-value map repeatedly.

## Test plan

- [x] Added `test_simplifier.py` coverage: per-atom folding, default-off behavior, constant-
      argument effect targets, `forall`-effect variable types, atoms with no initial value.
- [x] Added `test_grounder.py` coverage: a per-atom static precondition folds and prunes an
      action; `fold_static_fluent_exps=False` reproduces the prior grounder output exactly.