### PR TITLE
feat(grounder): iterate folding/pruning to a fixed point

### DIFF
--- a/unified_planning/engines/compilers/grounder.py
+++ b/unified_planning/engines/compilers/grounder.py
@@ -31,15 +31,18 @@ from unified_planning.model import (
 )
 from unified_planning.model.types import domain_size, domain_item
 from unified_planning.model.walkers import Simplifier
+from unified_planning.model.walkers.simplifier import _EffectTargetIndex
 from unified_planning.model.problem_kind_versioning import LATEST_PROBLEM_KIND_VERSION
 from unified_planning.engines.compilers.utils import (
     lift_action_instance,
     create_action_with_given_subs,
     split_all_ands,
+    remove_fluents,
 )
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Iterator, cast
 from itertools import product
 from functools import partial
+import collections
 
 
 class _AtomPattern(NamedTuple):
@@ -736,6 +739,14 @@ class Grounder(engines.engine.Engine, CompilerMixin):
     value during grounding -- see
     :func:`GrounderHelper.__init__ <unified_planning.engines.compilers.GrounderHelper>` for details.
 
+    Grounding also folds every goal, timed goal, and trajectory constraint through the same
+    `Simplifier` (whenever `prune_actions` is `True`), and, when the `remove_static_fluents` flag
+    (`True` by default) is also set, removes from the grounded `Problem` any fluent that is
+    :func:`schema-static <unified_planning.model.Problem.get_static_fluents>` -- never the target
+    of any effect anywhere -- and, after that folding, unreferenced anywhere else in the grounded
+    problem (preconditions, effects, durations, action costs, goals, timed goals, trajectory
+    constraints).
+
     Interpreted functions are treated as ordinary sub-expressions: calls appearing in conditions, effect
     values and duration bounds have their arguments rewritten by the parameter substitution, exactly like
     any other fluent-based expression. Once an interpreted function call's arguments are all constant, the
@@ -751,6 +762,7 @@ class Grounder(engines.engine.Engine, CompilerMixin):
         prune_actions: bool = True,
         join_max_candidates: int = GrounderHelper.DEFAULT_JOIN_MAX_CANDIDATES,
         fold_static_fluent_exps: bool = True,
+        remove_static_fluents: bool = True,
     ):
         engines.engine.Engine.__init__(self)
         CompilerMixin.__init__(self, CompilationKind.GROUNDING)
@@ -758,6 +770,7 @@ class Grounder(engines.engine.Engine, CompilerMixin):
         self._prune_actions = prune_actions
         self._join_max_candidates = join_max_candidates
         self._fold_static_fluent_exps = fold_static_fluent_exps
+        self._remove_static_fluents = remove_static_fluents
 
     @property
     def name(self):
@@ -892,22 +905,213 @@ class Grounder(engines.engine.Engine, CompilerMixin):
                 new_problem.add_action(new_action)
                 trace_back_map[new_action] = (old_action, list(parameters))
 
+        # Round-0 grounding above only ever folds a reference against the LIFTED problem's own
+        # static-fluent knowledge (grounder_helper.simplifier.static_fluents). That's not a fixed
+        # point: pruning one action can make a fluent newly static (every action that used to
+        # write it is now gone from new_problem), which can in turn make another action's
+        # precondition foldably infeasible, pruning it too -- a cascade a single pass never
+        # catches. Refine new_problem's own (already-grounded) actions -- and trace_back_map, kept
+        # in lockstep -- to a fixed point before anything downstream (metrics, goals, fluent
+        # removal) reads static-fluent knowledge, so all of it benefits from the fullest picture.
+        simplifier = grounder_helper.simplifier
+        if self._prune_actions:
+            simplifier = _refine_actions_to_fixed_point(
+                new_problem, trace_back_map, self._fold_static_fluent_exps
+            )
+
         new_problem.clear_quality_metrics()
         for qm in problem.quality_metrics:
             if qm.is_minimize_action_costs():
                 assert isinstance(qm, MinimizeActionCosts)
                 new_metric = ground_minimize_action_costs_metric(
-                    qm, trace_back_map, grounder_helper.simplifier
+                    qm, trace_back_map, simplifier
                 )
                 new_problem.add_quality_metric(new_metric)
             else:
                 new_problem.add_quality_metric(qm)
+
+        _fold_goal_like_fields(problem, new_problem, simplifier)
+        if self._remove_static_fluents:
+            # simplifier.static_fluents is the FIXED POINT's own view of which fluents of
+            # new_problem are static: a fluent it considers static provably has zero effects among
+            # the actions that survive to the final grounded problem -- which is exactly the
+            # correct, complete notion of "static in the grounded problem" (see
+            # _refine_actions_to_fixed_point's docstring and the design notes for this feature).
+            # This is a deliberate change from an earlier, more conservative version of this code,
+            # which only trusted the LIFTED problem's own static-fluent set: a fluent that becomes
+            # static purely because every action that could write it is gone from new_problem --
+            # for any reason, including an action schema grounding to zero instances -- is
+            # genuinely, correctly static now, not a false positive to guard against.
+            _remove_fully_static_fluents(new_problem, simplifier.static_fluents)
 
         return CompilerResult(
             new_problem,
             partial(lift_action_instance, map=trace_back_map),
             self.name,
         )
+
+
+def _trigger_fluents(
+    env: "up.environment.Environment", a: Action
+) -> Set["up.model.fluent.Fluent"]:
+    """The fluents whose value can affect whether `a` survives further folding: everything its
+    own feasibility check reads (preconditions/conditions, and -- for a `DurativeAction` -- its
+    duration bounds). Not its effects' *values* -- those don't gate whether `a` applies, only what
+    it does once applied."""
+    fve = env.free_vars_extractor
+    if isinstance(a, up.model.action.InstantaneousAction):
+        exprs: List[FNode] = list(a.preconditions)
+    else:
+        assert isinstance(a, up.model.action.DurativeAction)
+        exprs = [c for cl in a.conditions.values() for c in cl]
+        exprs = exprs + [a.duration.lower, a.duration.upper]
+    return {f.fluent() for e in exprs for f in fve.get(e)}
+
+
+def _written_fluents(a: Action) -> Set["up.model.fluent.Fluent"]:
+    """The fluents `a` currently targets with an effect, of any kind (assignment/increase/
+    decrease, continuous, simulated)."""
+    if isinstance(a, up.model.action.InstantaneousAction):
+        written = {e.fluent.fluent() for e in a.effects}
+        if a.simulated_effect is not None:
+            written.update(f.fluent() for f in a.simulated_effect.fluents)
+        return written
+    assert isinstance(a, up.model.action.DurativeAction)
+    written = {e.fluent.fluent() for el in a.effects.values() for e in el}
+    written.update(
+        e.fluent.fluent() for el in a.continuous_effects.values() for e in el
+    )
+    for se in a.simulated_effects.values():
+        written.update(f.fluent() for f in se.fluents)
+    return written
+
+
+def _effect_targets(a: Action) -> Iterator[FNode]:
+    """The raw effect-target `FNode`s of `a` -- what `_EffectTargetIndex.learn` expects (the
+    effects' own `.fluent` expressions and simulated effects' `.fluents`, not yet reduced to bare
+    `Fluent`s the way `_written_fluents` reduces them)."""
+    if isinstance(a, up.model.action.InstantaneousAction):
+        for e in a.effects:
+            yield e.fluent
+        if a.simulated_effect is not None:
+            yield from a.simulated_effect.fluents
+        return
+    assert isinstance(a, up.model.action.DurativeAction)
+    for el in a.effects.values():
+        for e in el:
+            yield e.fluent
+    for el in a.continuous_effects.values():
+        for e in el:
+            yield e.fluent
+    for se in a.simulated_effects.values():
+        yield from se.fluents
+
+
+def _refine_actions_to_fixed_point(
+    new_problem: Problem,
+    trace_back_map: Dict[Action, Tuple[Action, List[FNode]]],
+    fold_static_fluent_exps: bool,
+) -> Simplifier:
+    """
+    Repeatedly re-simplifies and re-prunes `new_problem`'s own (already-grounded, zero-parameter)
+    actions to a fixed point: dropping one action -- or narrowing which fluents it still writes,
+    because one of its conditional effects got dropped -- can, in a later step, reveal that
+    another fluent has become fully static too (every action that used to write it is gone), which
+    can unlock folding/pruning of some OTHER action that reads it, cascading further. A single
+    pass over `new_problem`'s freshly-grounded actions (using only the *lifted* problem's own
+    static-fluent knowledge) never discovers this; this function keeps going until nothing more
+    changes.
+
+    Modifies `new_problem`'s actions and `trace_back_map` (kept in lockstep) in place, and returns
+    the `Simplifier` reflecting the fixed point's own knowledge -- callers doing any further
+    static-fluent-aware work on `new_problem` (folding metrics/goals, deciding what's now fully
+    unreferenced and removable) should use *this* `Simplifier`, not the one round-0 grounding used,
+    to get the benefit of everything this loop discovered.
+
+    Implemented as an incremental worklist rather than a "rebuild everything, every round" loop:
+    the expensive part of any of this is not re-simplifying one action, it's *scanning the whole
+    problem* to know which fluents are static (`_EffectTargetIndex`, an `O(total effects)` scan) --
+    rebuilding that scan once per round, even if only re-verifying a handful of affected actions
+    each time, would still cost `O(rounds x total effects)` overall. Instead, one `_EffectTargetIndex`
+    is built ONCE and kept incrementally up to date (`forget`/`learn`, each `O(that one action's
+    own effect count)`) as actions are dropped or narrowed, and every `Simplifier` built around it
+    (`make_simplifier`, below) becomes cheap -- no scanning, just wiring a reference -- which is
+    what makes a true one-action-at-a-time worklist (rather than a batch-per-round one) both safe
+    (see `Simplifier`'s own `effect_target_index` parameter docstring for why *reusing* one mutable
+    `Simplifier` across rounds would be unsafe instead) and worthwhile.
+    """
+    env = new_problem.environment
+    # Always built, regardless of fold_static_fluent_exps: this is what makes every
+    # make_simplifier() call's static_fluents correct without re-scanning new_problem.actions,
+    # which -- unlike a naive rebuild-per-round approach -- is deliberately NOT kept in sync
+    # during the loop (see `current`, below); a Simplifier(new_problem) without an index would
+    # otherwise silently answer get_static_fluents() from the stale, pre-loop action list on every
+    # single step. fold_static_fluent_exps only controls whether make_simplifier() also *uses*
+    # this index for per-atom folding -- its existence, and its role driving static_fluents, does
+    # not depend on it.
+    index = _EffectTargetIndex(new_problem)
+
+    # Local working copy, keyed by name (stable across refolds -- create_action_with_given_subs
+    # keeps an action's name when substituting with an empty dict, utils.py's own docstring):
+    # avoids touching new_problem.actions, an O(n)-membership/O(n)-rebuild list, on every single
+    # worklist step. Synced back to new_problem once, after the worklist drains.
+    current: Dict[str, Action] = {a.name: a for a in new_problem.actions}
+    trigger_index: Dict["up.model.fluent.Fluent", Set[str]] = {}
+    for a in current.values():
+        for f in _trigger_fluents(env, a):
+            trigger_index.setdefault(f, set()).add(a.name)
+
+    def make_simplifier() -> Simplifier:
+        return Simplifier(
+            env,
+            new_problem,
+            fold_static_fluent_exps=fold_static_fluent_exps,
+            effect_target_index=index,
+        )
+
+    worklist: "collections.deque[str]" = collections.deque(current.keys())
+    queued: Set[str] = set(worklist)
+    while worklist:
+        name = worklist.popleft()
+        queued.discard(name)
+        old_action = current[name]
+        simplifier = (
+            make_simplifier()
+        )  # cheap: wraps the current index, fresh memoization
+        refolded = create_action_with_given_subs(
+            new_problem, old_action, simplifier, {}
+        )
+        old_entry = trace_back_map.pop(old_action)
+        old_written = _written_fluents(old_action)
+        index.forget(old_action)
+        for f in _trigger_fluents(env, old_action):
+            trigger_index.get(f, set()).discard(name)
+
+        if refolded is None:
+            del current[name]
+            changed_fluents = old_written
+        else:
+            current[name] = refolded
+            trace_back_map[refolded] = old_entry
+            index.learn(refolded, _effect_targets(refolded))
+            for f in _trigger_fluents(env, refolded):
+                trigger_index.setdefault(f, set()).add(name)
+            changed_fluents = old_written - _written_fluents(refolded)
+
+        for f in changed_fluents:
+            for dep_name in trigger_index.get(f, ()):
+                if dep_name != name and dep_name not in queued:
+                    worklist.append(dep_name)
+                    queued.add(dep_name)
+
+    new_problem.clear_actions()
+    for a in current.values():
+        new_problem.add_action(a)
+    # A Simplifier's static_fluents is a snapshot taken at construction time (Simplifier.__init__
+    # copies it out of the index then, it doesn't track the index live) -- so the simplifier from
+    # the worklist's last iteration would still be missing that very iteration's own forget/learn
+    # update. Build one more, now that index reflects every update, to get an accurate final view.
+    return make_simplifier()
 
 
 def ground_minimize_action_costs_metric(
@@ -935,4 +1139,118 @@ def ground_minimize_action_costs_metric(
         old_cost = metric.get_action_cost(old_action)
         if old_cost is not None:
             new_costs[new_action] = simplifier.simplify(old_cost.substitute(subs))
-    return MinimizeActionCosts(new_costs)
+    # metric.default isn't action-parameterized (unlike a per-action cost, it never gets
+    # substituted with grounding parameters), so it only needs folding, not substitution;
+    # every compiler-owned helper that remaps a MinimizeActionCosts metric carries this over
+    # (utils.updated_minimize_action_costs, durative_actions_to_processes,
+    # undefined_initial_numeric_remover, ProblemKindMixin's own metric clone) -- this one was the
+    # odd one out, silently dropping it instead.
+    new_default = (
+        simplifier.simplify(metric.default) if metric.default is not None else None
+    )
+    return MinimizeActionCosts(new_costs, new_default)
+
+
+def _fold_goal_like_fields(
+    problem: Problem, new_problem: Problem, simplifier: Simplifier
+) -> None:
+    """
+    Re-simplifies `new_problem`'s goals, timed goals, and trajectory constraints -- copied
+    verbatim from `problem` by `Problem._clone_to_without_actions_and_metrics`/`clone`, and
+    otherwise never touched by grounding -- through `simplifier` (the same one already used for
+    every grounded action's preconditions/effects/durations/costs), so a static-fluent reference
+    that only appears in one of these fields gets folded too, instead of surviving grounding
+    completely unfolded.
+
+    :param problem: The original (lifted) `Problem`, whose goal-like fields are the source to
+        re-simplify from.
+    :param new_problem: The grounded `Problem` under construction; its own goal-like fields are
+        replaced in place.
+    :param simplifier: The (typically problem-aware, static-fluent-folding) `Simplifier` to fold
+        every field through.
+    """
+    em = problem.environment.expression_manager
+
+    new_problem.clear_goals()
+    for g in problem.goals:
+        # Problem.add_goal already drops a folded-True result on its own (only appending when
+        # goal_exp != TRUE()) and keeps a folded-False result as-is, correctly preserving
+        # unsatisfiability -- nothing extra to do here.
+        new_problem.add_goal(simplifier.simplify(g))
+
+    new_problem.clear_timed_goals()
+    for interval, goal_list in problem.timed_goals.items():
+        for g in goal_list:
+            sg = simplifier.simplify(g)
+            # Unlike add_goal, add_timed_goal only dedups identical entries -- it does not drop
+            # a trivially-true goal on its own, so do it here to match add_goal's behavior.
+            if not sg.is_true():
+                new_problem.add_timed_goal(interval, sg)
+
+    new_problem.clear_trajectory_constraints()
+    for c in problem.trajectory_constraints:
+        sc = simplifier.simplify(c)
+        if sc.is_true():
+            # Vacuously satisfied -- drop, mirrors add_goal's own TRUE handling.
+            continue
+        if sc.is_false():
+            # add_trajectory_constraint's own shape assertion (problem.py) only accepts one of
+            # the 5 trajectory-constraint operators, or an And/Forall wrapping only those -- it
+            # has no way to represent "this constraint can never be satisfied". A goal does.
+            new_problem.add_goal(em.FALSE())
+            continue
+        if sc.is_and():
+            # add_trajectory_constraint stores an And(...) as one entry; re-split it back into
+            # individual constraints, matching how the original was most likely built one
+            # add_trajectory_constraint call at a time.
+            for arg in sc.args:
+                new_problem.add_trajectory_constraint(arg)
+        else:
+            new_problem.add_trajectory_constraint(sc)
+
+
+def _remove_fully_static_fluents(
+    new_problem: Problem, static_fluents: Set["up.model.fluent.Fluent"]
+) -> None:
+    """
+    Removes from `new_problem` every fluent in `static_fluents` that is, after
+    `_fold_goal_like_fields` and every action's own folding, unreferenced anywhere in
+    `new_problem`.
+
+    Must run after every other field of `new_problem` that a fluent reference could hide in has
+    already been folded (grounded actions' preconditions/effects/durations/costs, and goals/timed
+    goals/trajectory constraints via `_fold_goal_like_fields`) -- otherwise a fluent that is
+    genuinely still referenced somewhere not-yet-folded could be wrongly identified as unused.
+
+    :param new_problem: The grounded `Problem`, modified in place.
+    :param static_fluents: The fluents eligible for removal -- must be `new_problem`'s own
+        *fixed-point* notion of staticness (`_refine_actions_to_fixed_point`'s returned
+        `Simplifier.static_fluents`), not a one-shot `new_problem.get_static_fluents()` call taken
+        mid-refinement: dropping one action can, in a later round, reveal that another fluent has
+        also become fully static (see `_refine_actions_to_fixed_point`) -- only once the loop has
+        actually converged is a fluent it calls static guaranteed to stay that way, i.e. to
+        provably have zero effects among the actions that survive to the final grounded problem.
+    """
+    if not static_fluents:
+        return
+    (
+        _,
+        unused_fluents,
+        fluents_in_durations,
+        fluents_in_action_costs,
+    ) = new_problem._get_static_and_unused_fluents()
+    # fluents_in_durations/fluents_in_action_costs are Problem._get_static_and_unused_fluents's
+    # own documented, intentional carve-outs: a fluent referenced ONLY in a DurativeAction's
+    # duration bound, or ONLY in a MinimizeActionCosts cost/default, is unconditionally counted as
+    # "unused" regardless of whether that reference is still symbolic (see its docstring). Both
+    # locations are already run through the same folding Simplifier by
+    # create_action_with_given_subs/ground_minimize_action_costs_metric, so a genuinely-foldable
+    # static fluent's references there are already constants and won't appear in either set at
+    # all -- this subtraction only matters as a safety net for the rarer case of a static fluent
+    # nested inside a non-constant argument (e.g. f(dynamic_object_fluent())) that never got
+    # folded, where it must correctly block removal instead of being silently dropped.
+    prunable = (
+        static_fluents & unused_fluents - fluents_in_durations - fluents_in_action_costs
+    )
+    if prunable:
+        remove_fluents(new_problem, prunable)

--- a/unified_planning/model/walkers/simplifier.py
+++ b/unified_planning/model/walkers/simplifier.py
@@ -16,7 +16,7 @@
 
 from fractions import Fraction
 from collections import OrderedDict
-from typing import Dict, Iterable, List, Optional, FrozenSet, Tuple, Union, cast
+from typing import Dict, Iterable, List, Optional, FrozenSet, Set, Tuple, Union, cast
 import unified_planning as up
 import unified_planning.environment
 from unified_planning.exceptions import UPUnreachableCodeError
@@ -53,44 +53,66 @@ class _EffectTargetIndex:
     return `True` more often than strictly necessary, the safe direction: every atom that really
     is written is matched by its own pattern, so it is never mistakenly folded to a constant.
 
+    Every recorded pattern is tagged with an `owner` -- the `Action`/`Event`/`Process` (or, for a
+    timed effect, the `Effect` itself) it was scanned from -- so `forget`/`learn` can incrementally
+    un-record/re-record exactly one owner's contribution in `O(that owner's own effect count)`,
+    instead of rebuilding the whole index from a fresh scan of the `Problem` in `O(problem size)`.
+    A `Grounder` refining an already-grounded problem to a fixed point (see
+    `unified_planning.engines.compilers.grounder._refine_actions_to_fixed_point`) uses this to
+    keep one index up to date across many action replacements/drops, at the cost of exactly the
+    actions that actually change -- events/processes/timed-effects are never touched by that loop,
+    so their entries never need `forget`/`learn` (any hashable owner key works for them; they're
+    only ever consulted, never removed).
+
     Important NOTE: same contract as `Simplifier` itself -- the `Problem` given at construction
-    time must not be modified afterwards, or this index's answers (and its cache) become stale.
+    time must not be modified directly (bypassing `forget`/`learn`) afterwards, or this index's
+    answers (and its cache) become stale.
     """
 
     def __init__(self, problem: "up.model.problem.Problem"):
-        self._patterns: Dict["up.model.fluent.Fluent", List[Tuple[_ArgSpec, ...]]] = {}
+        self._patterns: Dict[
+            "up.model.fluent.Fluent", Dict[object, List[Tuple[_ArgSpec, ...]]]
+        ] = {}
+        self._owners_fluents: Dict[object, Set["up.model.fluent.Fluent"]] = {}
         self._may_write_cache: Dict[FNode, bool] = {}
         for a in problem.actions:
             self._scan_action(a)
         for ev in problem.events:
-            self._scan_effects(ev.effects)
-            self._scan_simulated_effects(ev.simulated_effect)
+            self._scan_effects(ev, ev.effects)
+            self._scan_simulated_effects(ev, ev.simulated_effect)
         for pro in problem.processes:
-            self._scan_effects(pro.effects)
+            self._scan_effects(pro, pro.effects)
         for effs in problem.timed_effects.values():
-            self._scan_effects(effs)
+            for e in effs:
+                # No natural per-timed-effect "owner" object exists (unlike an Action/Event/
+                # Process) -- the Effect itself is a fine, unique, hashable key: the grounder
+                # never calls forget/learn on it (timed effects aren't touched by action
+                # refinement), so nothing depends on it being anything more than stable.
+                self._record_target(e, e.fluent)
 
     def _scan_action(self, a: "up.model.action.Action"):
         if isinstance(a, up.model.action.InstantaneousAction):
-            self._scan_effects(a.effects)
-            self._scan_simulated_effects(a.simulated_effect)
+            self._scan_effects(a, a.effects)
+            self._scan_simulated_effects(a, a.simulated_effect)
         elif isinstance(a, up.model.action.DurativeAction):
             for effs in a.effects.values():
-                self._scan_effects(effs)
+                self._scan_effects(a, effs)
             for effs in a.continuous_effects.values():
-                self._scan_effects(effs)
+                self._scan_effects(a, effs)
             for se in a.simulated_effects.values():
-                self._scan_simulated_effects(se)
+                self._scan_simulated_effects(a, se)
         else:
             raise NotImplementedError(
                 f"_EffectTargetIndex does not know how to scan the effects of {type(a)}"
             )
 
-    def _scan_effects(self, effects: Iterable["up.model.effect.Effect"]):
+    def _scan_effects(self, owner: object, effects: Iterable["up.model.effect.Effect"]):
         for e in effects:
-            self._record_target(e.fluent)
+            self._record_target(owner, e.fluent)
 
-    def _scan_simulated_effects(self, se: Optional["up.model.effect.SimulatedEffect"]):
+    def _scan_simulated_effects(
+        self, owner: object, se: Optional["up.model.effect.SimulatedEffect"]
+    ):
         if se is None:
             return
         # SimulatedEffect.fluents entries are, by construction, plain fluent expressions whose
@@ -99,16 +121,18 @@ class _EffectTargetIndex:
         # forall-quantified), so they fit the same per-position classification as a regular
         # effect target and need no separate handling.
         for f in se.fluents:
-            self._record_target(f)
+            self._record_target(owner, f)
 
-    def _record_target(self, target: FNode):
+    def _record_target(self, owner: object, target: FNode) -> "up.model.fluent.Fluent":
         if target.is_dot():
             # Multi-agent effect target: unwrap the `Dot` to the underlying fluent expression --
             # see UntimedEffectMixin.add_effect, which accepts `fluent_exp.is_dot()`.
             target = target.arg(0)
         fluent = target.fluent()
         pattern = tuple(self._arg_spec(arg) for arg in target.args)
-        self._patterns.setdefault(fluent, []).append(pattern)
+        self._patterns.setdefault(fluent, {}).setdefault(owner, []).append(pattern)
+        self._owners_fluents.setdefault(owner, set()).add(fluent)
+        return fluent
 
     @staticmethod
     def _arg_spec(arg: FNode) -> _ArgSpec:
@@ -126,16 +150,19 @@ class _EffectTargetIndex:
         cached = self._may_write_cache.get(fluent_exp)
         if cached is not None:
             return cached
-        patterns = self._patterns.get(fluent_exp.fluent())
+        owners_patterns = self._patterns.get(fluent_exp.fluent())
         result = False
-        if patterns:
+        if owners_patterns:
             args = fluent_exp.args
-            for pattern in patterns:
-                if all(
-                    self._arg_matches(spec, arg) for spec, arg in zip(pattern, args)
-                ):
-                    result = True
+            for patterns in owners_patterns.values():
+                if result:
                     break
+                for pattern in patterns:
+                    if all(
+                        self._arg_matches(spec, arg) for spec, arg in zip(pattern, args)
+                    ):
+                        result = True
+                        break
         self._may_write_cache[fluent_exp] = result
         return result
 
@@ -148,6 +175,48 @@ class _EffectTargetIndex:
             return arg == payload
         assert kind == "type"
         return cast("up.model.types.Type", payload).is_compatible(arg.type)
+
+    def write_count(self, fluent: "up.model.fluent.Fluent") -> int:
+        """The number of distinct owners currently recorded as (possibly) writing `fluent` -- `0`
+        means `fluent` is schema-static given everything this index has recorded so far."""
+        return len(self._patterns.get(fluent, {}))
+
+    def forget(self, owner: object) -> Set["up.model.fluent.Fluent"]:
+        """Un-records every pattern `owner` contributed (e.g. because the action it came from was
+        dropped, or is about to be replaced by a refolded version with different effects).
+
+        :return: The fluents `owner` touched -- whether or not their pattern set became empty as a
+            result. A *narrower* surviving pattern set (another owner still writes the fluent, so
+            `write_count` didn't reach zero) can still newly unlock folding of one specific ground
+            atom of that fluent (`may_write`), so callers must not assume only a `write_count` drop
+            to zero matters.
+        """
+        fluents = self._owners_fluents.pop(owner, None)
+        if not fluents:
+            return set()
+        for f in fluents:
+            owners = self._patterns.get(f)
+            if owners is not None:
+                owners.pop(owner, None)
+                if not owners:
+                    del self._patterns[f]
+        self._may_write_cache.clear()
+        return fluents
+
+    def learn(
+        self, owner: object, targets: Iterable[FNode]
+    ) -> Set["up.model.fluent.Fluent"]:
+        """Records `owner`'s current effect targets. Intended to be called right after `forget`,
+        with whichever (possibly narrower, possibly empty) set of effects `owner` currently has --
+        calling it without a preceding `forget` would duplicate `owner`'s previously-recorded
+        patterns rather than replace them.
+
+        :return: The fluents touched by `targets`.
+        """
+        touched = {self._record_target(owner, target) for target in targets}
+        if touched:
+            self._may_write_cache.clear()
+        return touched
 
 
 class Simplifier(walkers.dag.DagWalker):
@@ -162,11 +231,13 @@ class Simplifier(walkers.dag.DagWalker):
         environment: "unified_planning.environment.Environment",
         problem: Optional["unified_planning.model.problem.Problem"] = None,
         fold_static_fluent_exps: bool = False,
+        effect_target_index: Optional[_EffectTargetIndex] = None,
     ):
         """
         :param environment: The `Environment` this `Simplifier` operates in.
-        :param problem: If given, static fluents (`problem.get_static_fluents()`) are folded to
-            their initial value.
+        :param problem: If given, static fluents (`problem.get_static_fluents()`, or
+            `effect_target_index`'s own view of staticness when that is given -- see below) are
+            folded to their initial value.
         :param fold_static_fluent_exps: If `True`, also fold a ground fluent atom that is not
             static at the *schema* level (`problem.get_static_fluents()` doesn't include its
             fluent, because some other grounding of it IS written somewhere) but that this exact
@@ -178,16 +249,37 @@ class Simplifier(walkers.dag.DagWalker):
             which don't expose the effect surface `_EffectTargetIndex` scans. Defaults to `False`
             so existing callers (and `problem.kind`, which is computed through its own
             `Simplifier`) are unaffected.
+        :param effect_target_index: An already-built `_EffectTargetIndex` to use instead of
+            scanning `problem` again -- for a caller that already maintains one incrementally
+            (see `unified_planning.engines.compilers.grounder._refine_actions_to_fixed_point`,
+            which builds many cheap, short-lived `Simplifier`s around one long-lived index rather
+            than re-scanning the whole problem on every one of them). When given, `static_fluents`
+            is *derived from the index* (`write_count(f) == 0`) instead of a separate
+            `problem.get_static_fluents()` call -- regardless of `fold_static_fluent_exps`, which
+            only controls whether the index is *also* consulted for per-atom folding
+            (`self._effect_target_index`, below). Requires `problem` to be given too (for
+            `problem.fluents` and `problem.initial_value`).
         """
         walkers.dag.DagWalker.__init__(self)
         self.environment = environment
         self.manager = environment.expression_manager
+        self.problem: Optional["unified_planning.model.problem.Problem"] = problem
+        if effect_target_index is not None:
+            assert problem is not None, (
+                "effect_target_index requires problem to be given too"
+            )
+            self.static_fluents = {
+                f for f in problem.fluents if effect_target_index.write_count(f) == 0
+            }
+            self._effect_target_index: Optional[_EffectTargetIndex] = (
+                effect_target_index if fold_static_fluent_exps else None
+            )
+            return
         if problem is not None:
             self.static_fluents = problem.get_static_fluents()
         else:
             self.static_fluents = set()
-        self.problem: Optional["unified_planning.model.problem.Problem"] = problem
-        self._effect_target_index: Optional[_EffectTargetIndex] = None
+        self._effect_target_index = None
         if fold_static_fluent_exps and isinstance(problem, up.model.problem.Problem):
             self._effect_target_index = _EffectTargetIndex(problem)
 

--- a/unified_planning/test/test_grounder.py
+++ b/unified_planning/test/test_grounder.py
@@ -1115,6 +1115,425 @@ class TestGrounder(unittest_TestCase):
         ga = cast(InstantaneousAction, grounded_problem.action("check_waypoint"))
         self.assertEqual(ga.preconditions, [Equals(pos(waypoint), 5)])
 
+    def _static_pos_problem(self, name: str):
+        # A fluent pos(o: Place) that is never the target of any effect anywhere -- schema-static
+        # -- plus a dummy action so the problem has something to ground. Shared setup for the
+        # goal/timed-goal/trajectory-constraint folding tests below.
+        place_type = UserType("Place")
+        pos = Fluent("pos", IntType(), o=place_type)
+        waypoint = Object("waypoint", place_type)
+        dummy = Fluent("dummy")
+        act = InstantaneousAction("act")
+        act.add_effect(dummy, True)
+
+        problem = Problem(name)
+        problem.add_fluent(pos, default_initial_value=0)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_object(waypoint)
+        problem.set_initial_value(pos(waypoint), 5)
+        problem.add_action(act)
+        return problem, pos, waypoint
+
+    def test_static_fluent_referenced_only_in_goal_folds_and_is_removed(self):
+        problem, pos, waypoint = self._static_pos_problem("static_in_goal")
+        problem.add_goal(GT(pos(waypoint), 3))  # 5 > 3: always true
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        # folds to True, which Problem.add_goal silently drops
+        self.assertEqual(grounded_problem.goals, [])
+        self.assertFalse(grounded_problem.has_fluent("pos"))
+
+    def test_static_fluent_referenced_only_in_timed_goal_folds_and_is_removed(self):
+        problem, pos, waypoint = self._static_pos_problem("static_in_timed_goal")
+        problem.add_timed_goal(GlobalStartTiming(1), GT(pos(waypoint), 3))
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        for goal_list in grounded_problem.timed_goals.values():
+            self.assertEqual(goal_list, [])
+        self.assertFalse(grounded_problem.has_fluent("pos"))
+
+    def test_static_fluent_referenced_only_in_trajectory_constraint_folds_and_is_removed(
+        self,
+    ):
+        problem, pos, waypoint = self._static_pos_problem(
+            "static_in_trajectory_constraint"
+        )
+        problem.add_trajectory_constraint(Sometime(GT(pos(waypoint), 3)))
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        # Sometime(True) folds to True, which is vacuously satisfied and dropped.
+        self.assertEqual(grounded_problem.trajectory_constraints, [])
+        self.assertFalse(grounded_problem.has_fluent("pos"))
+
+    def test_trajectory_constraint_folding_to_false_becomes_a_false_goal(self):
+        problem, pos, waypoint = self._static_pos_problem("trajectory_constraint_false")
+        # pos(waypoint) == 5, so this never holds.
+        problem.add_trajectory_constraint(Always(GT(pos(waypoint), 10)))
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        # add_trajectory_constraint has no way to represent "always fails" (its shape assertion
+        # rejects a bare Bool constant) -- it must be redirected to a goal instead of crashing.
+        self.assertEqual(grounded_problem.trajectory_constraints, [])
+        self.assertIn(Bool(False), grounded_problem.goals)
+
+    def test_goal_conjunct_folding_leaves_the_dynamic_conjunct_untouched(self):
+        place_type = UserType("Place")
+        pos = Fluent("pos", IntType(), o=place_type)
+        waypoint = Object("waypoint", place_type)
+        moved = Fluent("moved")
+        act = InstantaneousAction("act")
+        act.add_effect(moved, True)
+
+        problem = Problem("mixed_goal_conjuncts")
+        problem.add_fluent(pos, default_initial_value=0)
+        problem.add_fluent(moved, default_initial_value=False)
+        problem.add_object(waypoint)
+        problem.set_initial_value(pos(waypoint), 5)
+        problem.add_action(act)
+        problem.add_goal(And(GT(pos(waypoint), 3), moved))
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(grounded_problem.goals, [moved()])
+        self.assertFalse(grounded_problem.has_fluent("pos"))
+
+    def test_static_fluent_referenced_only_via_non_foldable_action_cost_default_is_not_removed(
+        self,
+    ):
+        # pos is schema-static, but the metric's default cost expression reads it through a
+        # DYNAMIC object fluent's value (pos(cursor())) -- since cursor() can't be resolved to a
+        # constant at grounding time, pos(cursor()) can't be folded either, so pos genuinely stays
+        # referenced. Problem._get_static_and_unused_fluents() never scans a MinimizeActionCosts
+        # cost/default into unused_fluents at all (a documented blind spot), so without the
+        # fluents_in_action_costs exemption this fluent would be wrongly removed.
+        place_type = UserType("Place")
+        p1 = Object("p1", place_type)
+        p2 = Object("p2", place_type)
+        cursor = Fluent("cursor", place_type)
+        pos = Fluent("pos", IntType(), o=place_type)
+
+        act = InstantaneousAction("act")
+        act.add_effect(cursor, p2)
+
+        problem = Problem("non_foldable_cost_default")
+        problem.add_fluent(cursor, default_initial_value=p1)
+        problem.add_fluent(pos, default_initial_value=0)
+        problem.add_object(p1)
+        problem.add_object(p2)
+        problem.set_initial_value(pos(p1), 3)
+        problem.set_initial_value(pos(p2), 4)
+        problem.add_action(act)
+        problem.add_quality_metric(MinimizeActionCosts({act: 1}, default=pos(cursor())))
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertTrue(grounded_problem.has_fluent("pos"))
+        metric = grounded_problem.quality_metrics[0]
+        assert isinstance(metric, MinimizeActionCosts)
+        # the default itself is preserved (fixing ground_minimize_action_costs_metric's previous
+        # silent drop), and stays symbolic since it can't be folded.
+        self.assertEqual(metric.default, pos(cursor()))
+
+    def test_static_fluent_referenced_only_via_non_foldable_duration_bound_is_not_removed(
+        self,
+    ):
+        # Same shape as the action-cost-default case above, but for a DurativeAction's fixed
+        # duration: Problem._get_static_and_unused_fluents() never scans duration expressions
+        # into unused_fluents either, so pos here needs the same fluents_in_durations exemption.
+        place_type = UserType("Place")
+        p1 = Object("p1", place_type)
+        p2 = Object("p2", place_type)
+        cursor = Fluent("cursor", place_type)
+        pos = Fluent("pos", IntType(1, 10), o=place_type)
+
+        set_cursor = InstantaneousAction("set_cursor")
+        set_cursor.add_effect(cursor, p2)
+
+        dur_act = DurativeAction("dur_act")
+        dur_act.set_fixed_duration(pos(cursor()))
+
+        problem = Problem("non_foldable_duration")
+        problem.add_fluent(cursor, default_initial_value=p1)
+        problem.add_fluent(pos, default_initial_value=1)
+        problem.add_object(p1)
+        problem.add_object(p2)
+        problem.set_initial_value(pos(p1), 3)
+        problem.set_initial_value(pos(p2), 4)
+        problem.add_action(set_cursor)
+        problem.add_action(dur_act)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertTrue(grounded_problem.has_fluent("pos"))
+        ga = cast(DurativeAction, grounded_problem.action("dur_act"))
+        self.assertEqual(ga.duration.lower, pos(cursor()))
+
+    def test_remove_static_fluents_false_only_folds_and_never_removes(self):
+        problem, pos, waypoint = self._static_pos_problem(
+            "remove_static_fluents_disabled"
+        )
+        problem.add_goal(GT(pos(waypoint), 3))
+
+        grounded_problem = (
+            Grounder(remove_static_fluents=False)
+            .compile(problem, CompilationKind.GROUNDING)
+            .problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        # the goal still folds (Part 1 folding is unconditional)...
+        self.assertEqual(grounded_problem.goals, [])
+        # ...but the now-unreferenced fluent stays declared, exactly as before this feature.
+        self.assertTrue(grounded_problem.has_fluent("pos"))
+        self.assertIn(pos(waypoint), grounded_problem.initial_values)
+
+    def test_cascade_two_actions_pruning_one_reveals_the_other_is_dead(self):
+        # `enabled` is schema-static (never written), initially False, so `set_flag`'s own
+        # precondition folds to False in the FIRST pass and it's pruned. Only a fixed point
+        # discovers what happens next: `flag` (only ever written by set_flag) now has zero
+        # writers left in the grounded problem, so it becomes static too (default False), which
+        # folds `use_flag`'s precondition to False in a SECOND round -- a single pass never runs.
+        enabled = Fluent("enabled")
+        flag = Fluent("flag")
+        dummy = Fluent("dummy")
+
+        set_flag = InstantaneousAction("set_flag")
+        set_flag.add_precondition(enabled)
+        set_flag.add_effect(flag, True)
+
+        use_flag = InstantaneousAction("use_flag")
+        use_flag.add_precondition(flag)
+        use_flag.add_effect(dummy, True)
+
+        problem = Problem("cascade")
+        problem.add_fluent(enabled, default_initial_value=False)
+        problem.add_fluent(flag, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_action(set_flag)
+        problem.add_action(use_flag)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(grounded_problem.actions, [])
+        # every fluent in the cascade is now static and unreferenced -- removed too.
+        self.assertEqual(grounded_problem.fluents, [])
+
+    def test_chain_of_three_actions_cascades_through_multiple_rounds(self):
+        # `base` folds C's own precondition directly; C is `mid`'s only writer, B's precondition
+        # reads `mid`, B is `top`'s only writer, and A's precondition reads `top` -- dropping C
+        # must cascade through B and then to A, over more than one refinement round.
+        base = Fluent("base")
+        mid = Fluent("mid")
+        top = Fluent("top")
+        dummy = Fluent("dummy")
+
+        act_c = InstantaneousAction("act_c")
+        act_c.add_precondition(base)
+        act_c.add_effect(mid, True)
+
+        act_b = InstantaneousAction("act_b")
+        act_b.add_precondition(mid)
+        act_b.add_effect(top, True)
+
+        act_a = InstantaneousAction("act_a")
+        act_a.add_precondition(top)
+        act_a.add_effect(dummy, True)
+
+        problem = Problem("chain_of_three")
+        problem.add_fluent(base, default_initial_value=False)
+        problem.add_fluent(mid, default_initial_value=False)
+        problem.add_fluent(top, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_action(act_c)
+        problem.add_action(act_b)
+        problem.add_action(act_a)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(grounded_problem.actions, [])
+
+    def test_long_chain_converges_without_looping_forever(self):
+        # A 5-action chain where only the first action's precondition is directly
+        # static-foldable; every later action can only be pruned once the entire chain ahead of
+        # it has already cascaded. A non-terminating (or non-converging) refinement loop would
+        # hang this test rather than fail it cleanly.
+        base = Fluent("base")
+        chain = [Fluent(f"f{i}") for i in range(5)]
+        actions = []
+        first = InstantaneousAction("act0")
+        first.add_precondition(base)
+        first.add_effect(chain[0], True)
+        actions.append(first)
+        for i in range(1, 5):
+            a = InstantaneousAction(f"act{i}")
+            a.add_precondition(chain[i - 1])
+            a.add_effect(chain[i], True)
+            actions.append(a)
+
+        problem = Problem("long_chain")
+        problem.add_fluent(base, default_initial_value=False)
+        for f in chain:
+            problem.add_fluent(f, default_initial_value=False)
+        for a in actions:
+            problem.add_action(a)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertEqual(grounded_problem.actions, [])
+
+    def test_conditional_effect_only_cascade_via_dropped_effect_not_whole_action(self):
+        # `gate` is schema-static, initially False. act_writer's OWN precondition is trivially
+        # satisfiable (it survives), but its conditional effect on `f` is gated by `gate`, which
+        # folds to False -- so only that ONE effect gets dropped, not the whole action. If that
+        # was `f`'s only writer, `f` becomes static too, and act_reader's precondition on `f`
+        # must fold/prune accordingly. This is the "fluent loses a writer without its owning
+        # action being dropped" case the design relies on `_written_fluents`'s before/after diff
+        # (rather than only reacting to whole-action drops) to catch.
+        gate = Fluent("gate")
+        f = Fluent("f")
+        dummy = Fluent("dummy")
+
+        act_writer = InstantaneousAction("act_writer")
+        act_writer.add_effect(f, True, condition=gate)
+        act_writer.add_effect(dummy, True)
+
+        act_reader = InstantaneousAction("act_reader")
+        act_reader.add_precondition(f)
+        act_reader.add_effect(dummy, False)
+
+        problem = Problem("conditional_effect_cascade")
+        problem.add_fluent(gate, default_initial_value=False)
+        problem.add_fluent(f, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_action(act_writer)
+        problem.add_action(act_reader)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertTrue(grounded_problem.has_action("act_writer"))
+        self.assertFalse(grounded_problem.has_action("act_reader"))
+        ga = cast(InstantaneousAction, grounded_problem.action("act_writer"))
+        # the gated effect on f is gone; the unconditional effect on dummy survives.
+        self.assertEqual(len(ga.effects), 1)
+        self.assertEqual(ga.effects[0].fluent, FluentExp(dummy))
+
+    def test_per_atom_cascade_from_dropping_one_of_two_writers(self):
+        # f(o1) is written only by act_x, f(o2) only by act_y -- independently. act_x's own
+        # precondition (`gate`, static) folds to False and it's dropped, so f(o1) now has zero
+        # writers left, even though `f` as a WHOLE stays schema-dynamic (act_y still writes
+        # f(o2)). act_reader's precondition on f(o1) specifically must still fold/prune: a
+        # trigger signal based only on whole-fluent staticness flips (rather than "did this
+        # action's own written-fluent set shrink at all") would miss this.
+        place_type = UserType("Place")
+        o1 = Object("o1", place_type)
+        o2 = Object("o2", place_type)
+        gate = Fluent("gate")
+        f = Fluent("f", BoolType(), o=place_type)
+        dummy = Fluent("dummy")
+
+        act_x = InstantaneousAction("act_x")
+        act_x.add_precondition(gate)
+        act_x.add_effect(f(o1), True)
+
+        act_y = InstantaneousAction("act_y")
+        act_y.add_effect(f(o2), True)
+
+        act_reader = InstantaneousAction("act_reader")
+        act_reader.add_precondition(f(o1))
+        act_reader.add_effect(dummy, True)
+
+        problem = Problem("per_atom_cascade")
+        problem.add_fluent(gate, default_initial_value=False)
+        problem.add_fluent(f, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_object(o1)
+        problem.add_object(o2)
+        problem.add_action(act_x)
+        problem.add_action(act_y)
+        problem.add_action(act_reader)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertFalse(grounded_problem.has_action("act_x"))
+        self.assertTrue(grounded_problem.has_action("act_y"))
+        self.assertFalse(grounded_problem.has_action("act_reader"))
+        # f stays schema-dynamic overall: act_y still writes f(o2).
+        self.assertNotIn(f, grounded_problem.get_static_fluents())
+
+    def test_unrelated_actions_survive_a_cascade_elsewhere_unchanged(self):
+        # A genuine cascade (as above) alongside completely independent actions that don't
+        # read/write any of the cascade's fluents -- they must survive the worklist untouched,
+        # with their original content intact.
+        enabled = Fluent("enabled")
+        flag = Fluent("flag")
+        dummy = Fluent("dummy")
+        other = Fluent("other", IntType())
+
+        set_flag = InstantaneousAction("set_flag")
+        set_flag.add_precondition(enabled)
+        set_flag.add_effect(flag, True)
+
+        use_flag = InstantaneousAction("use_flag")
+        use_flag.add_precondition(flag)
+        use_flag.add_effect(dummy, True)
+
+        unrelated_precondition = GE(other, 0)
+        unrelated_1 = InstantaneousAction("unrelated_1")
+        unrelated_1.add_precondition(unrelated_precondition)
+        unrelated_1.add_increase_effect(other, 1)
+
+        unrelated_2 = InstantaneousAction("unrelated_2")
+        unrelated_2.add_increase_effect(other, 2)
+
+        problem = Problem("cascade_plus_unrelated")
+        problem.add_fluent(enabled, default_initial_value=False)
+        problem.add_fluent(flag, default_initial_value=False)
+        problem.add_fluent(dummy, default_initial_value=False)
+        problem.add_fluent(other, default_initial_value=0)
+        problem.add_action(set_flag)
+        problem.add_action(use_flag)
+        problem.add_action(unrelated_1)
+        problem.add_action(unrelated_2)
+
+        grounded_problem = (
+            Grounder().compile(problem, CompilationKind.GROUNDING).problem
+        )
+        assert isinstance(grounded_problem, Problem)
+        self.assertFalse(grounded_problem.has_action("set_flag"))
+        self.assertFalse(grounded_problem.has_action("use_flag"))
+        ga1 = cast(InstantaneousAction, grounded_problem.action("unrelated_1"))
+        ga2 = cast(InstantaneousAction, grounded_problem.action("unrelated_2"))
+        self.assertEqual(ga1.preconditions, [unrelated_precondition])
+        self.assertEqual(len(ga1.effects), 1)
+        self.assertEqual(len(ga2.effects), 1)
+
 
 class TestGrounderJoinPruning(unittest_TestCase):
     """Tests for the grounder's join-based static-fluent pruning

--- a/unified_planning/test/test_problem.py
+++ b/unified_planning/test/test_problem.py
@@ -577,6 +577,8 @@ class TestProblem(unittest_TestCase):
         problem.add_fluent(is_at, default_initial_value=False)
         problem.add_fluent(distance, default_initial_value=100)
         problem.add_fluent(total_distance, default_initial_value=0)
+        problem.add_object(l1)
+        problem.add_object(l2)
         problem.set_initial_value(distance(l1, l2), 5)
         problem.add_action(move)
         problem.add_goal(distance(l1, l2) < 6)

--- a/unified_planning/test/test_simplifier.py
+++ b/unified_planning/test/test_simplifier.py
@@ -17,6 +17,7 @@ import unified_planning
 from unified_planning.shortcuts import *
 from unified_planning.test import unittest_TestCase, main
 from unified_planning.model.walkers import Simplifier, Substituter
+from unified_planning.model.walkers.simplifier import _EffectTargetIndex
 from unified_planning.environment import get_environment
 from fractions import Fraction
 from typing import List
@@ -877,6 +878,103 @@ class TestPerAtomStaticFluentFolding(unittest_TestCase):
         s = Simplifier(problem.environment, problem, fold_static_fluent_exps=True)
         e = GT(self.pos(self.waypoint), 5)
         self.assertEqual(s.simplify(e), e)
+
+
+class TestEffectTargetIndexIncremental(unittest_TestCase):
+    """`_EffectTargetIndex.forget`/`learn` let a caller (the `Grounder`'s fixed-point refinement
+    loop) incrementally keep one index up to date as actions are dropped/replaced, instead of
+    rebuilding it -- an `O(problem size)` scan -- every time something changes. `Simplifier`'s
+    `effect_target_index` parameter lets a caller hand it such an index directly, deriving
+    `static_fluents` from it instead of a second, independent `problem.get_static_fluents()` scan.
+    """
+
+    def setUp(self):
+        unittest_TestCase.setUp(self)
+        place_type = UserType("Place")
+        self.pos = Fluent("pos", IntType(), o=place_type)
+        self.p1 = Object("p1", place_type)
+        self.p2 = Object("p2", place_type)
+        self.act1 = InstantaneousAction("act1")
+        self.act1.add_effect(self.pos(self.p1), 1)
+        self.act2 = InstantaneousAction("act2")
+        self.act2.add_effect(self.pos(self.p2), 2)
+
+        problem = Problem("two_writers")
+        problem.add_fluent(self.pos, default_initial_value=0)
+        problem.add_object(self.p1)
+        problem.add_object(self.p2)
+        problem.add_action(self.act1)
+        problem.add_action(self.act2)
+        self.problem = problem
+
+    def test_forget_unrecorded_owner_is_a_no_op(self):
+        index = _EffectTargetIndex(self.problem)
+        before = index.write_count(self.pos)
+        self.assertEqual(index.forget(InstantaneousAction("never_scanned")), set())
+        self.assertEqual(index.write_count(self.pos), before)
+
+    def test_forget_then_learn_same_targets_round_trips(self):
+        index = _EffectTargetIndex(self.problem)
+        self.assertEqual(index.write_count(self.pos), 2)
+        self.assertTrue(index.may_write(self.pos(self.p1)))
+
+        touched = index.forget(self.act1)
+        self.assertEqual(touched, {self.pos})
+        self.assertEqual(index.write_count(self.pos), 1)
+        self.assertFalse(index.may_write(self.pos(self.p1)))
+        self.assertTrue(index.may_write(self.pos(self.p2)))  # act2 untouched
+
+        learned = index.learn(self.act1, (e.fluent for e in self.act1.effects))
+        self.assertEqual(learned, {self.pos})
+        self.assertEqual(index.write_count(self.pos), 2)
+        self.assertTrue(index.may_write(self.pos(self.p1)))
+
+    def test_forget_one_of_two_writers_leaves_the_other_intact(self):
+        index = _EffectTargetIndex(self.problem)
+        index.forget(self.act1)
+        self.assertEqual(index.write_count(self.pos), 1)
+        self.assertFalse(index.may_write(self.pos(self.p1)))
+        self.assertTrue(index.may_write(self.pos(self.p2)))
+
+    def test_simplifier_derives_static_fluents_from_a_given_index_not_the_problem(self):
+        index = _EffectTargetIndex(self.problem)
+        index.forget(self.act1)
+        index.forget(self.act2)
+        # write_count(pos) is now 0 in the index, even though self.problem's own actions (never
+        # touched) still target it -- problem.get_static_fluents() would disagree.
+        self.assertNotIn(self.pos, self.problem.get_static_fluents())
+
+        s = Simplifier(
+            self.problem.environment, self.problem, effect_target_index=index
+        )
+        self.assertIn(self.pos, s.static_fluents)
+
+    def test_may_write_cache_is_invalidated_by_forget_and_learn(self):
+        index = _EffectTargetIndex(self.problem)
+        s1 = Simplifier(
+            self.problem.environment,
+            self.problem,
+            fold_static_fluent_exps=True,
+            effect_target_index=index,
+        )
+        e = GT(self.pos(self.p1), 5)
+        # pos(p1) is still written (by act1): stays symbolic, and this also populates
+        # index._may_write_cache for pos(p1).
+        self.assertEqual(s1.simplify(e), e)
+
+        index.forget(self.act1)  # p1's only writer is gone
+        # A fresh Simplifier wrapping the SAME index must see the update, not a stale cached
+        # answer from before the forget() call -- this is exactly what forget()'s cache clear is
+        # for (reusing s1 itself is deliberately not supported, see Simplifier's own docstring).
+        s2 = Simplifier(
+            self.problem.environment,
+            self.problem,
+            fold_static_fluent_exps=True,
+            effect_target_index=index,
+        )
+        self.assertEqual(
+            s2.simplify(e), Bool(False)
+        )  # pos(p1) == 0 (default), 0 > 5 is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Grounding folded static-fluent references and pruned infeasible actions in a single pass, using
  only the lifted problem's own static-fluent knowledge. Pruning one action can leave a fluent
  with zero writers in the grounded problem, which can fold another action's precondition to
  `False` in turn, pruning it too -- a cascade a single pass never re-checks.
- Refines the grounded problem's own actions to a fixed point after round-0 grounding via an
  incremental worklist (not a rescan-per-round): `_EffectTargetIndex` becomes owner-keyed with
  `forget()`/`learn()` to un-record/re-record one action's contribution in `O(that action's own
  effect count)`, and `Simplifier` can wrap an already-built index instead of scanning the problem
  itself, so constructing one per re-check is cheap.
- Quality-metric, goal/timed-goal/trajectory-constraint folding, and the final fluent-removal step
  now all run once the fixed point is reached, using its fuller static-fluent knowledge.
- Fixes `test_simple_numeric_planning_ad_hoc_1`'s pre-existing setup bug (`Object`s built but
  never registered via `add_object`) -- exposed now that fluent removal trusts the grounded
  problem's own fixed-point staticness rather than a one-shot lifted-problem view.

## Test plan

- [x] Added `test_simplifier.py` coverage for `_EffectTargetIndex.forget`/`learn` directly:
      no-op on an unrecorded owner, forget+learn round-trips, one of two writers surviving a
      forget, `Simplifier`'s `effect_target_index` parameter deriving `static_fluents` from the
      index rather than the problem, and cache invalidation across a forget/learn pair.
- [x] Added `test_grounder.py` coverage: the two-action cascade itself, a three- and five-action
      chain (the latter to check convergence rather than an infinite loop), a cascade triggered by
      a dropped conditional effect (not a dropped action), a per-atom-only cascade (the fluent
      stays schema-dynamic overall), and unrelated actions surviving a cascade elsewhere
      untouched.